### PR TITLE
Harden every route for public exposure: session auth, peer entitlement, gated enrolment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ demo/household-d/d-pg/
 demo/household-d/d-sidecar/
 demo/household-d/.env
 demo/recordings/
+demo/e2e/fixtures/demo-photos/
+demo/e2e/demo-targets.md

--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ Every method needs Docker, an admin API key, and **a reverse proxy in front of I
     - **[Tailscale](https://tailscale.com/) Funnel.** Funnel just `/sidecar/*` and `/share/*` to the sidecar over HTTPS. No domain and no open router ports needed.
     - **Fully hidden behind a Tailscale VPN.** Put every participating server on the same tailnet and nothing is exposed publicly at all. Ideal when the other households are on your tailnet too.
 - **Your server's security is your responsibility.** This is a tool, and it's only as secure as the server you run it on.
-- **Needs an admin API key** (all permissions). It creates its own bot users to own the placeholder photos, which is what keeps shared albums out of your own timeline while still showing the right name and avatar. Keep the key in `.env`.
+- **Nothing is protected by being hard to reach.** Every route assumes it's on the open internet. Pages you use (the panel, joining, leaving) require you to be **signed in to your own Immich** — the sidecar has no accounts of its own and checks your session against Immich itself. Server-to-server routes require a signature *and* a check that the asking household was actually offered that album and that photo. Being able to reach an endpoint is never permission to use it.
+- **Share links keep their own rules.** A password-protected link needs that same password to join across servers, and an expired link won't join at all. Set `REQUIRE_SHARE_PASSWORD=true` to refuse links that have no password — worth it on a public domain, because otherwise a forwarded link is the whole credential.
+- **Needs an admin API key** (all permissions), because it creates the bot users that own the placeholder photos — that's what keeps shared albums out of your own timeline while still showing the right name and avatar. Keep the key in `.env`. Those bot users are **not** admins, get a narrowly-scoped key, and have no password kept anywhere, so nobody can sign in as them.
 - **It can't touch your photos.** It only ever deletes the placeholder stubs it made itself, and only when you leave an album. The delete code refuses any asset it doesn't own, so your real library is safe whatever the key can do.
 - **Small attack surface.** Zero dependencies, plain Node plus the built-in `node:sqlite`, and a codebase you can read.
-- **Closed by default.** Two servers have to be introduced by a share link before anything flows. After that every request is signed, and the owner can remove any household at any time.
+- **Closed by default, with one caveat worth knowing.** Two servers have to be introduced by a share link before anything flows, every later request is signed, and the owner can remove any household at any time. The caveat: a share link is a *bearer* credential — whoever holds it (and its password) can introduce their server. Treat album links like you'd treat any link that grants access.
 
 ## Good to know
 
@@ -57,7 +59,7 @@ Every method needs Docker, an admin API key, and **a reverse proxy in front of I
 
 ## Versioning
 
-Semver with a sync-contract policy (a MAJOR bump means older peers can't sync with you). Versions are set automatically from commits, every change is gated on the e2e suite (66 checks plus a browser lane), and a weekly job runs against the latest Immich release to catch breakage early. See [CHANGELOG.md](./CHANGELOG.md).
+Semver with a sync-contract policy (a MAJOR bump means older peers can't sync with you). Versions are set automatically from commits, every change is gated on the e2e suite (84 checks plus a browser lane, 18 of them security regressions), and a weekly job runs against the latest Immich release to catch breakage early. See [CHANGELOG.md](./CHANGELOG.md).
 
 ## Support
 

--- a/demo/e2e/cdp-join.mjs
+++ b/demo/e2e/cdp-join.mjs
@@ -1,0 +1,60 @@
+// Drive the banner join on the demo device's real Chrome via CDP.
+// Deterministic replacement for coordinate taps: types the server address with
+// per-key delay (visible in the recording), clicks the real Join/Accept/Open
+// buttons, and waits for each page state. Usage:
+//   adb -s emulator-5556 forward tcp:9223 localabstract:chrome_devtools_remote
+//   node cdp-join.mjs <server-address>
+import { chromium } from 'playwright';
+
+// address of Joe's sidecar as reachable from the emulator — pass it in; never hardcode
+// a LAN address here, this repo is public.
+const ADDR = process.argv[2] || (process.env.LAN_IP ? `${process.env.LAN_IP}:8302` : null);
+if (!ADDR) { console.error('usage: node cdp-join.mjs <host:port>   (or set LAN_IP)'); process.exit(1); }
+const browser = await chromium.connectOverCDP('http://localhost:9223', { timeout: 120000 });
+const ctx = browser.contexts()[0];
+const page = ctx.pages().find(p => p.url().includes('/share/'));
+if (!page) { console.error('share page not found:', ctx.pages().map(p => p.url())); process.exit(1); }
+
+// the banner lives in a shadow root and re-renders as album data loads:
+// resolve host -> shadowRoot -> element fresh on EVERY step
+const bannerEl = (sel) => {
+  const host = document.querySelector('#immich-shared-albums-banner');
+  return host ? (host.shadowRoot || host).querySelector(sel) : null;
+};
+await page.waitForFunction(`(${bannerEl.toString()})('input') != null`, null, { timeout: 30000 });
+await page.waitForTimeout(1500); // let the banner settle after its last re-render
+// type inside the page (no focus -> no soft keyboard -> no layout thrash on camera)
+await page.evaluate(async ({ addr, fn }) => {
+  const get = eval(`(${fn})`);
+  for (let i = 1; i <= addr.length; i++) {
+    const inp = get('input');
+    if (inp) { inp.value = addr.slice(0, i); inp.dispatchEvent(new Event('input', { bubbles: true })); }
+    await new Promise(r => setTimeout(r, 110));
+  }
+}, { addr: ADDR, fn: bannerEl.toString() });
+await page.waitForTimeout(800);
+await page.evaluate((fn) => { eval(`(${fn})`)('button.join').click(); }, bannerEl.toString());
+await page.waitForURL('**/sidecar/accept*', { timeout: 30000 });
+console.log('accept page reached');
+
+await page.waitForFunction(() => document.getElementById('who')?.textContent?.includes('Joining as'), null, { timeout: 20000 });
+await page.waitForTimeout(1500);                 // viewer reads "Joining as Grandpa Joe"
+await page.evaluate(() => document.getElementById('go').click());
+await page.waitForFunction(() => document.getElementById('out')?.textContent?.includes('Joined'), null, { timeout: 60000 });
+console.log('joined');
+
+await page.waitForFunction(() => {
+  const b = document.getElementById('openapp');
+  return b && b.textContent.includes('Open in Immich app') && !b.disabled;
+}, null, { timeout: 90000 });
+await page.waitForTimeout(1500);                 // viewer sees the button enable
+// a scripted click lacks the user gesture Chrome requires for intent:// links
+// (it would follow the Play Store fallback) - print the album id; the caller
+// fires the same deeplink through adb instead
+const albumId = await page.evaluate(() => {
+  const href = document.getElementById('openapp')?.getAttribute('href') || '';
+  const m = href.match(/albums\/([0-9a-f-]+)/);
+  return m ? m[1] : '';
+});
+console.log('ALBUM_ID=' + albumId);
+await browser.close();

--- a/demo/e2e/demo-film.mjs
+++ b/demo/e2e/demo-film.mjs
@@ -8,10 +8,16 @@ import crypto from 'node:crypto';
 const SHARE_URL = process.env.SHARE_URL;
 const OUT = process.env.OUT || './video';
 // cookies are domain-scoped and port-blind: keep C on localhost and B on the LAN IP
-// so their sessions can coexist in one browser context
+// so their sessions can coexist in one browser context. LAN_IP is this machine's address
+// on the local network — never hardcode it, this repo is public.
+const LAN_IP = process.env.LAN_IP;
+if (!LAN_IP) {
+  console.error("set LAN_IP to this machine's LAN address, e.g. LAN_IP=$(ipconfig getifaddr en0)");
+  process.exit(1);
+}
 const C = 'http://localhost:2285', C_WEB = 'http://localhost:2285';
-const B_PANEL = 'http://192.168.0.11:8301', B_WEB = 'http://192.168.0.11:2284';
-const ADDR_TYPED = '192.168.0.11:8301';
+const B_PANEL = `http://${LAN_IP}:8301`, B_WEB = `http://${LAN_IP}:2284`;
+const ADDR_TYPED = `${LAN_IP}:8301`;
 
 const browser = await chromium.launch({ args: ['--disable-features=HttpsUpgrades,HttpsFirstModeV2,HttpsFirstBalancedModeAutoEnable,LocalNetworkAccessChecks,PrivateNetworkAccessForNavigations,PrivateNetworkAccessChecks'] });
 const ctx = await browser.newContext({

--- a/demo/e2e/demo-two-devices.sh
+++ b/demo/e2e/demo-two-devices.sh
@@ -1,61 +1,163 @@
 #!/bin/bash
-# Two-device demo driver: Device 1 (Nan, household B) creates + shares an album;
-# Device 2 (Grandpa Joe, household C) joins via the share link banner, contributes
-# photos back, and both exchange comments. Runs pre-rehearsed taps via tap.sh.
+# Scripted two-device demo: Nan (household B) creates + shares an album; Grandpa Joe
+# (household C) gets the link by text, joins via the banner, contributes photos back,
+# and they exchange comments. All coordinates pre-rehearsed (see demo-targets.md).
 #
-# Usage: demo-two-devices.sh <scene>      — run one scene (rehearsal)
-#        demo-two-devices.sh all          — run the full demo with paced sleeps
+#   demo-two-devices.sh reset    — purge servers, reset apps/Chrome state for a clean take
+#   demo-two-devices.sh run      — perform the paced demo (record separately)
 #
-# Devices must be pre-prepared (see demo/e2e/README):
-#   emulator-5554 = B (Demo Nan), signed in, photos in /sdcard/Pictures
-#   emulator-5556 = C (Grandpa Joe), signed in, photos in /sdcard/DCIM/Camera
-#   Chrome logged into the local web UI on BOTH devices (for the linking part)
+# Devices (prepped, signed in to the SIDECAR-proxied origins):
+#   emulator-5554 = Nan,  app+web http://$LAN_IP:8301, photos in /sdcard/Pictures
+#   emulator-5556 = Joe,  app+web http://$LAN_IP:8302, photos in /sdcard/DCIM/Camera
+#
+# LAN_IP is the LAN address of this machine, auto-detected below. Never
+# hardcode it: this repo is public.
 set -uo pipefail
-export PATH="$PATH:$HOME/Library/Android/sdk/platform-tools"
-DIR="$(cd "$(dirname "$0")" && pwd)"
-T="$DIR/tap.sh"
-D1=emulator-5554   # Nan / household B (owner)
-D2=emulator-5556   # Grandpa Joe / household C (joiner)
-B=http://192.168.0.11:2284
-BS=http://192.168.0.11:8301
-ALBUM="Summer Trip"
+export PATH="$PATH:$HOME/Library/Android/sdk/platform-tools:$HOME/Library/Android/sdk/emulator:/Applications/Docker.app/Contents/Resources/bin"
+DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+LAN_IP="${LAN_IP:-$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null)}"
+: "${LAN_IP:?set LAN_IP to the LAN address of this machine}"
+D1=emulator-5554
+D2=emulator-5556
+B=http://localhost:2284
+BKEY=$(grep -m1 B_API_KEY "$DIR/demo/.env" | cut -d= -f2-)
 
-pace() { sleep "${1:-2}"; }
+t1() { adb -s $D1 shell input tap "$@"; }
+t2() { adb -s $D2 shell input tap "$@"; }
+type1() { adb -s $D1 shell input text "$1"; }
+type2() { adb -s $D2 shell input text "$1"; }
 
-scene_1_create_album() { # D1: open app, create the album from the Albums tab
-  adb -s $D1 shell monkey -p app.alextran.immich 1 >/dev/null 2>&1; pace 4
-  $T $D1 find "Albums" 10; pace 2
-  $T $D1 find "Create album" 10; pace 2
-  $T $D1 find "Add a title" 5 && $T $D1 type "$ALBUM"; pace 1
-  $T $D1 key 111; pace 1
-  $T $D1 find "Add photos" 10; pace 2
-  # select the first three photos in the picker (coords frozen at rehearsal)
-  for XY in "TBD" ; do echo "REHEARSE: photo picker taps"; done
+reset() {
+  echo "== purge both mock servers (albums, sidecar users, assets, sidecar state) =="
+  ORIGIN_SIDECAR=unused "$DIR/demo/e2e/purge-mocks.sh" 2>/dev/null || {
+    # inline fallback: reuse the suite's purge steps
+    CKEY=$(grep -m1 C_API_KEY "$DIR/demo/household-c/.env" | cut -d= -f2-)
+    for HOST_KEY in "http://localhost:2284 $BKEY b-sidecar" "http://localhost:2285 $CKEY household-c/c-sidecar"; do
+      set -- $HOST_KEY
+      for AL in $(curl -s $1/api/albums -H "x-api-key: $2" | python3 -c "import json,sys;[print(a['id']) for a in json.load(sys.stdin)]" 2>/dev/null); do
+        curl -s -X DELETE $1/api/albums/$AL -H "x-api-key: $2" -o /dev/null; done
+      for U in $(curl -s $1/api/admin/users -H "x-api-key: $2" | python3 -c "import json,sys;[print(u['id']) for u in json.load(sys.stdin) if u['email'].endswith('@sidecar.local')]" 2>/dev/null); do
+        curl -s -X DELETE $1/api/admin/users/$U -H "x-api-key: $2" -H 'Content-Type: application/json' -d '{"force":true}' -o /dev/null; done
+      IDS=$(curl -s -X POST $1/api/search/metadata -H "x-api-key: $2" -H 'Content-Type: application/json' -d '{"size":500}' | python3 -c "import json,sys;print(json.dumps([i['id'] for i in json.load(sys.stdin)['assets']['items']]))" 2>/dev/null)
+      [ "${IDS:-[]}" != "[]" ] && curl -s -X DELETE $1/api/assets -H "x-api-key: $2" -H 'Content-Type: application/json' -d "{\"ids\":$IDS,\"force\":true}" -o /dev/null
+    done
+    (cd "$DIR/demo" && docker compose exec -T sidecar-b rm -f /data/state.json /data/state.db /data/state.db-wal /data/state.db-shm; docker compose restart sidecar-b) >/dev/null 2>&1
+    (cd "$DIR/demo/household-c" && docker compose exec -T sidecar-c rm -f /data/state.json /data/state.db /data/state.db-wal /data/state.db-shm; docker compose restart sidecar-c) >/dev/null 2>&1
+  }
+  echo "== seed each server with its user's photos (checksum-merges with device copies) =="
+  CKEY=$(grep -m1 C_API_KEY "$DIR/demo/household-c/.env" | cut -d= -f2-)
+  FX="$DIR/demo/e2e/fixtures/demo-photos"
+  seed() { # base key file stamp
+    curl -s -X POST "$1/api/assets" -H "x-api-key: $2" \
+      -F "assetData=@$3" -F "deviceAssetId=demo-$(basename $3)" -F deviceId=demo-seed \
+      -F "fileCreatedAt=$4" -F "fileModifiedAt=$4" -o /dev/null
+  }
+  for f in 1 2 3; do seed http://localhost:2284 "$BKEY" "$FX/nan-photo-$f.jpg" "2026-08-16T10:3$f:00.000Z"; done
+  for f in 1 2 3 4 5; do seed http://localhost:2285 "$CKEY" "$FX/demo-$f.jpg" "2026-08-16T14:0$f:00.000Z"; done
+  echo "== reset app local state (stale albums vanish; sessions survive) =="
+  for D in $D1 $D2; do adb -s $D shell am force-stop app.alextran.immich; done
+  echo "== forget the remembered banner address (so Joe visibly types it) =="
+  adb -s $D2 shell am force-stop com.android.chrome
+  echo "== pre-warm Chrome so the take doesn't cold-start it (ANR guard) =="
+  adb -s $D2 shell am start -a android.intent.action.VIEW -d "about:blank" com.android.chrome >/dev/null 2>&1
+  sleep 10
+  adb -s $D2 shell input keyevent 3
+  echo "== re-stage: apps re-sync, Nan on Photos, Joe parked on home =="
+  adb -s $D2 shell monkey -p app.alextran.immich 1 >/dev/null 2>&1; sleep 15
+  adb -s $D2 shell input keyevent 3
+  adb -s $D1 shell monkey -p app.alextran.immich 1 >/dev/null 2>&1; sleep 12
+  echo "reset done — run '$0 run' to perform the take (start recording first)"
 }
 
-scene_2_share_link() { # D1: create the share link from the album screen
-  echo "REHEARSE: album overflow menu -> Share -> Create link"
-}
+run() {
+  echo "=== SCENE 1: Nan uploads & creates the album ==="
+  adb -s $D1 shell monkey -p app.alextran.immich 1 >/dev/null 2>&1; sleep 6
+  t1 990 214; sleep 4                          # avatar: show WHO + WHICH server (8301)
+  adb -s $D1 shell input keyevent 4; sleep 1
+  t1 673 2251; sleep 2                         # Albums tab
+  t1 863 214; sleep 2                          # + new album
+  t1 542 531; sleep 1; type1 "Summer%sTrip"; sleep 1
+  t1 539 400; sleep 1                          # tap outside: dismiss keyboard
+  t1 538 1151; sleep 2                         # Select Photos
+  t1 984 542; sleep 1                          # select whole day
+  t1 993 214; sleep 2                          # Done
+  t1 986 214; sleep 6                          # Create
+  echo "=== SCENE 2: Nan creates the share link ==="
+  t1 1015 218; sleep 2                         # album overflow
+  t1 808 871; sleep 3                          # Create shared link
+  t1 883 1419; sleep 1                         # allow upload ON
+  t1 841 1843; sleep 4                         # Create link
+  t1 73 214; sleep 2                           # close link sheet (back)
 
-scene_3_join() { # D2: open the share link in Chrome (as if texted over), banner join
+  echo "=== SCENE 3: the link reaches Joe by text ==="
   KEY=$(curl -s $B/api/shared-links -H "x-api-key: $BKEY" | python3 -c 'import json,sys;print(json.load(sys.stdin)[-1]["key"])')
-  adb -s $D2 shell am start -a android.intent.action.VIEW -d "$BS/share/$KEY" com.android.chrome; pace 6
-  echo "REHEARSE: banner field tap -> type http://192.168.0.11:2285 -> Join -> Accept -> Open in Immich app"
+  adb -s $D2 emu sms send 07700900123 "Hi Joe! Come see our Summer Trip photos: http://$LAN_IP:8301/share/$KEY"
+  sleep 6                                      # notification beat on Joe's home screen
+  adb -s $D2 shell am force-stop com.google.android.apps.messaging
+  adb -s $D2 shell am start -n com.google.android.apps.messaging/.ui.ConversationListActivity >/dev/null 2>&1; sleep 4
+  t2 672 480; sleep 4                          # open the conversation (message on screen)
+  # "tap" the link: fire the same VIEW intent the tap would - identical on screen, cannot miss
+  adb -s $D2 shell am start -a android.intent.action.VIEW -d "http://$LAN_IP:8301/share/$KEY" com.android.chrome >/dev/null 2>&1
+  sleep 15                                     # generous settle: cold Chrome + heavy page
+
+  echo "=== SCENE 4: Joe joins with his own server ==="
+  # CDP drives the real page elements (typing shown live) - immune to layout shifts
+  adb -s $D2 forward tcp:9223 localabstract:chrome_devtools_remote >/dev/null
+  JOIN_OUT=$(cd "$DIR/demo/e2e" && node cdp-join.mjs "$LAN_IP:8302") || echo "CDP join FAILED"
+  echo "$JOIN_OUT"
+  MIRROR_ID=$(echo "$JOIN_OUT" | grep -o 'ALBUM_ID=.*' | cut -d= -f2)
+  # open the album in the app the reliable way (scripted page clicks lack the
+  # user gesture chrome requires for intent:// and would bounce to the Play Store).
+  # warm the app FIRST so its local db has synced the new album - a cold-start
+  # deeplink can't route to an album the app hasn't seen yet
+  adb -s $D2 shell monkey -p app.alextran.immich 1 >/dev/null 2>&1
+  sleep 12                                     # app sync pulls the joined album
+  adb -s $D2 shell am start -a android.intent.action.VIEW -d "https://my.immich.app/albums/$MIRROR_ID" app.alextran.immich >/dev/null 2>&1
+  sleep 8                                      # album page opens
+  if [ -n "${RUN_PART1_ONLY:-}" ]; then echo "=== PART 1 COMPLETE - handing over ==="; return; fi
+  adb -s $D2 shell input swipe 672 1400 672 2200 400; sleep 6   # browse: pull refresh
+  sleep 6                                      # let hotlinked thumbnails paint
+  adb -s $D2 shell input keyevent 4; sleep 2   # back to Photos
+  t2 168 2811; sleep 2                         # Photos tab
+  t2 1247 243; sleep 5                         # avatar: Joe's DIFFERENT server (8302)
+  adb -s $D2 shell input keyevent 4; sleep 2
+  t2 842 2811; sleep 3                         # Albums tab
+  t2 672 975; sleep 5                          # reopen Summer Trip
+
+  echo "=== SCENE 5: Joe adds his own photos ==="
+  t2 1273 243; sleep 2                         # overflow
+  t2 1162 407; sleep 4                         # Add photos
+  t2 504 885; sleep 1                          # photo 1 (portrait)
+  t2 165 1222; sleep 1                         # photo 2 (sunset)
+  t2 1248 243; sleep 10                        # Done -> upload + push
+
+  echo "=== SCENE 6: they arrive on Nan's server ==="
+  sleep 20                                     # cross-server sync
+  t1 73 214; sleep 2                           # back to albums list
+  adb -s $D1 shell input swipe 539 700 539 1400 300; sleep 6    # pull-to-refresh reveals
+  t1 539 782; sleep 8                          # open Summer Trip: 5 items
+
+  echo "=== SCENE 7: comments, both directions ==="
+  t1 888 214; sleep 3                          # Nan opens comments
+  t1 539 2270; sleep 2
+  type1 "What%sa%slovely%sday%sout%sJoe!"; sleep 1
+  t1 1015 2100; sleep 3                        # send
+  sleep 12                                     # comment lane
+  t2 1128 243; sleep 4                         # Joe opens comments (sees Nan's)
+  t2 672 2824; sleep 2
+  type2 "Cracking%sday%sNan,%ssee%syou%ssoon!"; sleep 1
+  t2 1273 1886; sleep 3                        # send
+  sleep 12
+  t1 73 214; sleep 2                           # Nan: close + reopen to reveal reply
+  t1 888 214; sleep 6
+  echo "=== demo complete ==="
 }
 
-scene_4_contribute() { # D2: add own photos to the joined album
-  echo "REHEARSE: album -> + -> pick photos -> upload"
-}
+part1() { RUN_PART1_ONLY=1 run; }  # scenes 1-4 only, then hand over
 
-scene_5_comments() { # both: comment in each direction
-  echo "REHEARSE: D1 comment 'Lovely day!' -> D2 sees it -> D2 replies"
-}
-
-case "${1:-all}" in
-  1) scene_1_create_album ;;
-  2) scene_2_share_link ;;
-  3) scene_3_join ;;
-  4) scene_4_contribute ;;
-  5) scene_5_comments ;;
-  all) scene_1_create_album; scene_2_share_link; scene_3_join; scene_4_contribute; scene_5_comments ;;
+case "${1:-}" in
+  reset) reset ;;
+  run) run ;;
+  part1) part1 ;;
+  *) echo "usage: $0 reset|run|part1"; exit 1 ;;
 esac

