### PR TITLE
docs: prefer the AI-agent install, state the reverse-proxy requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Two households, one shared album, created and shared and joined and commented on
 
 ## Install
 
-- **Guided:** clone next to your Immich and run `bash deploy/install.sh`. It asks for your Immich network, public URL, household name and an API key, then builds, starts and health-checks the sidecar and prints the reverse-proxy lines you add.
-- **Got an AI agent on the box?** Paste [deploy/INSTALL-AI.md](./deploy/INSTALL-AI.md) and it does the lot.
-- **Manual:** one container plus three proxy routes (Caddy, nginx or Traefik). See [deploy/](./deploy/).
+Every method needs Docker, an admin API key, and **a reverse proxy in front of Immich**. Shared photos and the join banner reach your server through three small routes (`/sidecar/*`, `/share/*`, and the GET byte routes) placed ahead of your normal Immich route. Pick one, easiest first:
+
+- **Preferred: let an AI agent install it.** If you have an AI coding agent on the server (Claude Code, Cursor, Copilot CLI, etc.), paste [deploy/INSTALL-AI.md](./deploy/INSTALL-AI.md). It discovers your setup, installs the sidecar, adds the proxy routes adapted to *your* reverse proxy, and verifies the result. It's the most hands-off option and the only one that adapts to any proxy (Caddy, nginx, NPM, Traefik, tunnels).
+- **Guided script.** No agent? Clone next to your Immich and run `bash deploy/install.sh`. It auto-detects your Immich network, builds and starts the sidecar, health-checks it, and prints the proxy routes for you to add.
+- **Manual.** Build the container and add the three routes yourself. See [deploy/](./deploy/).
 
 ## Permissions & security
 


### PR DESCRIPTION
Install section now leads with the AI-agent method (the most hands-off, and the only one that adapts to any reverse proxy), and states up front that a reverse proxy in front of Immich is required for every method, naming the three routes. Docs only.