### PR TITLE
docs: AGENTS.md contributor contract + remote-SSH AI-agent wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Working on this repo (humans and AI agents)
+
+This is the contract for changing immich-shared-albums. It applies to everyone, and
+especially to AI coding agents — read it before you make changes.
+
+## Golden rules
+
+- **Never touch Immich itself.** This is a sidecar: it only ever adds its own container
+  and talks to Immich over the public API. Never modify Immich's source, compose
+  services, database, or upload folders. Everything must fail open — Immich has to work
+  perfectly with the sidecar dead. (Design invariants: [src/ARCHITECTURE.md](./src/ARCHITECTURE.md) "Iron rules".)
+- **Keep the docs in sync.** Every folder under `src/` has a Markdown doc describing it,
+  and `src/ARCHITECTURE.md` describes the whole. Any behaviour change updates the relevant
+  doc(s) in the same change. A doc that lies is worse than no doc: treat drift as a bug and
+  fix it with the code that caused it.
+- **Never test against a real server.** Use the throwaway mock rig in `demo/`. Never run
+  the suite or experiments against anyone's production Immich, and never modify a real
+  user's library.
+- **No secrets in the repo.** No API keys, passwords, tokens, or personal data in commits,
+  logs, or committed files. Ever.
+
+## How changes land
+
+- **Everything goes through a pull request**, gated on the e2e suite (66 checks + a browser
+  lane). Branch protection enforces it; merges are squash-only.
+- **Conventional commits** decide the version automatically via release-please
+  (`fix:` → patch, `feat:` → minor, `feat!:` → major). Don't hand-edit version numbers.
+- **Before pushing:** `npx tsc --noEmit` clean, and the suite green
+  (`bash demo/run-mock-e2e.sh`). CI runs both; run them locally first when you can.
+
+## Layout
+
+Code is grouped by concern under `src/` (a `config`/`state`/`peers` core, then `immich/`,
+`p2p/`, `sync/`, `media/`, `web/`). See [src/ARCHITECTURE.md](./src/ARCHITECTURE.md) for the
+module map, the data flow, and the doc conventions.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Two households, one shared album, created and shared and joined and commented on
 
 Every method needs Docker, an admin API key, and **a reverse proxy in front of Immich**. Shared photos and the join banner reach your server through three small routes (`/sidecar/*`, `/share/*`, and the GET byte routes) placed ahead of your normal Immich route. Pick one, easiest first:
 
-- **Preferred: let an AI agent install it.** If you have an AI coding agent on the server (Claude Code, Cursor, Copilot CLI, etc.), paste [deploy/INSTALL-AI.md](./deploy/INSTALL-AI.md). It discovers your setup, installs the sidecar, adds the proxy routes adapted to *your* reverse proxy, and verifies the result. It's the most hands-off option and the only one that adapts to any proxy (Caddy, nginx, NPM, Traefik, tunnels).
+- **Preferred: let an AI agent install it.** If you use an AI coding agent (Claude Code, Cursor, Copilot CLI, etc.), either on the server or on your own machine with SSH access to it, paste [deploy/INSTALL-AI.md](./deploy/INSTALL-AI.md). It discovers your setup, installs the sidecar, adds the proxy routes adapted to *your* reverse proxy, and verifies the result. It's the most hands-off option and the only one that adapts to any proxy (Caddy, nginx, NPM, Traefik, tunnels).
 - **Guided script.** No agent? Clone next to your Immich and run `bash deploy/install.sh`. It auto-detects your Immich network, builds and starts the sidecar, health-checks it, and prints the proxy routes for you to add.
 - **Manual.** Build the container and add the three routes yourself. See [deploy/](./deploy/).
 

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -2,9 +2,10 @@
 
 > 🎬 What you get once installed: [2-minute demo of two servers sharing an album](https://www.youtube.com/watch?v=c3GO-YFchYo).
 
-Running an AI coding agent (Claude Code, Copilot CLI, Cursor, …) on the machine
-that hosts your Immich? Paste the prompt below and it will do the install for
-you, adapted to *your* setup, asking you only for the things it can't discover.
+Running an AI coding agent (Claude Code, Copilot CLI, Cursor, …) with access to
+the machine that hosts your Immich, either on the box itself or SSH'd in from
+your own machine? Paste the prompt below and it will do the install for you,
+adapted to *your* setup, asking you only for the things it can't discover.
 
 ---
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -129,11 +129,9 @@ Conventions for this tree:
    nothing else here; feature folders depend on core and, at most, on layers
    below them. `p2p` and `sync` reference each other only through runtime calls
    (join → reconcile, watcher → nudge), never at module-load time.
-4. **Keep the docs in sync — this is a rule, not a nicety.** Any change to a
-   folder's behaviour updates that folder's `.md` in the *same* change, and
-   anything that alters how sync, the protocol, or the byte path works updates
-   this file too. This applies to every contributor, human or AI agent. A doc
-   that lies is worse than no doc: treat drift as a bug and fix it with the code.
+
+Keeping these docs in sync with the code is a project rule for every contributor,
+human or AI agent — see [AGENTS.md](../AGENTS.md).
 
 ## Iron rules
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -129,6 +129,11 @@ Conventions for this tree:
    nothing else here; feature folders depend on core and, at most, on layers
    below them. `p2p` and `sync` reference each other only through runtime calls
    (join → reconcile, watcher → nudge), never at module-load time.
+4. **Keep the docs in sync — this is a rule, not a nicety.** Any change to a
+   folder's behaviour updates that folder's `.md` in the *same* change, and
+   anything that alters how sync, the protocol, or the byte path works updates
+   this file too. This applies to every contributor, human or AI agent. A doc
+   that lies is worse than no doc: treat drift as a bug and fix it with the code.
 
 ## Iron rules
 


### PR DESCRIPTION
- The AI-agent install method doesn't require the agent to run *on* the server — it can run on your own machine with SSH access. Reworded in README and INSTALL-AI.md.
- Adds ARCHITECTURE.md convention #4: keeping the per-folder docs and ARCHITECTURE.md in sync with code is a rule for every contributor, human or AI agent. Directly targets the doc-drift we just cleaned up. Docs only.