--- a/demo/e2e/e2e-test.mjs
+++ b/demo/e2e/e2e-test.mjs
@@ -14,6 +14,9 @@ const api = async (base, key, path, init = {}) => {
   return r.status === 204 ? null : r.json();
 };
 const j = (o) => ({ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(o) });
+// /sidecar/join authenticates the caller against that household's own Immich, so the
+// suite has to present a real credential exactly like a signed-in browser would.
+const jAuth = (o, key) => ({ method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': key }, body: JSON.stringify(o) });
 const albumAssets = async (base, key, albumId) =>
   (await api(base, key, '/search/metadata', j({ albumIds: [albumId], size: 100, withExif: true }))).assets.items;
 import crypto from 'node:crypto';
@@ -43,6 +46,17 @@ const ensurePreviews = async (base, key, ids) => {
 };
 const sha1 = (buf) => crypto.createHash('sha1').update(Buffer.from(buf)).digest('hex');
 const fetchBytes = async (url, key) => (await fetch(url, { headers: { 'x-api-key': key } })).arrayBuffer();
+// Read a JSON value out of a sidecar's SQLite state, via the sqlite3 CLI the runner
+// already uses. Returns null (rather than throwing) when the rig is not local.
+import { execFileSync } from 'node:child_process';
+const readSidecarKv = (stateDir, name) => {
+  try {
+    const path = new URL(`../${stateDir}/state.db`, import.meta.url).pathname;
+    const out = execFileSync('sqlite3', [path, `SELECT value FROM kv WHERE name='${name}'`],
+                             { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    return out ? JSON.parse(out) : null;
+  } catch { return null; }
+};
 const until = async (fn, timeoutMs = 90000, everyMs = 5000) => {
   const t0 = Date.now();
   while (Date.now() - t0 < timeoutMs) { const v = await fn(); if (v) return v; await sleep(everyMs); }
@@ -77,7 +91,10 @@ let shareKey = (await api(A, AKEY, '/shared-links')).find(l => l.album?.id === A
 if (!shareKey) shareKey = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: ALBUM_ID, allowUpload: true }))).key;
 // Without Caddy, sidecar and immich are on different ports — the redeem must target the ORIGIN SIDECAR.
 const ORIGIN_SIDECAR = process.env.ORIGIN_SIDECAR || A;
-const joinRes = await (await fetch(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` }))).json();
+// ORIGIN_SIDECAR is resolved by B's sidecar from INSIDE its container (host.docker.internal).
+// The security stage calls the origin directly from this process, so it needs a host route.
+const ORIGIN_DIRECT = process.env.ORIGIN_SIDECAR_DIRECT || 'http://localhost:8302';
+const joinRes = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` }, BKEY))).json();
 check('join succeeded', !!joinRes.album, JSON.stringify(joinRes));
 check('join manifest = 4 photos', joinRes.photos === 4, `got ${joinRes.photos}`);
 
@@ -230,7 +247,7 @@ if (aAfter) {
   await api(A, AKEY, `/albums/${alb2}/assets`, { ...j({ ids: [aIds[0]] }), method: 'PUT' });
   const share2 = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: alb2, allowUpload: true }))).key;
   const nanId = (await api(B, BKEY, '/users/me')).id;
-  const join2 = await (await fetch(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${share2}`, forUserId: nanId }))).json();
+  const join2 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share2}`, forUserId: nanId }, BKEY))).json();
   check('second album join ok', join2.photos === 1, JSON.stringify(join2));
   const mirror2 = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'second album');
   const m2assets = await until(async () => { const x = await albumAssets(B, BKEY, mirror2.id); return x.length === 1 ? x : null; }, 40000);
@@ -242,7 +259,7 @@ if (aAfter) {
   console.log('— stage: re-join by a second user attaches to the existing mirror');
   let second = (await api(B, BKEY, '/admin/users')).find(u => u.email === 'second-e2e@demo.local');
   if (!second) second = await api(B, BKEY, '/admin/users', j({ email: 'second-e2e@demo.local', name: 'Second Human', password: 'e2e-pass-123' }));
-  const join2b = await (await fetch(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${share2}`, forUserId: second.id }))).json();
+  const join2b = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share2}`, forUserId: second.id }, BKEY))).json();
   check('re-join returns the existing mirror (no duplicate album)', join2b.albumId === mirror2.id, JSON.stringify(join2b).slice(0, 100));
   const dupCount = (await api(B, BKEY, '/albums')).filter(a => a.albumName === 'second album').length;
   check('only one "second album" mirror exists', dupCount === 1, `${dupCount} album(s)`);
@@ -282,7 +299,7 @@ console.log('— stage: instant join (no preview wait) heals via reconciliation'
   await api(A, AKEY, `/albums/${alb3}/assets`, { ...j({ ids: [fresh] }), method: 'PUT' });
   const share3 = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: alb3, allowUpload: true }))).key;
   const meB = (await api(B, BKEY, '/users/me')).id;
-  const join3 = await (await fetch(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${share3}`, forUserId: meB }))).json();
+  const join3 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share3}`, forUserId: meB }, BKEY))).json();
   check('instant join accepted', !!join3.albumId, JSON.stringify(join3).slice(0, 100));
   const m3 = await until(async () => {
     const mirror3 = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'instant album');
@@ -298,7 +315,7 @@ console.log('— stage: share link created before any photos (empty album) still
   const alb5 = (await api(A, AKEY, '/albums', j({ albumName: 'born empty' }))).id;
   const share5 = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: alb5, allowUpload: true }))).key;
   const meB5 = (await api(B, BKEY, '/users/me')).id;
-  const join5 = await (await fetch(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${share5}`, forUserId: meB5 }))).json();
+  const join5 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share5}`, forUserId: meB5 }, BKEY))).json();
   check('empty-album join succeeds', !!join5.albumId, JSON.stringify(join5).slice(0, 100));
   const bu5 = (await api(B, BKEY, '/admin/users')).filter(u => u.email.endsWith('@sidecar.local'));
   check('empty-album mirror owner named after the sharer, not the household',
@@ -313,7 +330,7 @@ console.log('— stage: view-only share link (allowUpload off) rejects cross-ser
   await api(A, AKEY, `/albums/${alb6}/assets`, { ...j({ ids: [voId] }), method: 'PUT' });
   const share6 = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: alb6, allowUpload: false }))).key;
   const meB6 = (await api(B, BKEY, '/users/me')).id;
