### PR TITLE
ci: stop the release job racing release-please to create the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,19 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:latest
 
-      - name: Create GitHub Release
+      # release-please owns the tag, the changelog and the GitHub release. This job runs
+      # on the tag it just pushed, so the release normally exists by the time we get here
+      # — creating it again is a 422, which is what failed v0.1.0, v0.4.0 and v0.5.0.
+      # Only create one if release-please didn't (it occasionally loses to a 503), and
+      # let it write the notes: it generates them from the changelog entry it authored.
+      - name: Ensure a GitHub Release exists for this tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --notes "$(sed -n "/^## ${{ github.ref_name }}/,/^## v/p" CHANGELOG.md | sed '$d')" \
-            || gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --generate-notes
+          TAG="${{ github.ref_name }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists (created by release-please) — nothing to do."
+          else
+            echo "No release found for $TAG — creating one as a fallback."
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi


### PR DESCRIPTION
The `release` job failed on the v0.5.0 tag. The release itself shipped fine — the
multi-arch image is on ghcr as `v0.5.0`/`latest`, the e2e suite passed, and the GitHub
release exists with correct notes. The only failure was a redundant create.

## Two bugs

**The race.** `release-please` creates the tag *and* the GitHub release. Pushing that tag
triggers this job, which created the release again → HTTP 422. It has failed v0.1.0,
v0.4.0 and v0.5.0; the others passed only by getting there first.

**The notes extraction had silently died.** The step grepped `^## v0.5.0`, which matched
the old hand-written changelog headings (`## v0.4.1 — 2026-08-17`). release-please writes
`## [0.5.0](…compare…) (date)`, and v0.5.0 is the first entry it generated — so the pattern
now matches nothing, and any release this job created from here would carry empty notes
with a raw commit list.

## Fix

Check whether the release exists and create one only if release-please didn't. Notes come
from release-please in every normal case, generated from the changelog entry it authored,
so the broken sed is deleted rather than patched.

Verified both branches of the condition against the live repo: `v0.5.0` skips, a
nonexistent tag takes the create path.

`ci:` so release-please doesn't cut a version for a workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)