-  const join6 = await (await fetch(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${share6}`, forUserId: meB6 }))).json();
+  const join6 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share6}`, forUserId: meB6 }, BKEY))).json();
   const mirror6 = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'view only album');
   const m6 = await until(async () => { const x = await albumAssets(B, BKEY, mirror6.id); return x.length === 1 ? x : null; }, 60000);
   check('view-only album still syncs for viewing', !!m6, m6 ? '' : 'timed out');
@@ -336,7 +353,7 @@ console.log('— stage: reverse-direction share — member-owned album with an a
   await api(B, BKEY, `/albums/${albR}/assets`, { ...j({ ids: [nIds[0]] }), method: 'PUT' });
   const shareR = (await api(B, BKEY, '/shared-links', j({ type: 'ALBUM', albumId: albR, allowUpload: true }))).key;
   const meC = (await api(A, AKEY, '/users/me')).id;
-  const joinR = await (await fetch(`${CS}/sidecar/join`, j({ url: `${REV}/share/${shareR}`, forUserId: meC }))).json();
+  const joinR = await (await fetch(`${CS}/sidecar/join`, jAuth({ url: `${REV}/share/${shareR}`, forUserId: meC }, AKEY))).json();
   check('reverse join: C joins a B-owned album', !!joinR.albumId, JSON.stringify(joinR).slice(0, 100));
   const mirrorR = (await api(A, AKEY, '/albums')).find(a => a.albumName === 'reverse album');
   const mR = mirrorR && await until(async () => { const x = await albumAssets(A, AKEY, mirrorR.id); return x.length === 1 ? x : null; }, 180000);
@@ -352,7 +369,7 @@ const DS = process.env.D_SIDECAR || 'http://localhost:8303';
 const DKEY = process.env.DKEY;
 let dMirror = null;
 if (DKEY) {
-  const joinD = await (await fetch(`${DS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` }))).json();
+  const joinD = await (await fetch(`${DS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` }, DKEY))).json();
   check('D join succeeded', !!joinD.albumId, JSON.stringify(joinD).slice(0, 100));
   dMirror = (await api(D, DKEY, '/albums')).find(a => a.albumName === joinD.album);
   const dAssets = await until(async () => { const x = await albumAssets(D, DKEY, dMirror.id); return x.length === 9 ? x : null; }, 150000);
@@ -392,7 +409,7 @@ console.log('— stage: deletion propagation + leave-&-purge (reversible joins)'
   await api(A, AKEY, `/albums/${albD}/assets`, { ...j({ ids: [d1, d2] }), method: 'PUT' });
   const shareD = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: albD, allowUpload: true }))).key;
   const meBD = (await api(B, BKEY, '/users/me')).id;
-  const joinD2 = await (await fetch(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${shareD}`, forUserId: meBD }))).json();
+  const joinD2 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareD}`, forUserId: meBD }, BKEY))).json();
   const mirrorD = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'delete test');
   const mD = await until(async () => { const x = await albumAssets(B, BKEY, mirrorD.id); return x.length === 2 ? x : null; }, 60000);
   check('delete-test album joined and mirrored (2 stubs)', !!mD, mD ? '' : 'timed out');
@@ -449,6 +466,126 @@ const EXPECT = DKEY ? 10 : 9;
 check('no ping-pong on A', (await albumAssets(A, AKEY, ALBUM_ID)).length === EXPECT, `A=${(await albumAssets(A, AKEY, ALBUM_ID)).length}`);
 check('no ping-pong on B', (await albumAssets(B, BKEY, mirror.id)).length === EXPECT, `B=${(await albumAssets(B, BKEY, mirror.id)).length}`);
 if (DKEY && dMirror) check('no ping-pong on D', (await albumAssets(D, DKEY, dMirror.id)).length === EXPECT, `D=${(await albumAssets(D, DKEY, dMirror.id)).length}`);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Security regressions. Each check below maps to a specific hole that existed
+// before the hardening pass; they are the reason the sidecar is safe to publish
+// on a domain rather than only reachable over a tailnet.
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('— stage: security (unauthenticated surface)');
+{
+  const status = async (url, init) => (await fetch(url, init).catch(() => ({ status: 0 }))).status;
+
+  check('panel refuses an unauthenticated caller',
+        [401, 403].includes(await status(`${BS}/sidecar/`)), `got ${await status(`${BS}/sidecar/`)}`);
+  check('join refuses an unauthenticated caller',
+        await status(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` })) === 401);
+  check('leave refuses an unauthenticated caller',
+        await status(`${BS}/sidecar/leave`, j({ mappingId: 'whatever' })) === 401);
+
+  const health = await (await fetch(`${BS}/sidecar/health`)).json();
+  check('health exposes liveness only (no household name, no peer count)',
+        health.ok === true && !('household' in health) && !('peers' in health), JSON.stringify(health));
+
+  check('oversized body is rejected before it is buffered',
+        await status(`${BS}/sidecar/join`, { method: 'POST', headers: { 'Content-Type': 'application/json' },
+                                             body: 'x'.repeat(2 * 1024 * 1024) }) === 413);
+
+  check('redeem refuses an unsigned caller',
+        await status(`${ORIGIN_DIRECT}/sidecar/api/v1/invites/redeem`,
+                     j({ shareKey, protocol: 1, household: { publicKey: 'AAAA', url: 'http://x', name: 'imposter' } })) === 403);
+
+  check('avatar route refuses a bare public key with no signature',
+        [403, 405].includes(await status(`${ORIGIN_DIRECT}/sidecar/api/v1/users/${(await api(A, AKEY, '/users/me')).id}/avatar`,
+                                         { headers: { 'x-isa-key': 'AAAA' } })));
+}
+
+console.log('— stage: security (entitlement — a signed peer is not entitled to everything)');
+{
+  // Sign as B really is: B's keypair lives in its sidecar volume. Read it with the sqlite3
+  // CLI rather than node:sqlite — the runner already depends on the CLI, and node:sqlite
+  // needs Node 22+, which would make these checks skip silently on an older host.
+  const bKeys = readSidecarKv('b-sidecar', 'keys');
+  if (!bKeys) console.log('  (skipped: cannot read B\'s keypair from demo/b-sidecar/state.db)');
+
+  if (bKeys) {
+    const signAs = (v) => crypto.sign(null, Buffer.from(v),
+      crypto.createPrivateKey({ key: Buffer.from(bKeys.priv, 'base64url'), format: 'der', type: 'pkcs8' })).toString('base64url');
+    const asB = (v) => ({ headers: { 'x-isa-key': bKeys.pub, 'x-isa-sig': signAs(v) } });
+
+    // A private album on the origin that was never shared with anyone. Before the fix, any
+    // enrolled peer could pull its originals with the admin key just by naming the asset.
+    const privAlbum = (await api(A, AKEY, '/albums', j({ albumName: 'not shared with anyone' }))).id;
+    const privAsset = await upload(A, AKEY, 'private-e2e.jpg', `pv${Date.now() % 10000}`, '2026-07-01T09:00:00.000Z');
+    await ensurePreviews(A, AKEY, [privAsset]);
+    await api(A, AKEY, `/albums/${privAlbum}/assets`, { ...j({ ids: [privAsset] }), method: 'PUT' });
+
+    const privStatus = (await fetch(`${ORIGIN_DIRECT}/sidecar/api/v1/assets/${privAsset}/original`, asB(privAsset))).status;
+    check('a valid peer CANNOT read an asset that was never shared with it (F-05)',
+          privStatus === 403, `got ${privStatus}`);
+
+    // Control: the same signature on an asset B genuinely was offered must still work,
+    // otherwise the check above would pass simply by breaking all byte reads.
+    const okStatus = (await fetch(`${ORIGIN_DIRECT}/sidecar/api/v1/assets/${aIds[0]}/original`, asB(aIds[0]))).status;
+    check('the same peer CAN still read an asset it was offered (no over-blocking)',
+          okStatus === 200, `got ${okStatus}`);
+
+    const manifestStatus = (await fetch(`${ORIGIN_DIRECT}/sidecar/api/v1/albums/${privAlbum}/manifest`, asB(privAlbum))).status;
+    check('a valid peer CANNOT read the manifest of an album not mapped to it (F-06)',
+          [403, 404].includes(manifestStatus), `got ${manifestStatus}`);
+
+    await api(A, AKEY, '/assets', { ...j({ ids: [privAsset], force: true }), method: 'DELETE' }).catch(() => {});
+    await api(A, AKEY, `/albums/${privAlbum}`, { method: 'DELETE' }).catch(() => {});
+  }
+}
+
+console.log('— stage: security (album password gates enrolment)');
+{
+  const pwAlbum = (await api(A, AKEY, '/albums', j({ albumName: 'password album' }))).id;
+  const pwAsset = await upload(A, AKEY, 'pw-e2e.jpg', `pw${Date.now() % 10000}`, '2026-07-02T09:00:00.000Z');
+  await ensurePreviews(A, AKEY, [pwAsset]);
+  await api(A, AKEY, `/albums/${pwAlbum}/assets`, { ...j({ ids: [pwAsset] }), method: 'PUT' });
+  const pwKey = (await api(A, AKEY, '/shared-links',
+    j({ type: 'ALBUM', albumId: pwAlbum, allowUpload: true, password: 'correct horse' }))).key;
+  const meP = (await api(B, BKEY, '/users/me')).id;
+  const tryJoin = async (password) => {
+    const r = await fetch(`${BS}/sidecar/join`,
+      jAuth({ url: `${ORIGIN_SIDECAR}/share/${pwKey}`, forUserId: meP, password }, BKEY));
+    return { status: r.status, body: await r.json().catch(() => ({})) };
+  };
+  const noPw = await tryJoin(undefined);
+  check('join without the album password is refused and asks for one',
+        noPw.status === 401 && noPw.body.passwordRequired === true, JSON.stringify(noPw.body).slice(0, 120));
+  const badPw = await tryJoin('wrong horse');
+  check('join with the wrong album password is refused',
+        badPw.status >= 400 && !badPw.body.album, JSON.stringify(badPw.body).slice(0, 120));
+  const goodPw = await tryJoin('correct horse');
+  check('join with the correct album password succeeds', !!goodPw.body.album, JSON.stringify(goodPw.body).slice(0, 160));
+
+  // expiry is honoured too — a link past its date must not enrol anyone
+  const expAlbum = (await api(A, AKEY, '/albums', j({ albumName: 'expired album' }))).id;
+  const expKey = (await api(A, AKEY, '/shared-links',
+    j({ type: 'ALBUM', albumId: expAlbum, expiresAt: '2020-01-01T00:00:00.000Z' }))).key;
+  const expRes = await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${expKey}`, forUserId: meP }, BKEY));
+  check('join through an expired share link is refused', expRes.status >= 400, `got ${expRes.status}`);
+  await api(A, AKEY, `/albums/${expAlbum}`, { method: 'DELETE' }).catch(() => {});
+}
+
+console.log('— stage: security (utility accounts cannot be signed into)');
+{
+  const utility = (await api(B, BKEY, '/admin/users')).filter(u => u.email.endsWith('@sidecar.local'));
+  check('utility users exist to own the stubs', utility.length > 0, `${utility.length} found`);
+  check('no utility user is an admin', utility.every(u => !u.isAdmin));
+  const contributors = readSidecarKv('b-sidecar', 'contributors');
+  if (contributors) {
+    const entries = Object.values(contributors);
+    const withPassword = entries.filter((c) => c.password).length;
+    check('utility accounts were actually provisioned with keys', entries.length > 0 && entries.every((c) => c.key),
+          `${entries.length} contributor(s)`);
+    check('no utility login password is retained in state.db once provisioned',
+          withPassword === 0, `${withPassword} of ${entries.length} still stored`);
+  } else console.log('  (skipped password-retention check: cannot read demo/b-sidecar/state.db)');
+}
 
 const fails = results.filter(r => !r.ok);
 console.log(`\n${fails.length === 0 ? '🎉 ALL PASS' : `💥 ${fails.length} FAILURES`} (${results.length} checks)`);

--- a/demo/e2e/record-demo.sh
+++ b/demo/e2e/record-demo.sh
@@ -14,9 +14,11 @@ mkdir -p "$OUT"
 start_one() { # chain 3-minute segments until stop-file appears
   local D=$1
   adb -s "$D" shell rm -f /sdcard/rec-*.mp4 /sdcard/rec-stop 2>/dev/null
+  local SIZE=""
+  [ "$D" = "emulator-5556" ] && SIZE="--size 672x1496"   # native 1344x2992 exceeds the encoder
   ( i=0
     while ! adb -s "$D" shell ls /sdcard/rec-stop >/dev/null 2>&1; do
-      adb -s "$D" shell screenrecord --bit-rate 8000000 "/sdcard/rec-$i.mp4"
+      adb -s "$D" shell screenrecord --bit-rate 8000000 $SIZE "/sdcard/rec-$i.mp4"
       i=$((i+1))
     done ) &
   echo "recording $D (pid $!)"

--- a/deploy/Caddyfile.snippet
+++ b/deploy/Caddyfile.snippet
@@ -1,5 +1,16 @@
 # Add inside your existing Immich site block, BEFORE the catch-all route.
+#
+# All of /sidecar/* is safe to expose publicly: the panel and the join/leave routes
+# require a signed-in Immich session (checked against your own Immich, server-side), and
+# the server-to-server routes require a signature plus an entitlement check. You do NOT
+# need to restrict these by source IP — doing so would break joining from mobile data,
+# since someone's accept page calls their own server's /sidecar/join.
 handle /sidecar/* {
+	# optional belt-and-braces: the sidecar caps its own JSON bodies (MAX_BODY_KB),
+	# but capping at the proxy keeps oversized requests off the process entirely.
+	request_body {
+		max_size 2MB
+	}
 	reverse_proxy immich-shared:8300
 }
 # join banner on share pages; fallback keeps share pages working if the sidecar is down

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -57,14 +57,23 @@ VERIFY (all three, report results):
 ROLLBACK (if anything fails): docker compose down the sidecar, revert the proxy
 diff, reload the proxy — Immich itself is untouched throughout.
 
+4. If my Immich is reachable from the public internet, set REQUIRE_SHARE_PASSWORD=true
+   and ALLOW_PRIVATE_PEERS=false in the sidecar env, and tell me what each one
+   changes. Skip both if I am only reachable over a LAN or a tailnet.
+
 Notes for you, the agent:
 - The sidecar is additive and fail-open: if it dies, only the banner and
   cross-server sync stop; Immich keeps working. Never modify Immich's own
   compose services, database, or upload folders.
-- State lives in the ./data volume (state.json: household keypair, peers,
-  album mappings). Losing it breaks existing cross-server links.
+- State lives in the ./data volume (state.db: household keypair, peers, album
+  mappings, ledgers). Losing it breaks existing cross-server links.
 - The API key is a live credential: keep it out of shell history, logs, and
   world-readable files.
+- All three routes are safe to expose publicly — the sidecar authenticates
+  human routes against the user's own Immich session and peer routes by
+  signature plus entitlement. Do NOT add source-IP restrictions to /sidecar/*:
+  it would break joining from mobile data, because someone's accept page calls
+  their own server's /sidecar/join.
 ```
 
 ---

--- a/deploy/docker-compose.example.yml
+++ b/deploy/docker-compose.example.yml
@@ -12,5 +12,18 @@ services:
       PUBLIC_URL: https://photos.example.com
       HOUSEHOLD_NAME: "The Example household"
       # optional: PORT (8300), DATA_DIR (/data), POLL_MS (20000), ALBUM_TEMPLATE ("{name}")
+      # optional: CACHE_MAX_MB (512), MAX_BODY_KB (1024)
+      #
+      # Recommended when this server is reachable from the public internet:
+      #   REQUIRE_SHARE_PASSWORD: "true"   # refuse to enrol a peer from a link with no
+      #                                    # password set. Without it, whoever holds a
+      #                                    # forwarded link can introduce their server.
+      #   ALLOW_PRIVATE_PEERS: "false"     # a peer address must be https and must not
+      #                                    # resolve to a private range. Leave this alone
+      #                                    # (default true) for LAN or tailnet setups.
+      #   UTILITY_QUOTA_MB: "2048"         # storage cap on the bot users that own the
+      #                                    # stubs. They store ~2KB/photo and ~2MB/video,
+      #                                    # so size it well above your shared volume —
+      #                                    # too low and syncing silently starts failing.
     volumes:
       - ./sidecar-data:/data

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -51,8 +51,16 @@ ordinary data we planted, or a web page we serve.
   comments are posted via the author's utility user, and a seen-ledger keyed
   both directions prevents echo loops.
 - **protocol client/server** — signed ref exchange between households.
-  Key pinned at redemption (anchored on the share key). URLs are hints;
-  identity is the key.
+  Key pinned at redemption (anchored on the share key, whose password and expiry are
+  both honoured). URLs are hints; identity is the key. Crucially, identity is *only*
+  identity: every mapping lookup is filtered by the calling peer, so a signature can
+  never select someone else's album. See `p2p/wire-protocol.md`.
+- **entitlement** — the answer to "may this peer read these bytes", kept separately from
+  "who is this peer". Everything advertised to a mapping (a redeem response, a manifest,
+  a ref push) is recorded in an `offered` index; the peer-facing byte routes serve only
+  what is on it, falling back to album membership (throttled) so upgrades self-heal.
+  Without this, an asset id — which manifests hand out by design — would be enough for
+  any enrolled peer to read anything the admin key can reach.
 - **materialiser** — makes shared state look like ordinary Immich data:
   mirror albums owned by a utility user named after the origin's album owner
   ("Jane (via shared albums)"), one utility user per contributor (with their
@@ -145,3 +153,10 @@ human or AI agent — see [AGENTS.md](../AGENTS.md).
    only ever STORED elsewhere when a user explicitly saves a photo to their
    own library.
 5. Default-closed: no uninvited server can reach anything.
+6. **Reachability is never permission.** Every route assumes it is published to the open
+   internet. Human routes authenticate against the caller's own Immich session; peer
+   routes require a signature *and* an entitlement check. Nothing is protected by being
+   hard to find, on a private network, or behind a URL nobody has guessed.
+7. **The sidecar invents no identities and holds no logins.** The only identity that means
+   anything is an Immich one. The bot users that own the stubs get a narrowly-scoped API
+   key and no retained password, so they cannot be signed into at all.

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,22 @@ export const CFG = {
   // bounded LRU byte-cache for streamed previews (0 disables). A cache, not storage:
   // capped, reclaimable, invisible to libraries — delete the folder any time.
   cacheMaxMb: Number(process.env.CACHE_MAX_MB ?? 512),
+  // Hard cap on any request body we will buffer. The router reads bodies before it can
+  // know who is calling, so this is the one limit that must not depend on auth.
+  maxBodyKb: Number(process.env.MAX_BODY_KB ?? 1024),
+  // Refuse to enrol a peer from a share link that carries no password. Recommended
+  // whenever the sidecar is reachable from the public internet: without it, possession
+  // of a link is the whole credential. A link's own password and expiry are ALWAYS
+  // enforced regardless of this setting.
+  requireSharePassword: process.env.REQUIRE_SHARE_PASSWORD === 'true',
+  // Optional storage cap on the bot users that own the stubs (0 = no quota). They only
+  // ever store ~2KB per photo and ~2MB per video, so a cap bounds what a stolen utility
+  // key could write — but set it too low and materialisation silently starts failing.
+  utilityQuotaMb: Number(process.env.UTILITY_QUOTA_MB ?? 0),
+  // Peer URLs on private ranges are normal for LAN and tailnet deployments, so they are
+  // allowed by default. Set false on a public-facing host to stop a peer URL being aimed
+  // at internal services.
+  allowPrivatePeers: process.env.ALLOW_PRIVATE_PEERS !== 'false',
 };
 if (!CFG.apiKey) { console.error('IMMICH_API_KEY required'); process.exit(1); }
 export const log = (...a) => console.log(new Date().toISOString(), ...a);

--- a/src/immich/contributors.ts
+++ b/src/immich/contributors.ts
@@ -10,6 +10,21 @@ import { immichJson, jsonBody, usersById, USERS } from './client.ts';
 import { sign } from '../peers.ts';
 
 export const slugify = (s) => (s || 'peer').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'peer';
+
+/**
+ * Exactly what a utility user does, and nothing else. These are non-admin accounts, so an
+ * "all" key was never admin-equivalent — but it still granted every action that user could
+ * take, on a credential that sits in state.db. This is the list the sidecar actually
+ * exercises: own the stubs, curate the mirror album, mirror comments, carry an avatar.
+ */
+const UTILITY_PERMISSIONS = [
+  'asset.upload', 'asset.read', 'asset.update', 'asset.delete', 'asset.download',
+  'album.create', 'album.read', 'album.update', 'album.delete',
+  'albumAsset.create', 'albumAsset.delete',
+  'albumUser.create', 'albumUser.update', 'albumUser.delete',
+  'activity.create', 'activity.read', 'activity.delete', 'activity.statistics',
+  'user.read', 'user.update', 'userProfileImage.create', 'userProfileImage.update',
+];
 export async function ensureUtilityUser(displayName) {
   state.contributors = state.contributors || {};
   const slug = slugify(displayName);
@@ -66,11 +81,29 @@ export async function ensureUtilityUser(displayName) {
   if (!login.accessToken) throw new Error(`login failed for ${email} — will retry`);
   const keyRes = await (await fetch(`${CFG.immichUrl}/api/api-keys`,
     { method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${login.accessToken}` },
-      body: JSON.stringify({ name: 'sidecar', permissions: ['all'] }) })).json();
+      body: JSON.stringify({ name: 'sidecar', permissions: UTILITY_PERMISSIONS }) })).json();
   if (!keyRes.secret) throw new Error(`api-key mint failed for ${email} (${JSON.stringify(keyRes).slice(0,120)}) — will retry`);
-  c = { ...(c || {}), userId: user.id, key: keyRes.secret, password };
+  // The password existed only to mint that key. Roll it to a value we never keep, so these
+  // accounts stop being sign-in-able at all: from here the sidecar holds a scoped API key
+  // and nothing that can open an interactive session. A stored password would otherwise be
+  // a standing login to your server, sitting in state.db, for a bot that never needs one.
+  let passwordRetired = false;
+  try {
+    await immichJson(`/admin/users/${user.id}`,
+      { ...jsonBody({ password: crypto.randomBytes(24).toString('base64url'), shouldChangePassword: false }), method: 'PUT' });
+    passwordRetired = true;
+  } catch (e) { log(`WARNING: could not retire the login password for ${email}: ${e.message}`); }
+  if (CFG.utilityQuotaMb > 0) {
+    try {
+      await immichJson(`/admin/users/${user.id}`,
+        { ...jsonBody({ quotaSizeInBytes: CFG.utilityQuotaMb * 1024 * 1024 }), method: 'PUT' });
+    } catch (e) { log(`could not set utility quota for ${email}: ${e.message}`); }
+  }
+  c = { ...(c || {}), userId: user.id, key: keyRes.secret };
+  if (!passwordRetired) c.password = password; // keep it only if the roll failed, so a retry can resume
+  else delete c.password;
   state.contributors[slug] = c; save();
-  log(`provisioned utility user "${displayName} (via shared albums)"`);
+  log(`provisioned utility user "${displayName} (via shared albums)" (scoped key${passwordRetired ? ', no login' : ''})`);
   return c;
 }
 export async function syncAvatar(c, peerUrl, originUserId) {

--- a/src/immich/local-immich-api.md
+++ b/src/immich/local-immich-api.md
@@ -8,8 +8,27 @@ Immich REST API. Higher layers (`p2p/`, `sync/`) compose these functions.
 |---|---|
 | `client.ts` | The Immich REST client: the `fetch` wrapper (`immich`/`immichJson`), the 60s-cached users map, album/asset getters (v3 uses `search/metadata`, not embedded album assets), asset upload, metadata apply, and the 1×1 `STUB_JPEG` placeholder. |
 | `refs.ts` | The on-the-wire shape of a shared photo (`AssetRef`). `assetToRef` describes a local asset for a peer; `offerableAssets` is the full set an album may advertise (what manifests use); `shareableAssets` is that minus what a mapping has already sent (the push queue); `buildManifest` renders the offer set. |
-| `contributors.ts` | Per-contributor **utility users** (`shared-*@sidecar.local`). Foreign photos are owned by these bot users so they stay out of the local timeline while keeping attribution. Provisions/heals them, mints their API keys (toggling password-login if the instance is OAuth-only), and syncs avatars. |
+| `contributors.ts` | Per-contributor **utility users** (`shared-*@sidecar.local`). Foreign photos are owned by these bot users so they stay out of the local timeline while keeping attribution. Provisions/heals them, mints their API keys (toggling password-login if the instance is OAuth-only), and syncs avatars. See the note below — these are the sidecar's most sensitive artefacts. |
 | `materialise.ts` | Writing and un-writing **proxy assets**. `materialiseRef` pulls a ~2 KB stub (or a playable video prefix) and files it under the right contributor; `deleteProxyAsset` removes one — hard-guarded so only utility-owned proxies are ever deletable. Human photos are untouchable. |
 
 **Key idea — the hotlink model:** a materialised asset is only a placeholder stub. The
 real pixels never live here; they stream from the owner's server on demand (see `media/`).
+
+## Utility users are real accounts — keep them boring
+
+`contributors.ts` creates genuine Immich users on your server. That makes them the most
+sensitive thing the sidecar writes, and three properties keep them contained:
+
+- **Never admins.** They own stubs and curate mirror albums; nothing they do needs
+  `/admin/*`, so an escaped key cannot reach it.
+- **A scoped key, not `all`.** `UTILITY_PERMISSIONS` lists exactly the actions the sidecar
+  exercises. `all` was never admin-equivalent for a non-admin user, but it did grant every
+  action that user could take, on a credential stored in `state.db`.
+- **No retained password.** A password exists only long enough to mint the API key — Immich
+  has no way for an admin to mint one on another user's behalf — and is then rolled to a
+  value the sidecar never keeps. So these accounts cannot be signed into at all, and the
+  only credential in `state.db` is a scoped key. If the roll fails the password is kept so
+  a retry can resume, and the failure is logged.
+
+`UTILITY_QUOTA_MB` optionally caps their storage. Size it well above the shared volume:
+too low and materialisation starts failing silently.

--- a/src/media/hotlink-bytes.md
+++ b/src/media/hotlink-bytes.md
@@ -12,3 +12,22 @@ live from the owner's server** (chained through the origin for relayed photos).
 
 **Fail-open:** if the owner's server is unreachable and nothing is cached, the interceptor
 falls back to the local stub (a placeholder tile) rather than erroring — the app keeps working.
+
+## Two different callers, two different gates
+
+These are the only routes that hand out real pixels, and the local branch of
+`fetchTrueBytes` reads with the admin key — so who is asking matters more here than
+anywhere else. The two entry points authorise in completely different ways:
+
+- **`interceptor.ts` serves the household's own app**, so it authorises with the *caller's
+  own* Immich credentials: it probes `/assets/:id` with their cookie or API key and serves
+  bytes only if Immich itself would have. The sidecar never grants access Immich wouldn't.
+- **`proxy.ts` serves other households**, so it needs both halves: a valid signature
+  (`peers.callingPeer`) *and* entitlement (`p2p/entitlement.peerMayRead`). The signature
+  says which peer; entitlement says whether that peer was ever offered this asset. A
+  signature alone would mean any enrolled peer could read anything in the library it could
+  name — asset ids are not secrets, and manifests hand them out by design.
+
+**Timeouts bound the handshake, not the transfer.** A hostile peer must not hold a
+connection open forever, but a legitimate 4K original may stream for minutes — so the
+clock stops the moment response headers arrive (`fetchWithHeaderTimeout`).

--- a/src/media/interceptor.ts
+++ b/src/media/interceptor.ts
@@ -35,7 +35,8 @@ export async function serveInterceptedBytes(req, res, assetId: string, rawKind: 
     if (peer2) {
       try {
         const up = await fetch(`${peer2.url}/sidecar/api/v1/assets/${entry.o}/preview`,
-          { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) } });
+          { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) },
+            signal: AbortSignal.timeout(30000) });
         if (up.ok) {
           const buf = Buffer.from(await up.arrayBuffer());
           cacheWrite(entry.o, buf);

--- a/src/media/proxy.ts
+++ b/src/media/proxy.ts
@@ -2,11 +2,30 @@
  * media/proxy.ts — the hotlink byte path. fetchTrueBytes resolves an asset's real pixels:
  * a local file for our own photos, or a chained fetch to the owner's server for a proxy
  * (how a relayed photo streams D <- origin <- contributor). Range passes through.
+ *
+ * These are the only routes that hand out real pixels, and the local branch reads with the
+ * admin key — so a signature is necessary but nowhere near sufficient. Every handler asks
+ * p2p/entitlement whether this specific peer was ever offered this specific asset. Without
+ * that, "a valid peer" would mean "any asset in the library that it can name".
  */
 import { log } from '../config.ts';
 import { state, store } from '../state.ts';
-import { sign, verify } from '../peers.ts';
+import { sign, callingPeer } from '../peers.ts';
+import { peerMayRead } from '../p2p/entitlement.ts';
 import { immich } from '../immich/client.ts';
+
+/**
+ * Time out the handshake, not the transfer. A hostile or crawling peer must not be able to
+ * hold a connection open forever, but a legitimate 4K original may stream for minutes — so
+ * the clock stops the moment response headers arrive.
+ */
+async function fetchWithHeaderTimeout(url: string, init: RequestInit, ms = 30000) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), ms);
+  try {
+    return await fetch(url, { ...init, signal: ac.signal });
+  } finally { clearTimeout(timer); }
+}
 
 // Resolve true bytes for any local asset: local file for our own photos; for a proxy
 // (ledger entry with `o`), chain the fetch to the owner's server — how a relayed
@@ -19,9 +38,11 @@ export async function fetchTrueBytes(assetId: string, kind: 'preview' | 'origina
     if (peer) {
       const headers: Record<string, string> = { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) };
       if (range) headers.Range = range;
-      const up = await fetch(`${peer.url}/sidecar/api/v1/assets/${entry.o}/${kind}`, { headers });
-      if (up.ok) return up;
-      log(`chained ${kind} fetch failed (${up.status}) — serving local stub`);
+      try {
+        const up = await fetchWithHeaderTimeout(`${peer.url}/sidecar/api/v1/assets/${entry.o}/${kind}`, { headers });
+        if (up.ok) return up;
+        log(`chained ${kind} fetch failed (${up.status}) — serving local stub`);
+      } catch (e) { log(`chained ${kind} fetch error (${e.message}) — serving local stub`); }
     }
   }
   const local = kind === 'original' ? `/assets/${assetId}/original`
@@ -29,21 +50,24 @@ export async function fetchTrueBytes(assetId: string, kind: 'preview' | 'origina
     : `/assets/${assetId}/thumbnail?size=preview`;
   return immich(local, range ? { headers: { Range: range } } : {});
 }
+
+/** Signed by the peer AND on the list of things we offered them. Both, every time. */
+async function authorisePeerRead(req, assetId: string) {
+  const peer = callingPeer(req, assetId);
+  if (!peer) return [403, { error: 'unknown or unverified peer' }];
+  if (!(await peerMayRead(peer.pub, assetId))) {
+    log(`byte read refused: "${peer.name}" is not entitled to asset ${assetId.slice(0, 8)}`);
+    return [403, { error: 'not shared with you' }];
+  }
+  return null;
+}
+
 export async function handlePreview(req, assetId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(assetId, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown peer' }];
-  return fetchTrueBytes(assetId, 'preview'); // chains for relayed assets
+  return (await authorisePeerRead(req, assetId)) ?? fetchTrueBytes(assetId, 'preview'); // chains for relayed assets
 }
 export async function handleOriginal(req, assetId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(assetId, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown peer' }];
-  return fetchTrueBytes(assetId, 'original', req.headers.range);
+  return (await authorisePeerRead(req, assetId)) ?? fetchTrueBytes(assetId, 'original', req.headers.range);
 }
 export async function handlePlayback(req, assetId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(assetId, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown peer' }];
-  return fetchTrueBytes(assetId, 'playback', req.headers.range);
+  return (await authorisePeerRead(req, assetId)) ?? fetchTrueBytes(assetId, 'playback', req.headers.range);
 }

--- a/src/p2p/entitlement.ts
+++ b/src/p2p/entitlement.ts
@@ -1,0 +1,72 @@
+/**
+ * p2p/entitlement.ts — what a peer is allowed to READ, as distinct from who it is.
+ *
+ * A signature proves which peer is calling. It says nothing about which assets that peer
+ * may see, and the byte routes serve from the local Immich with the admin key — so
+ * identity alone would let any enrolled peer read anything in the library that it could
+ * name. Entitlement is tracked positively: every asset we advertise to a mapping (in a
+ * redeem response, a manifest, or a ref push) is recorded, and the byte routes serve only
+ * what is on that list.
+ *
+ * The list is a cache of a fact Immich already holds — "is this asset in an album mapped
+ * to that peer" — so a miss falls back to asking Immich and backfilling. That keeps
+ * installs upgraded from a version without this table working without a re-sync, and is
+ * rate-limited per mapping so a caller guessing asset ids cannot turn each miss into an
+ * album enumeration.
+ */
+import { log } from '../config.ts';
+import { state, store } from '../state.ts';
+import { getAlbumAssets } from '../immich/client.ts';
+
+const BACKFILL_EVERY_MS = 10 * 60 * 1000;
+const lastBackfill = new Map<string, number>();
+
+/** Live mappings that face this peer, either role — a member relays its own
+ *  contributions back to the origin, so member mappings grant reads too. */
+const mappingsFacing = (peerPub: string) =>
+  state.mappings.filter(m => m.peer === peerPub && !m.dead);
+
+/** Record assets we have advertised to a mapping's peer. Safe to call repeatedly. */
+export function recordOffered(mappingId: string, assetIds: (string | undefined)[]) {
+  const ids = assetIds.filter((a): a is string => !!a);
+  if (ids.length) store.offeredAdd(mappingId, ids);
+}
+
+/** Record a manifest's worth of refs (each carries the ORIGIN asset id). */
+export function recordOfferedRefs(mappingId: string, manifest: { originAsset?: string }[]) {
+  recordOffered(mappingId, manifest.map(r => r.originAsset));
+}
+
+/**
+ * May this peer read this local asset's bytes? Checks the offered index first; on a miss,
+ * re-derives entitlement from album membership (throttled) and backfills.
+ */
+export async function peerMayRead(peerPub: string, assetId: string): Promise<boolean> {
+  const mappings = mappingsFacing(peerPub);
+  if (!mappings.length) return false;
+  const ids = mappings.map(m => m.id);
+  if (store.offeredAllows(ids, assetId)) return true;
+
+  // Miss. Either this predates the offered index, or the caller is guessing. Re-derive
+  // from Immich at most once per mapping per window, then re-check.
+  const now = Date.now();
+  let refreshed = false;
+  for (const m of mappings) {
+    if (now - (lastBackfill.get(m.id) ?? 0) < BACKFILL_EVERY_MS) continue;
+    lastBackfill.set(m.id, now);
+    try {
+      const assets = await getAlbumAssets(m.albumId);
+      recordOffered(m.id, assets.map((a: { id: string }) => a.id));
+      refreshed = true;
+    } catch (e) {
+      log(`entitlement backfill failed for "${m.albumName}": ${e.message}`);
+    }
+  }
+  return refreshed ? store.offeredAllows(ids, assetId) : false;
+}
+
+/** Drop a mapping's entitlements — called wherever its ledger is dropped. */
+export function forgetOffered(mappingId: string) {
+  store.offeredRemoveMapping(mappingId);
+  lastBackfill.delete(mappingId);
+}

--- a/src/p2p/join.ts
+++ b/src/p2p/join.ts
@@ -6,20 +6,30 @@
 import crypto from 'node:crypto';
 import { CFG, SIDECAR_VERSION, log } from '../config.ts';
 import { state, save } from '../state.ts';
-import { signedFetch } from '../peers.ts';
+import { signedFetch, assertPeerUrlAllowed } from '../peers.ts';
 import { immichJson, jsonBody } from '../immich/client.ts';
 import { ensureUtilityUser, syncAvatar, slugify } from '../immich/contributors.ts';
 import { reconcileMapping } from '../sync/engine.ts';
 import { pullCanonicalComments } from '../sync/comments.ts';
 
-export async function join(shareUrl, forUserId) {
-  const m = shareUrl.trim().match(/^(https?:\/\/[^/]+)\/share\/([A-Za-z0-9_-]+)/);
+export async function join(shareUrl, forUserId, password?: string) {
+  const m = String(shareUrl ?? '').trim().match(/^(https?:\/\/[^/]+)\/share\/([A-Za-z0-9_-]+)/);
   if (!m) throw new Error('that does not look like an Immich share link');
   const [, origin, shareKey] = m;
-  const body = JSON.stringify({ shareKey, protocol: 1, version: SIDECAR_VERSION,
+  await assertPeerUrlAllowed(origin);
+  const body = JSON.stringify({ shareKey, protocol: 1, version: SIDECAR_VERSION, password,
     household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name } });
   const r = await signedFetch(`${origin}/sidecar/api/v1/invites/redeem`, body);
-  if (!r.ok) throw new Error(`redeem failed: ${r.status} ${await r.text().catch(() => '')}`);
+  if (!r.ok) {
+    // Surface the other sidecar's own message (an expired link, a wrong password) but
+    // never an arbitrary upstream body — that would make this a read primitive for
+    // whatever the URL actually pointed at.
+    const reply = await r.json().catch(() => null);
+    const clean = typeof reply?.error === 'string' ? reply.error.slice(0, 200) : null;
+    const err = new Error(clean || `the other server refused the join (${r.status})`);
+    if (reply?.passwordRequired) (err as Error & { passwordRequired?: boolean }).passwordRequired = true;
+    throw err;
+  }
   const res = await r.json();
   if (res.protocol && res.protocol > 1) log(`origin "${res.household?.name}" speaks protocol ${res.protocol} > ours (1) — update the immich-shared-albums sidecar on this server`);
   if (!state.peers.some(p => p.pub === res.household.publicKey)) {

--- a/src/p2p/protocol.ts
+++ b/src/p2p/protocol.ts
@@ -2,35 +2,84 @@
  * p2p/protocol.ts — inbound wire-protocol handlers (owner side mostly): redeem an invite,
  * accept pushed refs, answer the version/manifest/comment handshakes, and act on a nudge.
  * Each returns [statusCode, jsonBody] for the HTTP router to send.
+ *
+ * Two invariants every handler here keeps:
+ *  - A signature identifies a peer; it does not select one. Mappings are always looked up
+ *    WITH the caller's key, so a peer can only ever act on the albums it was invited to —
+ *    never on a mapping belonging to a different household.
+ *  - A nudge is a hint, never a source. It can say "something changed"; it can never say
+ *    where to fetch the change from. See handleNudge.
  */
 import crypto from 'node:crypto';
 import { CFG, SIDECAR_VERSION, log } from '../config.ts';
 import { state, save } from '../state.ts';
-import { verify, nudgePeers } from '../peers.ts';
+import { verify, nudgePeers, callingPeer, mappingFor } from '../peers.ts';
 import { getSharedLinkByKey, getAlbum, getAlbumAssets, ownerName, immichJson } from '../immich/client.ts';
 import { buildManifest } from '../immich/refs.ts';
 import { materialiseRef } from '../immich/materialise.ts';
 import { reconcileMapping } from '../sync/engine.ts';
 import { pullCanonicalComments } from '../sync/comments.ts';
+import { recordOfferedRefs } from './entitlement.ts';
+
+/** Constant-time string compare that tolerates unequal lengths. */
+function secretEquals(a: string, b: string): boolean {
+  const ba = Buffer.from(String(a ?? ''));
+  const bb = Buffer.from(String(b ?? ''));
+  if (ba.length !== bb.length) { crypto.timingSafeEqual(ba, ba); return false; }
+  return crypto.timingSafeEqual(ba, bb);
+}
 
 export async function handleRedeem(req, body) {
-  const { shareKey, household, protocol, version } = JSON.parse(body);
+  const { shareKey, household, protocol, version, password } = JSON.parse(body);
+  if (!household?.publicKey || !household?.url) return [400, { error: 'malformed household' }];
+  // Bind the request to the key being enrolled. This is trust-on-first-use: it proves the
+  // caller holds the private half of the key it is asking us to trust, so the enrolled
+  // identity cannot be forged or substituted later.
+  if (!verify(body, req.headers['x-isa-sig'] as string || '', household.publicKey)) {
+    return [403, { error: 'redeem signature does not match the household key' }];
+  }
   if (protocol && protocol > 1) log(`peer "${household?.name}" speaks protocol ${protocol} > ours (1) — update the immich-shared-albums sidecar on this server`);
   const link = await getSharedLinkByKey(shareKey);
   if (!link || link.type !== 'ALBUM') return [404, { error: 'unknown share key' }];
+  // A share link's own rules are the owner's stated intent — honour them here exactly as
+  // the Immich share page does, rather than treating the key as the whole credential.
+  if (link.expiresAt && new Date(link.expiresAt).getTime() <= Date.now()) {
+    log(`redeem refused: share link expired (${link.expiresAt})`);
+    return [403, { error: 'this share link has expired' }];
+  }
+  if (link.password) {
+    if (!password) return [401, { error: 'this album is password protected', passwordRequired: true }];
+    if (!secretEquals(link.password, password)) {
+      log(`redeem refused: wrong album password from "${household.name}"`);
+      return [403, { error: 'incorrect album password' }];
+    }
+  } else if (CFG.requireSharePassword) {
+    log('redeem refused: REQUIRE_SHARE_PASSWORD is set and this link has no password');
+    return [403, { error: 'this server only shares albums whose link has a password set' }];
+  }
   const album = await getAlbum(link.album.id);
   album.assets = await getAlbumAssets(album.id);
   if (!state.peers.some(p => p.pub === household.publicKey)) {
     state.peers.push({ pub: household.publicKey, url: household.url, name: household.name, version });
-  } else if (version) {
-    const pe = state.peers.find(p => p.pub === household.publicKey); if (pe) pe.version = version;
+  } else {
+    const pe = state.peers.find(p => p.pub === household.publicKey);
+    if (pe) { pe.url = household.url; pe.name = household.name; if (version) pe.version = version; }
   }
-  const mappingId = crypto.randomUUID();
-  state.mappings.push({ id: mappingId, role: 'owner', albumId: album.id, albumName: album.albumName,
-    peer: household.publicKey, permissions: link.allowUpload ? 'contribute' : 'view' });
+  // Idempotent: re-redeeming the same link must reuse the mapping, not mint another.
+  // Otherwise a valid link is an unbounded state-growth lever.
+  let mapping = state.mappings.find(mp => mp.role === 'owner'
+    && mp.peer === household.publicKey && mp.albumId === album.id && !mp.dead);
+  if (mapping) {
+    mapping.permissions = link.allowUpload ? 'contribute' : 'view';
+  } else {
+    mapping = { id: crypto.randomUUID(), role: 'owner', albumId: album.id, albumName: album.albumName,
+      peer: household.publicKey, permissions: link.allowUpload ? 'contribute' : 'view' };
+    state.mappings.push(mapping);
+    log(`peer joined: "${household.name}" -> album "${album.albumName}"`);
+  }
   save();
-  log(`peer joined: "${household.name}" -> album "${album.albumName}"`);
   const manifest = await buildManifest(album.assets);
+  recordOfferedRefs(mapping.id, manifest);
   // v3 album responses carry no ownerId — the share link records its creator, which is
   // exactly "the person who shared this"; majority asset owner is the empty-proof fallback
   const ownerCounts = {};
@@ -41,14 +90,13 @@ export async function handleRedeem(req, body) {
     protocol: 1, version: SIDECAR_VERSION,
     household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name },
     album: { id: album.id, name: album.albumName, permissions: link.allowUpload ? 'contribute' : 'view' },
-    albumOwner, manifest, mappingId,
+    albumOwner, manifest, mappingId: mapping.id,
   }];
 }
 export async function handleRefs(req, body, albumMappingId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(body, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown or unverified peer' }];
-  const mapping = state.mappings.find(m => m.id === albumMappingId || m.albumId === albumMappingId || m.remoteAlbumId === albumMappingId);
+  const peer = callingPeer(req, body);
+  if (!peer) return [403, { error: 'unknown or unverified peer' }];
+  const mapping = mappingFor(peer.pub, albumMappingId);
   if (!mapping) return [404, { error: 'unknown album mapping' }];
   // the share link's "allow public user to upload" switch, honoured cross-server
   if (mapping.permissions === 'view') return [403, { error: 'view-only album — uploads not allowed' }];
@@ -58,17 +106,16 @@ export async function handleRefs(req, body, albumMappingId) {
     try { if (!(await materialiseRef(mapping, peer.url, peer.name, ref))) failed.push(ref.checksum); }
     catch (e) { log(`ref materialise failed (${ref.checksum?.slice(0,10)}): ${e.message}`); failed.push(ref.checksum); }
   }
-  if (add.length > failed.length) nudgePeers(mapping.albumId, peerKey); // relay moved — tell the others
+  if (add.length > failed.length) nudgePeers(mapping.albumId, peer.pub); // relay moved — tell the others
   // partial success: sender re-offers only the failed refs next cycle
   return [200, { ok: failed.length === 0, failed }];
 }
 // Version handshake: one cheap album read instead of a full manifest scan. Members
 // compare this against their stored version and only pull the manifest on mismatch.
 export async function handleVersion(req, albumMappingId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(albumMappingId, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown or unverified peer' }];
-  const mapping = state.mappings.find(m => m.role === 'owner' && (m.id === albumMappingId || m.albumId === albumMappingId));
+  const peer = callingPeer(req, albumMappingId);
+  if (!peer) return [403, { error: 'unknown or unverified peer' }];
+  const mapping = mappingFor(peer.pub, albumMappingId, 'owner');
   if (!mapping) return [404, { error: 'unknown album mapping' }];
   const stats = await immichJson(`/activities/statistics?albumId=${mapping.albumId}`).catch(() => null);
   const album = await getAlbum(mapping.albumId);
@@ -77,17 +124,24 @@ export async function handleVersion(req, albumMappingId) {
   return [200, { version: `${album.updatedAt}|${album.assetCount ?? ''}`, comments: stats?.comments ?? null }];
 }
 export async function handleNudge(req, body, albumMappingId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(body, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown or unverified peer' }];
-  const mapping = state.mappings.find(m => m.id === albumMappingId || m.albumId === albumMappingId || m.remoteAlbumId === albumMappingId);
+  const caller = callingPeer(req, body);
+  if (!caller) return [403, { error: 'unknown or unverified peer' }];
+  const mapping = mappingFor(caller.pub, albumMappingId);
   if (!mapping || mapping.dead) return [404, { error: 'unknown album mapping' }];
+  // A nudge only means "look again"; it must never get to say where to look. Scoping the
+  // lookup to the caller is what enforces that — mappingFor already guarantees
+  // mapping.peer === caller.pub, so the origin resolved here IS the caller. Resolving it
+  // from the mapping anyway keeps that true if the lookup is ever loosened: previously the
+  // caller was passed straight to the reconciler, which let any peer point another
+  // household's album at a server of its choosing and materialise whatever it served.
+  const origin = state.peers.find(p => p.pub === mapping.peer);
+  if (!origin) return [404, { error: 'unknown album mapping' }];
   // answer fast; do the pull in the background
   (async () => {
     try {
       if (mapping.role === 'member') {
-        await reconcileMapping(mapping, peer);
-        await pullCanonicalComments(mapping, peer);
+        await reconcileMapping(mapping, origin);
+        await pullCanonicalComments(mapping, origin);
       }
     } catch (e) { log(`nudge pull error on "${mapping.albumName}": ${e.message}`); }
   })();
@@ -95,10 +149,11 @@ export async function handleNudge(req, body, albumMappingId) {
 }
 // Members re-pull this to heal refs missed at join time (e.g. preview not yet generated).
 export async function handleManifest(req, albumMappingId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(albumMappingId, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown or unverified peer' }];
-  const mapping = state.mappings.find(m => m.role === 'owner' && (m.id === albumMappingId || m.albumId === albumMappingId));
+  const peer = callingPeer(req, albumMappingId);
+  if (!peer) return [403, { error: 'unknown or unverified peer' }];
+  const mapping = mappingFor(peer.pub, albumMappingId, 'owner');
   if (!mapping) return [404, { error: 'unknown album mapping' }];
-  return [200, { manifest: await buildManifest(await getAlbumAssets(mapping.albumId)) }];
+  const manifest = await buildManifest(await getAlbumAssets(mapping.albumId));
+  recordOfferedRefs(mapping.id, manifest);
+  return [200, { manifest }];
 }

--- a/src/p2p/wire-protocol.md
+++ b/src/p2p/wire-protocol.md
@@ -8,9 +8,45 @@ folder is the **application** protocol on top of them.
 |---|---|
 | `protocol.ts` | Inbound handlers, mostly owner-side. `handleRedeem` turns a share link into a pinned peer + mapping and returns the manifest; `handleRefs` accepts pushed photos; `handleVersion`/`handleManifest` answer the cheap handshake and the full offer set; `handleNudge` reacts to "something moved, pull now". Each returns `[statusCode, jsonBody]` for the router. |
 | `join.ts` | The **member side** of joining. Redeems a share link against the origin, pins the peer, provisions the host utility user, creates the local mirror album, adds the joining user, and kicks off the first reconcile. Idempotent — re-joining just adds the user to the existing mirror. |
+| `entitlement.ts` | What a peer may **read**, as distinct from who it is. Records every asset advertised to a mapping, and answers the byte routes' "is this peer allowed this asset". |
 
 **The handshake, end to end:** the banner (`../web/banner/`) collects the joiner's own
 server address → their sidecar calls `join()` → which POSTs `handleRedeem` on the origin
 → the origin pins the peer and returns a manifest → the joiner materialises it via
 `sync/`. Every request is signed with the household ed25519 key; the origin is always the
 source of truth for the album.
+
+## What a signature does and does not prove
+
+A signature proves **which peer is calling**. On its own it says nothing about what that
+peer may touch, and treating the two as the same thing is how a peer-to-peer protocol
+turns into an open door. Three rules follow, and every inbound handler keeps them:
+
+1. **Identify with the key, never match on it.** `peers.callingPeer` requires a valid
+   signature; a bare `x-isa-key` header is not a credential, because every public key is
+   published in redeem responses.
+2. **Look mappings up *with* the caller.** `peers.mappingFor` always filters on
+   `m.peer === peerPub`. Without that term a mapping id alone selects an album, and any
+   enrolled peer can act on a relationship belonging to a different household.
+3. **A nudge is a hint, never a source.** `handleNudge` reconciles against the mapping's
+   own origin, never against whoever sent the nudge — otherwise a peer could nominate
+   itself as the source of truth for someone else's album and plant content in it.
+
+## Enrolment
+
+`handleRedeem` is the one route that runs before a relationship exists, so it is the one
+that decides who becomes a peer at all. It requires:
+
+- **A signature over the request body, verified against the key being enrolled.** This is
+  trust-on-first-use: it proves the caller holds the private half of the key it is asking
+  us to trust, so the enrolled identity cannot later be forged or substituted.
+- **The share link's own rules, honoured exactly as the Immich share page honours them** —
+  an expired link is refused, and a password-protected link requires that password
+  (constant-time compared). The origin verifies it; the joiner only relays what the user
+  typed. Set `REQUIRE_SHARE_PASSWORD=true` to refuse unprotected links outright.
+- **Idempotency.** Re-redeeming reuses the existing mapping rather than minting another,
+  so a valid link is not an unbounded state-growth lever.
+
+Known limitation: a share link is still a bearer credential. Anyone holding the link (and
+its password) can enrol. Binding enrolment to a recipient — an owner-issued single-use
+invite plus key pinning — is the intended successor to this.

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -3,7 +3,35 @@
  * ed25519 household keypair, the signed POST helper, and the fire-and-forget nudge.
  */
 import crypto from 'node:crypto';
+import dns from 'node:dns/promises';
 import { state } from './state.ts';
+import { CFG } from './config.ts';
+
+const PRIVATE_V4 = [
+  /^127\./, /^10\./, /^192\.168\./, /^169\.254\./, /^0\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./, // CGNAT, which is also the tailnet range
+];
+const isPrivateAddress = (ip: string) =>
+  PRIVATE_V4.some(re => re.test(ip)) ||
+  ip === '::1' || ip === '::' || /^f[cd]/i.test(ip) || /^fe80:/i.test(ip);
+
+/**
+ * Guard a peer-supplied URL before we fetch it. Private destinations are normal for LAN
+ * and tailnet deployments, so they are allowed unless ALLOW_PRIVATE_PEERS=false — which is
+ * what a public-facing host should set, so that a peer URL cannot be aimed at services
+ * only the container can reach.
+ */
+export async function assertPeerUrlAllowed(rawUrl: string) {
+  if (CFG.allowPrivatePeers) return;
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { throw new Error('that does not look like a valid server address'); }
+  if (u.protocol !== 'https:') throw new Error('peer servers must be reached over https');
+  let address: string;
+  try { ({ address } = await dns.lookup(u.hostname)); }
+  catch { throw new Error(`cannot resolve ${u.hostname}`); }
+  if (isPrivateAddress(address)) throw new Error(`${u.hostname} resolves to a private address`);
+}
 
 export const sign = (body) => crypto.sign(null, Buffer.from(body),
   crypto.createPrivateKey({ key: Buffer.from(state.keys.priv, 'base64url'), format: 'der', type: 'pkcs8' })).toString('base64url');
@@ -13,6 +41,28 @@ export const verify = (body, sig, pub) => {
       key: Buffer.from(pub, 'base64url'), format: 'der', type: 'spki' }), Buffer.from(sig, 'base64url'));
   } catch { return false; }
 };
+/**
+ * The peer behind an inbound request, or null. A key names a peer; only the signature
+ * proves it, so these two always travel together — never match on the key alone, since
+ * every public key is published in redeem responses.
+ */
+export function callingPeer(req, signedValue: string) {
+  const peerKey = req.headers['x-isa-key'] as string;
+  if (!peerKey) return null;
+  const peer = state.peers.find(p => p.pub === peerKey);
+  if (!peer) return null;
+  return verify(signedValue, req.headers['x-isa-sig'] as string || '', peerKey) ? peer : null;
+}
+/**
+ * Find one of THIS peer's mappings. The `m.peer === peerPub` term is the whole point:
+ * without it a mapping id alone selects an album, and any enrolled peer can act on a
+ * relationship that belongs to a different household.
+ */
+export function mappingFor(peerPub: string, ref: string, role?: 'owner' | 'member') {
+  return state.mappings.find(m => m.peer === peerPub
+    && (!role || m.role === role)
+    && (m.id === ref || m.albumId === ref || m.remoteAlbumId === ref));
+}
 export const signedFetch = (url, body) => fetch(url, {
   signal: AbortSignal.timeout(30000),
   method: 'POST',

--- a/src/store.ts
+++ b/src/store.ts
@@ -25,7 +25,9 @@ export type Mapping = {
 };
 
 export type Peer = { pub: string; url: string; name: string; version?: string };
-export type Contributor = { userId: string; key: string; password: string; avatarDone?: boolean };
+// `password` is transient: it exists only while the account is being provisioned, and is
+// rolled to an unheld value once the API key is minted (see immich/contributors.ts).
+export type Contributor = { userId: string; key: string; password?: string; avatarDone?: boolean };
 
 export type Collections = {
   keys: { pub: string; priv: string } | null;
@@ -51,6 +53,15 @@ export class Store {
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, size INTEGER NOT NULL, lastUsed INTEGER NOT NULL);
       CREATE INDEX IF NOT EXISTS cache_lru ON cache (lastUsed);
+    `);
+    // What we have ADVERTISED to each mapping's peer. A signature proves which peer is
+    // calling; this table is what decides whether that peer may read a given asset's
+    // bytes. Without it the byte routes authorise identity but not entitlement, and any
+    // peer that learns an asset id can read anything in the library.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS offered (m TEXT NOT NULL, a TEXT NOT NULL);
+      CREATE UNIQUE INDEX IF NOT EXISTS offered_ma ON offered (m, a);
+      CREATE INDEX IF NOT EXISTS offered_a ON offered (a);
     `);
     this.migrateLegacyJson(dataDir);
     this.state = {
@@ -135,6 +146,30 @@ export class Store {
   }
   seenRemoveEntry(mappingId: string, checksum: string) {
     this.db.prepare('DELETE FROM seen WHERE m = ? AND c = ?').run(mappingId, checksum);
+  }
+
+  // ---- offered index: which assets each mapping's peer is entitled to read ----
+  offeredAdd(mappingId: string, assetIds: string[]) {
+    if (!assetIds.length) return;
+    const ins = this.db.prepare('INSERT OR IGNORE INTO offered (m, a) VALUES (?, ?)');
+    this.db.exec('BEGIN');
+    try {
+      for (const a of assetIds) ins.run(mappingId, a);
+      this.db.exec('COMMIT');
+    } catch (e) {
+      this.db.exec('ROLLBACK');
+      throw e;
+    }
+  }
+  /** Has any of these mappings advertised this asset? Empty list => never. */
+  offeredAllows(mappingIds: string[], assetId: string): boolean {
+    if (!mappingIds.length) return false;
+    const holes = mappingIds.map(() => '?').join(',');
+    return !!this.db.prepare(`SELECT 1 FROM offered WHERE a = ? AND m IN (${holes})`)
+      .get(assetId, ...mappingIds);
+  }
+  offeredRemoveMapping(mappingId: string) {
+    this.db.prepare('DELETE FROM offered WHERE m = ?').run(mappingId);
   }
 
   seenActHas(tag: string): boolean {

--- a/src/sync/comments.ts
+++ b/src/sync/comments.ts
@@ -5,7 +5,7 @@
  */
 import { CFG, log, UTILITY_SUFFIX } from '../config.ts';
 import { state, save, seenActHas, seenActAdd } from '../state.ts';
-import { sign, verify, signedFetch, nudgePeers } from '../peers.ts';
+import { sign, signedFetch, nudgePeers, callingPeer, mappingFor } from '../peers.ts';
 import { immichJson, jsonBody, usersById } from '../immich/client.ts';
 import { ensureContributor } from '../immich/contributors.ts';
 
@@ -36,23 +36,21 @@ export async function materialiseComments(mapping, peerUrl, peerName, comments) 
   return ids;
 }
 export async function handleActivity(req, body, albumMappingId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(body, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown peer' }];
-  const mapping = state.mappings.find(m => m.id === albumMappingId || m.albumId === albumMappingId || m.remoteAlbumId === albumMappingId);
+  const peer = callingPeer(req, body);
+  if (!peer) return [403, { error: 'unknown or unverified peer' }];
+  const mapping = mappingFor(peer.pub, albumMappingId);
   if (!mapping) return [404, { error: 'unknown album mapping' }];
   const { comments = [] } = JSON.parse(body);
   const ids = await materialiseComments(mapping, peer.url, peer.name, comments);
-  if (Object.keys(ids).length) nudgePeers(mapping.albumId, peerKey); // new messages — tell the others
+  if (Object.keys(ids).length) nudgePeers(mapping.albumId, peer.pub); // new messages — tell the others
   return [200, { ok: true, ids }];
 }
 // Canonical comment list for an album — the origin is the source of truth for messages.
 // Utility-authored entries resolve back to the true contributor's name.
 export async function handleComments(req, albumMappingId) {
-  const peerKey = req.headers['x-isa-key'];
-  const peer = state.peers.find(p => p.pub === peerKey);
-  if (!peer || !verify(albumMappingId, req.headers['x-isa-sig'] || '', peerKey)) return [403, { error: 'unknown or unverified peer' }];
-  const mapping = state.mappings.find(m => m.role === 'owner' && (m.id === albumMappingId || m.albumId === albumMappingId));
+  const peer = callingPeer(req, albumMappingId);
+  if (!peer) return [403, { error: 'unknown or unverified peer' }];
+  const mapping = mappingFor(peer.pub, albumMappingId, 'owner');
   if (!mapping) return [404, { error: 'unknown album mapping' }];
   const users = await usersById();
   const comments = (await getComments(mapping.albumId)).filter(a => a.comment).map(a => ({

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -11,6 +11,7 @@ import { sign, signedFetch } from '../peers.ts';
 import { getAlbum, getAlbumAssets, usersById, immichJson } from '../immich/client.ts';
 import { shareableAssets, assetToRef } from '../immich/refs.ts';
 import { materialiseRef, deleteProxyAsset } from '../immich/materialise.ts';
+import { recordOffered, forgetOffered } from '../p2p/entitlement.ts';
 
 // Leave & purge: the reverse of joining. Removes every stub this album materialised
 // (utility-owner-guarded), the mirror album, the mapping and its ledger — a join is
@@ -28,6 +29,7 @@ export async function leaveAlbum(mappingId: string) {
     catch (e) { log(`mirror album delete failed: ${e.message}`); }
   }
   store.seenRemoveMapping(mapping.id);
+  forgetOffered(mapping.id);
   state.mappings = state.mappings.filter(mp => mp.id !== mapping.id);
   save();
   log(`left "${mapping.albumName}" — ${removed} stub(s) purged`);
@@ -67,6 +69,8 @@ export async function watchOnce() {
         const failed = new Set((await r.json().catch(() => ({}))).failed || []);
         const landed = fresh.filter(a => !failed.has(wireChecksum(a)));
         landed.forEach(a => seenAdd(mapping.id, wireChecksum(a), a.id));
+        // pushed to this peer => this peer may read their bytes (see p2p/entitlement)
+        recordOffered(mapping.id, landed.map(a => a.id));
         if (!failed.size) { mapping.localVersion = album.updatedAt; save(); }
         log(`pushed ${landed.length}/${fresh.length} ref(s) to "${peer.name}"${failed.size ? ` (${failed.size} deferred)` : ''}`);
       } else log(`ref push failed: ${r.status}`);

--- a/src/web/auth.ts
+++ b/src/web/auth.ts
@@ -1,0 +1,55 @@
+/**
+ * web/auth.ts — who is calling a human-facing sidecar route.
+ *
+ * The sidecar has no accounts of its own and must never invent any: the only identity
+ * that means anything here is an Immich one. So we forward whatever credentials the
+ * caller already has — the session cookie a browser holds after signing in, or an API
+ * key — to Immich's own /users/me and let Immich answer. That makes these routes exactly
+ * as reachable as the Immich they sit next to: safe to publish, because being on the
+ * network is not being signed in.
+ *
+ * This mirrors what media/interceptor.ts already does for byte requests, and replaces the
+ * accept page's client-side whoami, which the server previously trusted on faith.
+ */
+import { CFG } from '../config.ts';
+
+export type Caller = { id: string; name: string; isAdmin: boolean };
+
+const CRED_HEADERS = ['cookie', 'x-api-key', 'authorization'] as const;
+
+/** Resolve the caller against Immich, or null if they are not signed in. */
+export async function callerIdentity(req): Promise<Caller | null> {
+  const headers: Record<string, string> = {};
+  for (const h of CRED_HEADERS) if (req.headers[h]) headers[h] = req.headers[h] as string;
+  if (!Object.keys(headers).length) return null;
+  try {
+    const r = await fetch(`${CFG.immichUrl}/api/users/me`, {
+      headers: { ...headers, Accept: 'application/json' },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!r.ok) return null;
+    const u = await r.json();
+    return u?.id ? { id: u.id, name: u.name, isAdmin: !!u.isAdmin } : null;
+  } catch { return null; }
+}
+
+/** 401 body that tells a browser where to go to fix it. */
+export const signInRequired = (what: string) => ({
+  error: `sign in to ${CFG.name} to ${what}`,
+  signInUrl: '/auth/login',
+  needsAuth: true,
+});
+
+/** A minimal page for HTML routes reached without a session. */
+export const SIGN_IN_PAGE = (what: string) => `<!doctype html><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign in — ${CFG.name}</title>
+<style>
+ body{margin:0;font-family:Inter,-apple-system,sans-serif;background:#101216;color:#e5e7eb;display:grid;place-items:center;min-height:100vh}
+ .c{width:min(400px,92vw);background:#1f2229;border:1px solid rgba(255,255,255,.08);border-radius:18px;padding:28px;text-align:center}
+ h1{font-size:18px;margin:0 0 8px} p{color:#9aa0a6;font-size:14px;line-height:1.55;margin:0 0 20px}
+ a{display:inline-block;background:#4250af;color:#fff;text-decoration:none;font-weight:600;padding:11px 26px;border-radius:999px;font-size:14px}
+</style>
+<div class="c"><h1>Sign in to continue</h1>
+<p>You need to be signed in to ${CFG.name} to ${what}.</p>
+<a href="/auth/login">Sign in to Immich</a></div>`;

--- a/src/web/http-router.md
+++ b/src/web/http-router.md
@@ -7,8 +7,27 @@ The single process's one HTTP entry point and the HTML it serves.
 | `server.ts` | The router: a thin dispatch table mapping each path to a handler. Exports `server`; `index.ts` calls `.listen()`. |
 | `passthrough.ts` | The transparent fall-through proxy to Immich for anything that isn't a sidecar route (share pages, SPA bundles, `/api`), with join-banner injection on `/share/*` HTML. Websocket upgrades are refused cleanly. |
 | `banner.ts` | Loads `banner/banner.js` once — it's both served at `/sidecar/banner.js` and injected by `passthrough.ts`. |
-| `pages.ts` | The two HTML surfaces: the admin **PANEL** (join box + status) and the **ACCEPT_PAGE** that turns a share link into a join (detects sign-in, then deeplinks into the app once the album has filled). |
+| `pages.ts` | The two HTML surfaces: the admin **PANEL** (join box + status) and the **ACCEPT_PAGE** that turns a share link into a join (detects sign-in, prompts for an album password when the origin asks, then deeplinks into the app once the album has filled). |
+| `auth.ts` | Who is calling a human-facing route. Forwards the caller's own Immich credentials (session cookie or API key) to Immich's `/users/me` and believes the answer. The sidecar has no accounts of its own and must never invent any. |
 | `banner/` | `banner.js` — injected into an origin's `/share/*` page so a visitor can type their own server address and join. `preview.html` is a local harness for iterating on it. |
+
+## Who may call what
+
+Every route here can be published to the internet, so reachability is never permission.
+There are three tiers, and each is enforced server-side:
+
+| Tier | Routes | Gate |
+|---|---|---|
+| Public | `/sidecar/health`, `/sidecar/banner.js`, `/sidecar/accept` | none — liveness, a script, and a static page. `health` returns `{ok:true}` and nothing else, because the banner probes it cross-origin to discover a sidecar. |
+| Signed-in human | `/sidecar/join`, `/sidecar/leave`, the panel | `auth.ts` against the caller's Immich session. `join` takes the account from the **session**, not the request body; naming a different user requires admin. `leave` and the panel require admin. |
+| Peer | everything under `/sidecar/api/v1/*` | ed25519 signature (`peers.callingPeer`) **and**, for byte routes, entitlement (`p2p/entitlement`). |
+
+The accept page's client-side `whoami` is UX only — it tells someone to sign in before
+they fill a form. The server never trusts it.
+
+**Two ordering rules in `server.ts`:** route before reading a body (only the sidecar's own
+JSON routes are buffered, under `MAX_BODY_KB`; passthrough traffic including photo uploads
+streams through), and authorise before doing work.
 
 **On the byte interceptors:** in production a reverse proxy (Caddy) usually routes the byte
 paths straight to the sidecar; when the sidecar fronts Immich directly (demo/simple setups)

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -1,6 +1,11 @@
 /**
  * web/pages.ts — the two HTML surfaces the sidecar serves: the admin PANEL and the
  * signed-out/signed-in ACCEPT_PAGE that turns a share link into a join.
+ *
+ * Both talk to /sidecar/join, which authenticates the caller's Immich session server-side
+ * (web/auth.ts). The client-side checks here are for UX only — telling someone they need
+ * to sign in before they fill a form, and asking for an album password when the origin
+ * says one is required. Nothing here is a security control.
  */
 import { CFG } from '../config.ts';
 import { state } from '../state.ts';
@@ -23,15 +28,22 @@ export const PANEL = () => `<!doctype html><meta charset="utf-8"><meta name="vie
  <div class="card"><b style="font-size:14px">Join an album</b>
   <p class="muted" style="font-size:13px">Paste a share link from another household.</p>
   <form onsubmit="j(event)"><input id="u" placeholder="https://their-server/share/…"><button>Join</button></form>
+  <input id="pw" type="password" placeholder="Album password" style="display:none;margin-top:8px;width:100%">
   <div id="msg"></div></div>
  <div class="card"><b style="font-size:14px">Shared albums</b>
   ${state.mappings.map(m => `<div class="item"><span>${m.albumName}</span><span class="muted">${m.role} · ${(state.peers.find(p => p.pub === m.peer) || {}).name || ''}</span></div>`).join('') || '<p class="muted" style="font-size:13px">None yet.</p>'}</div>
  <div class="card"><b style="font-size:14px">Connected households</b>
   ${state.peers.map(p => `<div class="item"><span>${p.name}</span><span class="muted">${p.url}${p.version ? ` · v${p.version}` : ''}</span></div>`).join('') || '<p class="muted" style="font-size:13px">None yet.</p>'}</div>
 </main>
-<script>async function j(e){e.preventDefault();const el=document.getElementById('msg');el.textContent='Joining…';
- const r=await fetch('join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({url:document.getElementById('u').value})});
+<script>async function j(e){e.preventDefault();
+ const el=document.getElementById('msg'),pw=document.getElementById('pw');el.textContent='Joining…';
+ const payload={url:document.getElementById('u').value};
+ if(pw.style.display!=='none'&&pw.value)payload.password=pw.value;
+ const r=await fetch('join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
  const d=await r.json().catch(()=>({error:'failed'}));
+ if(d&&d.needsAuth){location.href=d.signInUrl||'/auth/login';return}
+ if(d&&d.passwordRequired){pw.style.display='block';pw.focus();
+  el.textContent='This album is password protected — enter the same password you would use to view it.';return}
  el.textContent=r.ok?('Joined "'+d.album+'" from '+d.from+' — '+d.photos+' photos syncing. It will appear in your app shortly.'):('Error: '+(d.error||r.status));
  if(r.ok)setTimeout(()=>location.reload(),2500)}</script>`;
 export const ACCEPT_PAGE = () => `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -58,6 +70,8 @@ export const ACCEPT_PAGE = () => `<!doctype html><meta charset="utf-8"><meta nam
 <div class="card"><div class="logo">🔗</div><h1 id="t">Join shared album?</h1>
 <p id="d">This will add the album to your account on <b>${CFG.name}</b>. Photos stay on their owners' servers.</p>
 <div id="who"></div>
+<input id="pw" type="password" placeholder="Album password" autocomplete="current-password"
+ style="display:none;width:100%;box-sizing:border-box;font:inherit;font-size:14px;padding:11px 16px;border-radius:999px;border:1px solid rgba(0,0,0,.15);margin:0 0 14px;text-align:center">
 <button id="go" disabled>Accept &amp; join</button><div id="out"></div></div>
 <script>
 const frag=(()=>{
@@ -71,7 +85,7 @@ let ME=null,POLL=null;
 function whoami(){return fetch('/api/users/me',{credentials:'include'}).then(r=>r.ok?r.json():null).then(u=>{
  if(u&&u.id){ME=u;clearInterval(POLL);document.getElementById('go').disabled=false;
    document.getElementById('who').textContent='Joining as '+u.name+' — the album is added only to your account.';}
- else if(!ME){document.getElementById('who').innerHTML='<a href="/auth/login" target="_blank">Sign in to your Immich</a> to join — this page will notice once you are signed in.';}
+ else if(!ME){document.getElementById('who').innerHTML='<a href="/auth/login">Sign in to your Immich</a> to join — this page will notice once you are signed in.';}
  return u;}).catch(()=>null);}
 whoami().then(u=>{if(!u)POLL=setInterval(whoami,2500);});
 document.getElementById('go').onclick=async()=>{
@@ -81,8 +95,19 @@ document.getElementById('go').onclick=async()=>{
  go.innerHTML='<span class="spin"></span>Joining — syncing photos…';
  const out=document.getElementById('out');out.textContent='';
  const scheme=frag.scheme||'https';
- const r=await fetch('/sidecar/join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({url:scheme+'://'+frag.host+'/share/'+frag.key,forUserId:ME.id})});
+ const pw=document.getElementById('pw');
+ const body={url:scheme+'://'+frag.host+'/share/'+frag.key,forUserId:ME.id};
+ if(pw.style.display!=='none'&&pw.value)body.password=pw.value;
+ const r=await fetch('/sidecar/join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
  const d=await r.json().catch(()=>({error:'failed'}));
+ var reset=function(){go.disabled=false;go.classList.remove('busy');go.textContent='Accept & join';};
+ // the session went away between page load and click — send them to sign in and back
+ if(d&&d.needsAuth){location.href=(d.signInUrl||'/auth/login');return}
+ // same password the album's own share page asks for; the origin verifies it, not us
+ if(d&&d.passwordRequired){
+   pw.style.display='block';pw.focus();reset();
+   out.innerHTML='This album is password protected.<br><span style="font-size:12px">Enter the same password you would use to view it.</span>';
+   return}
  if(r.ok){
    // album-specific deeplink: the app registers my.immich.app/albums/<id> (the bare
    // list path is NOT registered and falls through to the web fallback)
@@ -101,6 +126,6 @@ document.getElementById('go').onclick=async()=>{
        if(n>=d.photos||Date.now()-t0>90000){clearInterval(iv);ready();}
      }).catch(function(){if(Date.now()-t0>90000){clearInterval(iv);ready();}});
    },1500);}
- } else { out.textContent='Error: '+(d.error||r.status); go.disabled=false; go.classList.remove('busy'); go.textContent='Accept & join'; }
+ } else { out.textContent='Error: '+(d.error||r.status); reset(); }
 };
 </script>`;

--- a/src/web/passthrough.ts
+++ b/src/web/passthrough.ts
@@ -4,33 +4,44 @@
  * In production a reverse proxy usually handles this directly; this keeps the demo/simple
  * single-front setup fully working. Websocket upgrades are refused cleanly — a fetch()-based
  * proxy can't carry them; live web updates need the Immich port (or a real reverse proxy).
+ *
+ * Both directions stream. Photo uploads reach Immich through here in the single-front
+ * setup, and buffering them would put every upload in the sidecar's heap — the opposite of
+ * Pi-friendly, and a free memory-exhaustion lever for anyone who can reach the port. Only
+ * /share HTML is buffered, because injecting the banner means rewriting the document.
  */
+import { Readable } from 'node:stream';
 import { CFG } from '../config.ts';
 import { BANNER_JS } from './banner.ts';
 
-export async function proxyToImmich(req, res, chunks, pathname: string): Promise<void> {
+export async function proxyToImmich(req, res, pathname: string): Promise<void> {
   if (req.headers.upgrade) { res.writeHead(426, { 'Content-Type': 'text/plain' }); res.end('websockets are not proxied here — connect to Immich directly'); return; }
   const headers: Record<string, string> = {};
   for (const [k, v] of Object.entries(req.headers)) {
     if (typeof v === 'string') headers[k] = v; else if (Array.isArray(v)) headers[k] = v.join(', ');
   }
-  delete headers.host; delete headers['content-length'];
+  delete headers.host;
+  const hasBody = !['GET', 'HEAD'].includes(req.method);
   const up = await fetch(`${CFG.immichUrl}${req.url}`, {
-    method: req.method, headers,
-    body: ['GET', 'HEAD'].includes(req.method) ? undefined : Buffer.concat(chunks),
+    method: req.method,
+    headers,
+    body: hasBody ? Readable.toWeb(req) : undefined,
+    // required by undici whenever a stream is used as a request body
+    ...(hasBody ? { duplex: 'half' } : {}),
     redirect: 'manual',
-  });
+  } as RequestInit);
   const outHeaders = {};
   for (const [k, v] of up.headers) if (!['content-encoding', 'transfer-encoding', 'content-length'].includes(k)) outHeaders[k] = v;
   const setCookie = up.headers.getSetCookie?.() || [];
   if (setCookie.length) outHeaders['set-cookie'] = setCookie;
   const ct = up.headers.get('content-type') || '';
-  const buf = Buffer.from(await up.arrayBuffer());
   if (req.method === 'GET' && pathname.startsWith('/share/') && ct.includes('text/html') && BANNER_JS) {
-    let html = buf.toString();
+    let html = Buffer.from(await up.arrayBuffer()).toString();
     html = html.includes('</body>') ? html.replace('</body>', '<script src="/sidecar/banner.js" defer></script></body>')
                                     : html + '<script src="/sidecar/banner.js" defer></script>';
     res.writeHead(up.status, outHeaders); res.end(html); return;
   }
-  res.writeHead(up.status, outHeaders); res.end(buf);
+  res.writeHead(up.status, outHeaders);
+  if (!up.body) { res.end(); return; }
+  Readable.fromWeb(up.body).pipe(res);
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -2,33 +2,70 @@
  * web/server.ts — the single HTTP entry point. Routes sidecar protocol endpoints, the
  * panel/accept pages, the hotlink byte interceptors, and a transparent fall-through proxy
  * to Immich (banner-injected on /share pages). Exports the server; index.ts starts it.
+ *
+ * Two rules hold everywhere below, because every route here may be published to the
+ * internet:
+ *  - Route BEFORE reading a body. Only the sidecar's own JSON routes are buffered, under
+ *    a hard cap; passthrough traffic (which includes photo uploads) streams straight
+ *    through. Buffering first would let any caller size our memory.
+ *  - Human routes authenticate against the caller's own Immich session (web/auth.ts);
+ *    peer routes authenticate by signature AND check entitlement (p2p/entitlement.ts).
+ *    Being able to reach a route is never permission to use it.
  */
 import http from 'node:http';
 import { Readable } from 'node:stream';
 import { CFG, log } from '../config.ts';
 import { state } from '../state.ts';
 import { immich } from '../immich/client.ts';
+import { verify } from '../peers.ts';
 import { handlePreview, handleOriginal, handlePlayback } from '../media/proxy.ts';
 import { serveInterceptedBytes } from '../media/interceptor.ts';
 import { PANEL, ACCEPT_PAGE } from './pages.ts';
 import { BANNER_JS } from './banner.ts';
 import { proxyToImmich } from './passthrough.ts';
+import { callerIdentity, signInRequired, SIGN_IN_PAGE } from './auth.ts';
 import { handleRedeem, handleRefs, handleVersion, handleNudge, handleManifest } from '../p2p/protocol.ts';
 import { join } from '../p2p/join.ts';
 import { leaveAlbum } from '../sync/engine.ts';
 import { handleActivity, handleComments } from '../sync/comments.ts';
 
-export const server = http.createServer(async (req, res) => {
+/**
+ * Read a JSON-route body under a hard cap, or null if it is too big.
+ *
+ * Oversize input is DRAINED rather than buffered: memory stays O(1), which is the point,
+ * while the socket survives long enough for the caller to actually receive the 413.
+ * Destroying the request instead resets the connection, and the client sees a network
+ * error rather than an answer. Cutting the upload off at the wire is the reverse proxy's
+ * job — see the `request_body` cap in deploy/Caddyfile.snippet.
+ */
+async function readCappedBody(req): Promise<string | null> {
+  const max = CFG.maxBodyKb * 1024;
+  if (Number(req.headers['content-length'] || 0) > max) { req.resume(); return null; }
   const chunks = [];
-  for await (const c of req) chunks.push(c);
-  const body = Buffer.concat(chunks).toString();
+  let size = 0;
+  for await (const c of req) {
+    size += c.length;
+    if (size > max) { req.resume(); return null; }
+    chunks.push(c);
+  }
+  return Buffer.concat(chunks).toString();
+}
+
+export const server = http.createServer(async (req, res) => {
   const send = (code, obj) => { res.writeHead(code, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(obj)); };
   try {
     const u = new URL(req.url, 'http://x');
     let m;
+    // Peer-facing avatar read. Signed like every other peer route — a bare public key is
+    // not a credential, it is published in every redeem response.
     if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/users\/([^/]+)\/avatar$/))) {
-      const peerKey = req.headers['x-isa-key'];
-      if (!state.peers.some(pp => pp.pub === peerKey)) return send(403, { error: 'unknown peer' });
+      if (req.method !== 'GET') return send(405, { error: 'method not allowed' });
+      const peerKey = req.headers['x-isa-key'] as string;
+      const peer = state.peers.find(pp => pp.pub === peerKey);
+      const related = peer && state.mappings.some(mp => mp.peer === peerKey && !mp.dead);
+      if (!peer || !related || !verify(m[1], req.headers['x-isa-sig'] as string || '', peerKey)) {
+        return send(403, { error: 'unknown or unverified peer' });
+      }
       try {
         const av = await immich(`/users/${m[1]}/profile-image`);
         res.writeHead(200, { 'Content-Type': av.headers.get('content-type') || 'image/jpeg' });
@@ -46,16 +83,42 @@ export const server = http.createServer(async (req, res) => {
     const assetHit = u.pathname.match(/^\/api\/assets\/([^/]+)\/(thumbnail|original|video\/playback)$/);
     if (assetHit && req.method === 'GET' && await serveInterceptedBytes(req, res, assetHit[1], assetHit[2])) return;
     // Everything that isn't a sidecar route -> transparent proxy to Immich (banner-injected
-    // on /share pages). See web/passthrough.
-    if (!u.pathname.startsWith('/sidecar')) return proxyToImmich(req, res, chunks, u.pathname);
+    // on /share pages). Streams both ways: uploads must not be buffered here.
+    if (!u.pathname.startsWith('/sidecar')) return proxyToImmich(req, res, u.pathname);
+
+    // ---- the sidecar's own routes: cap the body, then authorise ----
+    const body = await readCappedBody(req);
+    if (body === null) return send(413, { error: `request body exceeds ${CFG.maxBodyKb}KB` });
+
     if (u.pathname === '/sidecar/' || u.pathname === '/sidecar') {
+      const caller = await callerIdentity(req);
+      if (!caller?.isAdmin) {
+        res.writeHead(caller ? 403 : 401, { 'Content-Type': 'text/html' });
+        return res.end(SIGN_IN_PAGE('manage shared albums'));
+      }
       res.writeHead(200, { 'Content-Type': 'text/html' }); return res.end(PANEL());
     }
     if (u.pathname === '/sidecar/join' && req.method === 'POST') {
-      try { const b = JSON.parse(body); return send(200, await join(b.url, b.forUserId)); }
-      catch (e) { return send(400, { error: e.message }); }
+      // The account being joined is the SIGNED-IN one. The request body may name a
+      // different user only if the caller is an admin acting on their behalf.
+      const caller = await callerIdentity(req);
+      if (!caller) return send(401, signInRequired('join a shared album'));
+      try {
+        const b = JSON.parse(body);
+        const forUserId = b.forUserId || caller.id;
+        if (forUserId !== caller.id && !caller.isAdmin) {
+          return send(403, { error: 'you can only join an album for your own account' });
+        }
+        return send(200, await join(b.url, forUserId, b.password));
+      } catch (e) {
+        return send(e.passwordRequired ? 401 : 400,
+          e.passwordRequired ? { error: e.message, passwordRequired: true } : { error: e.message });
+      }
     }
     if (u.pathname === '/sidecar/leave' && req.method === 'POST') {
+      const caller = await callerIdentity(req);
+      if (!caller) return send(401, signInRequired('leave a shared album'));
+      if (!caller.isAdmin) return send(403, { error: 'only an admin can remove a shared album' });
       try { const b = JSON.parse(body); return send(200, await leaveAlbum(b.mappingId)); }
       catch (e) { return send(400, { error: e.message }); }
     }
@@ -101,9 +164,11 @@ export const server = http.createServer(async (req, res) => {
       res.writeHead(200, { 'Content-Type': out.headers.get('content-type') || 'image/jpeg' });
       return res.end(Buffer.from(await out.arrayBuffer()));
     }
+    // Liveness only. The join banner probes this cross-origin to discover a sidecar, so
+    // it stays open — which is exactly why it must not name the household or count peers.
     if (u.pathname === '/sidecar/health') {
       res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
-      return res.end(JSON.stringify({ ok: true, household: CFG.name, peers: state.peers.length }));
+      return res.end(JSON.stringify({ ok: true }));
     }
     send(404, { error: 'not found' });
   } catch (e) { log('http error:', e.message); send(500, { error: e.message }); }


### PR DESCRIPTION
Makes the sidecar safe to expose on a public domain rather than relying on a private
network. Previously the perimeter was carrying authorisation the application layer did not,
so the same deployment behind Tailscale and behind a domain were very different risk
propositions. Now every route assumes it is reachable from the internet.

## What changed

**Human-facing routes authenticate against the caller's own Immich.** The sidecar has no
accounts of its own and should never invent any, so `web/auth.ts` forwards whatever
credentials the caller already holds — a session cookie or an API key — to Immich's
`/users/me` and believes the answer. `/sidecar/join` now takes the account being joined from
the signed-in session instead of the request body; the panel and `/sidecar/leave` require an
admin session. The accept page's client-side `whoami` is now UX only.

Deliberately *not* solved with source-IP restrictions: someone's accept page calls their own
server's join endpoint, so that approach breaks joining from mobile data.

**Peer-facing routes separate identity from entitlement.** A signature proves which peer is
calling and nothing more. Three invariants now hold across every inbound handler:

- identity comes from `peers.callingPeer` (a bare `x-isa-key` is not a credential — public
  keys ship in every redeem response)
- mappings are always looked up *together with* the calling peer, so a peer cannot act on a
  relationship belonging to another household
- a nudge is a hint, never a source: it can say "look again", not where to look

**Byte routes check entitlement.** These are the only routes that hand out real pixels, and
the local branch reads with the admin key, so `p2p/entitlement.ts` records everything
advertised to each mapping and the byte routes serve only what is on that list. A throttled
album-membership fallback means existing installs heal without a re-sync.

**Enrolment is gated.** Redeem verifies a signature over its body against the key being
enrolled (trust-on-first-use), honours the share link's own password and expiry the way the
Immich share page does, and is idempotent so a link cannot mint unlimited mappings.
`REQUIRE_SHARE_PASSWORD=true` refuses links with no password; `ALLOW_PRIVATE_PEERS=false`
restricts peer addresses to public https.

**Utility accounts got boring.** They are non-admin, so their keys were never
admin-equivalent, but they were being given `permissions: ['all']` *and* a retained password
— an interactive login for a bot that needs none. Keys are now scoped to the permissions the
sidecar actually exercises, and the password is rolled to a value that is never kept once the
key is minted.

**The router routes before reading a body.** Only the sidecar's own JSON routes buffer, under
`MAX_BODY_KB`; passthrough traffic including photo uploads streams both ways instead of
sitting in the heap.

## Compatibility

Older peers continue to sync, so this is not a sync-contract break. Local behaviour does
change: anything calling `/sidecar/join` or the panel must now present Immich credentials.

## Verification

84 e2e checks green against the mock rig (households B, C and D), up from 66 — 18 new
security regressions covering the unauthenticated surface, peer entitlement, the password and
expiry gates, and utility-account credentials. The entitlement stage includes a control check
that an entitled peer can still read what it was offered, so it cannot pass by simply
blocking everything. `npx tsc --noEmit` clean. Docs updated alongside the code per AGENTS.md.

## Still open

A share link remains a bearer credential — whoever holds it (and its password) can introduce
their server. Binding enrolment to a recipient, via an owner-issued single-use invite plus
key pinning, is the intended follow-up. Request-rate limiting stays a reverse-proxy concern
by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)