### PR TITLE
feat!: rename the route prefix to /immich-shared-albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Two households, one shared album, created and shared and joined and commented on
 
 ## Install
 
-Every method needs Docker, an admin API key, and **a reverse proxy in front of Immich**. Shared photos and the join banner reach your server through three small routes (`/sidecar/*`, `/share/*`, and the GET byte routes) placed ahead of your normal Immich route. Pick one, easiest first:
+Every method needs Docker, an admin API key, and **a reverse proxy in front of Immich**. Shared photos and the join banner reach your server through three small routes (`/immich-shared-albums/*`, `/share/*`, and the GET byte routes) placed ahead of your normal Immich route. Pick one, easiest first:
 
 - **Preferred: let an AI agent install it.** If you use an AI coding agent (Claude Code, Cursor, Copilot CLI, etc.), either on the server or on your own machine with SSH access to it, paste [deploy/INSTALL-AI.md](./deploy/INSTALL-AI.md). It discovers your setup, installs the sidecar, adds the proxy routes adapted to *your* reverse proxy, and verifies the result. It's the most hands-off option and the only one that adapts to any proxy (Caddy, nginx, NPM, Traefik, tunnels).
 - **Guided script.** No agent? Clone next to your Immich and run `bash deploy/install.sh`. It auto-detects your Immich network, builds and starts the sidecar, health-checks it, and prints the proxy routes for you to add.
@@ -39,9 +39,9 @@ Every method needs Docker, an admin API key, and **a reverse proxy in front of I
 
 ## Permissions & security
 
-- **You choose how exposed your server is.** This addon doesn't open your server to the internet or change how sharing works; it only handles the server-to-server handshake. Each server just needs to reach the other's sidecar. A peer only ever touches `/sidecar/*` and `/share/*`, so the rest of Immich (all of `/api`, your library, admin) can stay private whichever way you set it up:
+- **You choose how exposed your server is.** This addon doesn't open your server to the internet or change how sharing works; it only handles the server-to-server handshake. Each server just needs to reach the other's sidecar. A peer only ever touches `/immich-shared-albums/*` and `/share/*`, so the rest of Immich (all of `/api`, your library, admin) can stay private whichever way you set it up:
     - **Public domain over HTTPS.** The standard reverse-proxy setup under Install.
-    - **[Tailscale](https://tailscale.com/) Funnel.** Funnel just `/sidecar/*` and `/share/*` to the sidecar over HTTPS. No domain and no open router ports needed.
+    - **[Tailscale](https://tailscale.com/) Funnel.** Funnel just `/immich-shared-albums/*` and `/share/*` to the sidecar over HTTPS. No domain and no open router ports needed.
     - **Fully hidden behind a Tailscale VPN.** Put every participating server on the same tailnet and nothing is exposed publicly at all. Ideal when the other households are on your tailnet too.
 - **Your server's security is your responsibility.** This is a tool, and it's only as secure as the server you run it on. [deploy/exposure.md](./deploy/exposure.md) is a short, practical guide: pick how exposed you want to be, then paste one hardening block.
 - **Nothing is protected by being hard to reach.** Every route assumes it's on the open internet. Pages you use (the panel, joining, leaving) require you to be **signed in to your own Immich** — the sidecar has no accounts of its own and checks your session against Immich itself. Server-to-server routes require a signature *and* a check that the asking household was actually offered that album and that photo. Being able to reach an endpoint is never permission to use it.

--- a/demo/e2e/browser-test.mjs
+++ b/demo/e2e/browser-test.mjs
@@ -44,7 +44,7 @@ check('unknown server shows inline error (no 404 stranding)',
 // 3. auto-capitalised scheme + scheme discovery still reach the accept page
 await input.fill('Http://' + B_ADDR);
 await page.locator('#immich-shared-albums-banner button.join').click();
-const reached = await page.waitForURL('**/sidecar/accept*', { timeout: 20000 }).then(() => true).catch(() => false);
+const reached = await page.waitForURL('**/immich-shared-albums/accept*', { timeout: 20000 }).then(() => true).catch(() => false);
 check('"Http://"-cased address still reaches the accept page', reached);
 
 // 4. signed-out accept page: sign-in prompt, Accept disabled

--- a/demo/e2e/cdp-join.mjs
+++ b/demo/e2e/cdp-join.mjs
@@ -34,7 +34,7 @@ await page.evaluate(async ({ addr, fn }) => {
 }, { addr: ADDR, fn: bannerEl.toString() });
 await page.waitForTimeout(800);
 await page.evaluate((fn) => { eval(`(${fn})`)('button.join').click(); }, bannerEl.toString());
-await page.waitForURL('**/sidecar/accept*', { timeout: 30000 });
+await page.waitForURL('**/immich-shared-albums/accept*', { timeout: 30000 });
 console.log('accept page reached');
 
 await page.waitForFunction(() => document.getElementById('who')?.textContent?.includes('Joining as'), null, { timeout: 20000 });

--- a/demo/e2e/demo-film.mjs
+++ b/demo/e2e/demo-film.mjs
@@ -57,7 +57,7 @@ await page.waitForTimeout(600);
 await page.locator('#immich-shared-albums-banner button.join').click();
 
 console.log('scene 3: accept page — already knows who I am');
-await page.waitForURL('**/sidecar/accept*', { timeout: 20000 });
+await page.waitForURL('**/immich-shared-albums/accept*', { timeout: 20000 });
 await page.waitForFunction(() => document.getElementById('who')?.textContent?.includes('Joining as'), null, { timeout: 20000 });
 await page.waitForTimeout(1800);
 await page.locator('#go').click();

--- a/demo/e2e/e2e-test.mjs
+++ b/demo/e2e/e2e-test.mjs
@@ -14,7 +14,7 @@ const api = async (base, key, path, init = {}) => {
   return r.status === 204 ? null : r.json();
 };
 const j = (o) => ({ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(o) });
-// /sidecar/join authenticates the caller against that household's own Immich, so the
+// /immich-shared-albums/join authenticates the caller against that household's own Immich, so the
 // suite has to present a real credential exactly like a signed-in browser would.
 const jAuth = (o, key) => ({ method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': key }, body: JSON.stringify(o) });
 const albumAssets = async (base, key, albumId) =>
@@ -94,7 +94,7 @@ const ORIGIN_SIDECAR = process.env.ORIGIN_SIDECAR || A;
 // ORIGIN_SIDECAR is resolved by B's sidecar from INSIDE its container (host.docker.internal).
 // The security stage calls the origin directly from this process, so it needs a host route.
 const ORIGIN_DIRECT = process.env.ORIGIN_SIDECAR_DIRECT || 'http://localhost:8302';
-const joinRes = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` }, BKEY))).json();
+const joinRes = await (await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` }, BKEY))).json();
 check('join succeeded', !!joinRes.album, JSON.stringify(joinRes));
 check('join manifest = 4 photos', joinRes.photos === 4, `got ${joinRes.photos}`);
 
@@ -247,7 +247,7 @@ if (aAfter) {
   await api(A, AKEY, `/albums/${alb2}/assets`, { ...j({ ids: [aIds[0]] }), method: 'PUT' });
   const share2 = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: alb2, allowUpload: true }))).key;
   const nanId = (await api(B, BKEY, '/users/me')).id;
-  const join2 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share2}`, forUserId: nanId }, BKEY))).json();
+  const join2 = await (await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share2}`, forUserId: nanId }, BKEY))).json();
   check('second album join ok', join2.photos === 1, JSON.stringify(join2));
   const mirror2 = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'second album');
   const m2assets = await until(async () => { const x = await albumAssets(B, BKEY, mirror2.id); return x.length === 1 ? x : null; }, 40000);
@@ -259,7 +259,7 @@ if (aAfter) {
   console.log('— stage: re-join by a second user attaches to the existing mirror');
   let second = (await api(B, BKEY, '/admin/users')).find(u => u.email === 'second-e2e@demo.local');
   if (!second) second = await api(B, BKEY, '/admin/users', j({ email: 'second-e2e@demo.local', name: 'Second Human', password: 'e2e-pass-123' }));
-  const join2b = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share2}`, forUserId: second.id }, BKEY))).json();
+  const join2b = await (await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share2}`, forUserId: second.id }, BKEY))).json();
   check('re-join returns the existing mirror (no duplicate album)', join2b.albumId === mirror2.id, JSON.stringify(join2b).slice(0, 100));
   const dupCount = (await api(B, BKEY, '/albums')).filter(a => a.albumName === 'second album').length;
   check('only one "second album" mirror exists', dupCount === 1, `${dupCount} album(s)`);
@@ -299,7 +299,7 @@ console.log('— stage: instant join (no preview wait) heals via reconciliation'
   await api(A, AKEY, `/albums/${alb3}/assets`, { ...j({ ids: [fresh] }), method: 'PUT' });
   const share3 = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: alb3, allowUpload: true }))).key;
   const meB = (await api(B, BKEY, '/users/me')).id;
-  const join3 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share3}`, forUserId: meB }, BKEY))).json();
+  const join3 = await (await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share3}`, forUserId: meB }, BKEY))).json();
   check('instant join accepted', !!join3.albumId, JSON.stringify(join3).slice(0, 100));
   const m3 = await until(async () => {
     const mirror3 = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'instant album');
@@ -315,7 +315,7 @@ console.log('— stage: share link created before any photos (empty album) still
   const alb5 = (await api(A, AKEY, '/albums', j({ albumName: 'born empty' }))).id;
   const share5 = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: alb5, allowUpload: true }))).key;
   const meB5 = (await api(B, BKEY, '/users/me')).id;
-  const join5 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share5}`, forUserId: meB5 }, BKEY))).json();
+  const join5 = await (await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share5}`, forUserId: meB5 }, BKEY))).json();
   check('empty-album join succeeds', !!join5.albumId, JSON.stringify(join5).slice(0, 100));
   const bu5 = (await api(B, BKEY, '/admin/users')).filter(u => u.email.endsWith('@sidecar.local'));
   check('empty-album mirror owner named after the sharer, not the household',
@@ -330,7 +330,7 @@ console.log('— stage: view-only share link (allowUpload off) rejects cross-ser
   await api(A, AKEY, `/albums/${alb6}/assets`, { ...j({ ids: [voId] }), method: 'PUT' });
   const share6 = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: alb6, allowUpload: false }))).key;
   const meB6 = (await api(B, BKEY, '/users/me')).id;
-  const join6 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share6}`, forUserId: meB6 }, BKEY))).json();
+  const join6 = await (await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share6}`, forUserId: meB6 }, BKEY))).json();
   const mirror6 = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'view only album');
   const m6 = await until(async () => { const x = await albumAssets(B, BKEY, mirror6.id); return x.length === 1 ? x : null; }, 60000);
   check('view-only album still syncs for viewing', !!m6, m6 ? '' : 'timed out');
@@ -353,7 +353,7 @@ console.log('— stage: reverse-direction share — member-owned album with an a
   await api(B, BKEY, `/albums/${albR}/assets`, { ...j({ ids: [nIds[0]] }), method: 'PUT' });
   const shareR = (await api(B, BKEY, '/shared-links', j({ type: 'ALBUM', albumId: albR, allowUpload: true }))).key;
   const meC = (await api(A, AKEY, '/users/me')).id;
-  const joinR = await (await fetch(`${CS}/sidecar/join`, jAuth({ url: `${REV}/share/${shareR}`, forUserId: meC }, AKEY))).json();
+  const joinR = await (await fetch(`${CS}/immich-shared-albums/join`, jAuth({ url: `${REV}/share/${shareR}`, forUserId: meC }, AKEY))).json();
   check('reverse join: C joins a B-owned album', !!joinR.albumId, JSON.stringify(joinR).slice(0, 100));
   const mirrorR = (await api(A, AKEY, '/albums')).find(a => a.albumName === 'reverse album');
   const mR = mirrorR && await until(async () => { const x = await albumAssets(A, AKEY, mirrorR.id); return x.length === 1 ? x : null; }, 180000);
@@ -369,7 +369,7 @@ const DS = process.env.D_SIDECAR || 'http://localhost:8303';
 const DKEY = process.env.DKEY;
 let dMirror = null;
 if (DKEY) {
-  const joinD = await (await fetch(`${DS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` }, DKEY))).json();
+  const joinD = await (await fetch(`${DS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` }, DKEY))).json();
   check('D join succeeded', !!joinD.albumId, JSON.stringify(joinD).slice(0, 100));
   dMirror = (await api(D, DKEY, '/albums')).find(a => a.albumName === joinD.album);
   const dAssets = await until(async () => { const x = await albumAssets(D, DKEY, dMirror.id); return x.length === 9 ? x : null; }, 150000);
@@ -409,7 +409,7 @@ console.log('— stage: deletion propagation + leave-&-purge (reversible joins)'
   await api(A, AKEY, `/albums/${albD}/assets`, { ...j({ ids: [d1, d2] }), method: 'PUT' });
   const shareD = (await api(A, AKEY, '/shared-links', j({ type: 'ALBUM', albumId: albD, allowUpload: true }))).key;
   const meBD = (await api(B, BKEY, '/users/me')).id;
-  const joinD2 = await (await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareD}`, forUserId: meBD }, BKEY))).json();
+  const joinD2 = await (await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${shareD}`, forUserId: meBD }, BKEY))).json();
   const mirrorD = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'delete test');
   const mD = await until(async () => { const x = await albumAssets(B, BKEY, mirrorD.id); return x.length === 2 ? x : null; }, 60000);
   check('delete-test album joined and mirrored (2 stubs)', !!mD, mD ? '' : 'timed out');
@@ -475,6 +475,39 @@ if (DKEY && dMirror) check('no ping-pong on D', (await albumAssets(D, DKEY, dMir
 // Websockets: the sidecar must be able to front Immich on its own, which means carrying
 // protocol upgrades. Without this, live web updates silently die in single-front setups —
 // invisible to the mobile apps, which is exactly how it went unnoticed before.
+// The route prefix moved from /sidecar to /immich-shared-albums — a clean break, no shim, so
+// both peers must agree on it. Pins the panel answering WITHOUT a trailing slash, and that
+// nothing still emits the old prefix.
+console.log('— stage: route prefix rename + legacy compatibility');
+{
+  const code = async (u, init) => (await fetch(u, init).catch(() => ({ status: 0 }))).status;
+  const j2 = (o, key) => ({ method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': key }, body: JSON.stringify(o) });
+
+  check('new prefix: health responds', (await (await fetch(`${BS}/immich-shared-albums/health`)).json()).ok === true);
+  // With no shim, /sidecar/* is not ours any more — it falls through to Immich, which may well
+  // answer 200 with its SPA shell. So assert it no longer reaches OUR handler, not a status.
+  const oldBody = await (await fetch(`${BS}/sidecar/health`).catch(() => ({ text: async () => '' }))).text();
+  check('old prefix no longer reaches the sidecar (clean break, no shim)',
+        !oldBody.includes('"ok":true'), `body started: ${oldBody.slice(0, 40)}`);
+
+  const noSlash = await code(`${BS}/immich-shared-albums`);
+  const withSlash = await code(`${BS}/immich-shared-albums/`);
+  check('panel answers WITHOUT a trailing slash', [200, 401, 403].includes(noSlash) && noSlash === withSlash,
+        `no-slash=${noSlash} with-slash=${withSlash}`);
+  check('panel is still gated on both forms', noSlash === 401, `got ${noSlash}`);
+
+  // the join route must work on the new prefix and remain auth-gated on both
+  check('join is gated on the new prefix',
+        await code(`${BS}/immich-shared-albums/join`, j2({ url: 'x' }, '')) === 401);
+
+  // the injected banner must reference the NEW prefix, or discovery breaks
+  const bannerJs = await (await fetch(`${BS}/immich-shared-albums/banner.js`)).text();
+  const bannerOk = bannerJs.includes('/immich-shared-albums/health');
+  check('served banner.js points at the new prefix', bannerOk,
+        bannerOk ? '' : (bannerJs.includes('/sidecar/health') ? 'still says /sidecar/health' : 'no health probe found'));
+  check('served banner.js has no stale /sidecar/ paths', !bannerJs.includes('/sidecar/'));
+}
+
 console.log('— stage: websocket upgrades pass through the sidecar');
 {
   const http = await import('node:http');
@@ -507,26 +540,26 @@ console.log('— stage: security (unauthenticated surface)');
   const status = async (url, init) => (await fetch(url, init).catch(() => ({ status: 0 }))).status;
 
   check('panel refuses an unauthenticated caller',
-        [401, 403].includes(await status(`${BS}/sidecar/`)), `got ${await status(`${BS}/sidecar/`)}`);
+        [401, 403].includes(await status(`${BS}/immich-shared-albums/`)), `got ${await status(`${BS}/immich-shared-albums/`)}`);
   check('join refuses an unauthenticated caller',
-        await status(`${BS}/sidecar/join`, j({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` })) === 401);
+        await status(`${BS}/immich-shared-albums/join`, j({ url: `${ORIGIN_SIDECAR}/share/${shareKey}` })) === 401);
   check('leave refuses an unauthenticated caller',
-        await status(`${BS}/sidecar/leave`, j({ mappingId: 'whatever' })) === 401);
+        await status(`${BS}/immich-shared-albums/leave`, j({ mappingId: 'whatever' })) === 401);
 
-  const health = await (await fetch(`${BS}/sidecar/health`)).json();
+  const health = await (await fetch(`${BS}/immich-shared-albums/health`)).json();
   check('health exposes liveness only (no household name, no peer count)',
         health.ok === true && !('household' in health) && !('peers' in health), JSON.stringify(health));
 
   check('oversized body is rejected before it is buffered',
-        await status(`${BS}/sidecar/join`, { method: 'POST', headers: { 'Content-Type': 'application/json' },
+        await status(`${BS}/immich-shared-albums/join`, { method: 'POST', headers: { 'Content-Type': 'application/json' },
                                              body: 'x'.repeat(2 * 1024 * 1024) }) === 413);
 
   check('redeem refuses an unsigned caller',
-        await status(`${ORIGIN_DIRECT}/sidecar/api/v1/invites/redeem`,
+        await status(`${ORIGIN_DIRECT}/immich-shared-albums/api/v1/invites/redeem`,
                      j({ shareKey, protocol: 1, household: { publicKey: 'AAAA', url: 'http://x', name: 'imposter' } })) === 403);
 
   check('avatar route refuses a bare public key with no signature',
-        [403, 405].includes(await status(`${ORIGIN_DIRECT}/sidecar/api/v1/users/${(await api(A, AKEY, '/users/me')).id}/avatar`,
+        [403, 405].includes(await status(`${ORIGIN_DIRECT}/immich-shared-albums/api/v1/users/${(await api(A, AKEY, '/users/me')).id}/avatar`,
                                          { headers: { 'x-isa-key': 'AAAA' } })));
 }
 
@@ -550,17 +583,17 @@ console.log('— stage: security (entitlement — a signed peer is not entitled 
     await ensurePreviews(A, AKEY, [privAsset]);
     await api(A, AKEY, `/albums/${privAlbum}/assets`, { ...j({ ids: [privAsset] }), method: 'PUT' });
 
-    const privStatus = (await fetch(`${ORIGIN_DIRECT}/sidecar/api/v1/assets/${privAsset}/original`, asB(privAsset))).status;
+    const privStatus = (await fetch(`${ORIGIN_DIRECT}/immich-shared-albums/api/v1/assets/${privAsset}/original`, asB(privAsset))).status;
     check('a valid peer CANNOT read an asset that was never shared with it (F-05)',
           privStatus === 403, `got ${privStatus}`);
 
     // Control: the same signature on an asset B genuinely was offered must still work,
     // otherwise the check above would pass simply by breaking all byte reads.
-    const okStatus = (await fetch(`${ORIGIN_DIRECT}/sidecar/api/v1/assets/${aIds[0]}/original`, asB(aIds[0]))).status;
+    const okStatus = (await fetch(`${ORIGIN_DIRECT}/immich-shared-albums/api/v1/assets/${aIds[0]}/original`, asB(aIds[0]))).status;
     check('the same peer CAN still read an asset it was offered (no over-blocking)',
           okStatus === 200, `got ${okStatus}`);
 
-    const manifestStatus = (await fetch(`${ORIGIN_DIRECT}/sidecar/api/v1/albums/${privAlbum}/manifest`, asB(privAlbum))).status;
+    const manifestStatus = (await fetch(`${ORIGIN_DIRECT}/immich-shared-albums/api/v1/albums/${privAlbum}/manifest`, asB(privAlbum))).status;
     check('a valid peer CANNOT read the manifest of an album not mapped to it (F-06)',
           [403, 404].includes(manifestStatus), `got ${manifestStatus}`);
 
@@ -579,7 +612,7 @@ console.log('— stage: security (album password gates enrolment)');
     j({ type: 'ALBUM', albumId: pwAlbum, allowUpload: true, password: 'correct horse' }))).key;
   const meP = (await api(B, BKEY, '/users/me')).id;
   const tryJoin = async (password) => {
-    const r = await fetch(`${BS}/sidecar/join`,
+    const r = await fetch(`${BS}/immich-shared-albums/join`,
       jAuth({ url: `${ORIGIN_SIDECAR}/share/${pwKey}`, forUserId: meP, password }, BKEY));
     return { status: r.status, body: await r.json().catch(() => ({})) };
   };
@@ -596,7 +629,7 @@ console.log('— stage: security (album password gates enrolment)');
   const expAlbum = (await api(A, AKEY, '/albums', j({ albumName: 'expired album' }))).id;
   const expKey = (await api(A, AKEY, '/shared-links',
     j({ type: 'ALBUM', albumId: expAlbum, expiresAt: '2020-01-01T00:00:00.000Z' }))).key;
-  const expRes = await fetch(`${BS}/sidecar/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${expKey}`, forUserId: meP }, BKEY));
+  const expRes = await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${expKey}`, forUserId: meP }, BKEY));
   check('join through an expired share link is refused', expRes.status >= 400, `got ${expRes.status}`);
   await api(A, AKEY, `/albums/${expAlbum}`, { method: 'DELETE' }).catch(() => {});
 }

--- a/demo/e2e/film-join.mjs
+++ b/demo/e2e/film-join.mjs
@@ -41,7 +41,7 @@ await page.waitForTimeout(900);
 
 console.log('scene 3: Join -> pre-flight -> accept page (already signed in)');
 await page.locator('#immich-shared-albums-banner button.join').click();
-await page.waitForURL('**/sidecar/accept*', { timeout: 20000 });
+await page.waitForURL('**/immich-shared-albums/accept*', { timeout: 20000 });
 await page.waitForFunction(() => document.getElementById('who')?.textContent?.includes('Joining as'), null, { timeout: 20000 });
 await page.waitForTimeout(2500);
 

--- a/deploy/Caddyfile.snippet
+++ b/deploy/Caddyfile.snippet
@@ -4,12 +4,12 @@
 # Immich — no path matching, no ordering to get wrong. See deploy/exposure.md §2.
 # That file also has the recommended hardening (access log, rate limiting, headers).
 #
-# All of /sidecar/* is safe to expose publicly: the panel and the join/leave routes
+# All of /immich-shared-albums/* is safe to expose publicly: the panel and the join/leave routes
 # require a signed-in Immich session (checked against your own Immich, server-side), and
 # the server-to-server routes require a signature plus an entitlement check. You do NOT
 # need to restrict these by source IP — doing so would break joining from mobile data,
-# since someone's accept page calls their own server's /sidecar/join.
-handle /sidecar/* {
+# since someone's accept page calls their own server's /immich-shared-albums/join.
+handle /immich-shared-albums/* {
 	# optional belt-and-braces: the sidecar caps its own JSON bodies (MAX_BODY_KB),
 	# but capping at the proxy keeps oversized requests off the process entirely.
 	request_body {

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -41,7 +41,7 @@ INSTALL:
    volume for /data. Start it with docker compose up -d.
 3. Add these three routes to my reverse proxy BEFORE the catch-all Immich route,
    then reload the proxy:
-     /sidecar/*                                       -> sidecar :8300
+     /immich-shared-albums/*                                       -> sidecar :8300
      /share/*                                         -> sidecar :8300 (fallback: immich)
      GET /api/assets/*/{thumbnail,original,video/playback} -> sidecar :8300 (fallback: immich)
    The byte routes MUST be GET-only and fall back to Immich when the sidecar is
@@ -49,7 +49,7 @@ INSTALL:
    Show me the exact diff before applying it.
 
 VERIFY (all three, report results):
-1. GET <public-url>/sidecar/health returns {"ok":true,...}.
+1. GET <public-url>/immich-shared-albums/health returns {"ok":true,...}.
 2. Any Immich share link opened in a browser shows the
    "Join shared album with your server?" banner over the working share page.
 3. The share page itself still fully loads (photos render behind the banner).
@@ -74,9 +74,9 @@ Notes for you, the agent:
   world-readable files.
 - All three routes are safe to expose publicly — the sidecar authenticates
   human routes against the user's own Immich session and peer routes by
-  signature plus entitlement. Do NOT add source-IP restrictions to /sidecar/*:
+  signature plus entitlement. Do NOT add source-IP restrictions to /immich-shared-albums/*:
   it would break joining from mobile data, because someone's accept page calls
-  their own server's /sidecar/join.
+  their own server's /immich-shared-albums/join.
 ```
 
 ---
@@ -84,5 +84,5 @@ Notes for you, the agent:
 ## What a successful install looks like
 
 - One new container (`immich-shared`) on your Immich docker network.
-- `https://your-domain/sidecar/` shows the sidecar panel.
+- `https://your-domain/immich-shared-albums/` shows the sidecar panel.
 - Share links show the join banner; everything else about Immich is unchanged.

--- a/deploy/exposure.md
+++ b/deploy/exposure.md
@@ -58,7 +58,7 @@ photos.example.com {
 	}
 
 	# the sidecar speaks JSON only, so a tight body cap is safe HERE
-	handle /sidecar/* {
+	handle /immich-shared-albums/* {
 		request_body {
 			max_size 2MB
 		}
@@ -101,7 +101,7 @@ Apply changes with `docker exec caddy caddy reload --config /etc/caddy/Caddyfile
 downtime, and it refuses a bad config rather than half-applying it.
 
 Using nginx, Traefik or NPM instead? The single route above translates directly: one
-`location /`, one router label, or one proxy host. Only the `handle /sidecar/*` body cap and
+`location /`, one router label, or one proxy host. Only the `handle /immich-shared-albums/*` body cap and
 the header lines need their equivalents.
 
 ---
@@ -166,7 +166,7 @@ for p in 22 2283 9090 5432; do nc -z -w3 your-public-ip $p && echo "$p OPEN"; do
 curl -sI https://photos.example.com/ | grep -iE 'strict-transport|x-content-type|referrer'
 
 # the sidecar's admin surface must be closed
-curl -s -o /dev/null -w '%{http_code}\n' https://photos.example.com/sidecar/   # expect 401
+curl -s -o /dev/null -w '%{http_code}\n' https://photos.example.com/immich-shared-albums/   # expect 401
 
 # rate limiting bites (expect 401s then 429s)
 for i in $(seq 1 8); do

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -77,7 +77,7 @@ say "Starting sidecar"
 printf "waiting for health"
 ok=""
 for _ in $(seq 1 20); do
-  if (cd "$INSTALL_DIR" && docker compose exec -T immich-shared wget -qO- http://localhost:8300/sidecar/health 2>/dev/null) | grep -q '"ok":true'; then
+  if (cd "$INSTALL_DIR" && docker compose exec -T immich-shared wget -qO- http://localhost:8300/immich-shared-albums/health 2>/dev/null) | grep -q '"ok":true'; then
     ok=1; break
   fi
   printf "."; sleep 1
@@ -94,7 +94,7 @@ cat <<EOF
 Add to your existing site config, BEFORE the catch-all Immich route:
 
   Caddy (byte routes are GET-only and fall back to Immich if the sidecar is down):
-    handle /sidecar/* { reverse_proxy immich-shared:8300 }
+    handle /immich-shared-albums/* { reverse_proxy immich-shared:8300 }
     handle /share/*   { reverse_proxy immich-shared:8300 immich-server:2283 { lb_policy first } }
     @sharedbytes {
       method GET
@@ -103,7 +103,7 @@ Add to your existing site config, BEFORE the catch-all Immich route:
     handle @sharedbytes { reverse_proxy immich-shared:8300 immich-server:2283 { lb_policy first } }
 
   nginx:
-    location /sidecar/ { proxy_pass http://127.0.0.1:$HOST_PORT; }
+    location /immich-shared-albums/ { proxy_pass http://127.0.0.1:$HOST_PORT; }
     location /share/   { proxy_pass http://127.0.0.1:$HOST_PORT; }
     location ~ ^/api/assets/[^/]+/(thumbnail|original|video/playback)$ {
       limit_except GET { proxy_pass http://immich-upstream; }
@@ -112,7 +112,7 @@ Add to your existing site config, BEFORE the catch-all Immich route:
 
 Then reload the proxy and open any Immich share link — you should see the
 "Join shared album with your server?" banner. Verify the panel at:
-  $PUBLIC_URL/sidecar/
+  $PUBLIC_URL/immich-shared-albums/
 
 To uninstall: cd $INSTALL_DIR && docker compose down && remove the proxy lines.
 EOF

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -25,8 +25,8 @@ ordinary data we planted, or a web page we serve.
             │  state.db (SQLite): keys, peers, mappings,  │
             │        seen ledger, activity, contributors  │
             │                                             │
-            │  web: panel (/sidecar/) · banner (/share/*) │
-            │       accept page (/sidecar/accept)         │
+            │  web: panel (/immich-shared-albums/) · banner (/share/*) │
+            │       accept page (/immich-shared-albums/accept)         │
             └─────────────────────────────────────────────┘
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,3 +37,13 @@ export const CFG = {
 if (!CFG.apiKey) { console.error('IMMICH_API_KEY required'); process.exit(1); }
 export const log = (...a) => console.log(new Date().toISOString(), ...a);
 export const UTILITY_SUFFIX = ' (via shared albums)';
+
+/**
+ * The URL prefix this addon owns on the Immich origin.
+ *
+ * "sidecar" was a generic term staking a claim another Immich addon could reasonably want, so
+ * it moved to a name specific to this project. There is deliberately no compatibility shim for
+ * the old prefix: the install base was small enough that a clean break beat carrying a second
+ * route surface forever. Both peers must run a version that agrees on this.
+ */
+export const ROUTE_PREFIX = '/immich-shared-albums';

--- a/src/immich/contributors.ts
+++ b/src/immich/contributors.ts
@@ -4,7 +4,7 @@
  * attribution). Provisions/heals them, mints their API keys, and syncs their avatars.
  */
 import crypto from 'node:crypto';
-import { CFG, log, UTILITY_SUFFIX } from '../config.ts';
+import { CFG, log, UTILITY_SUFFIX, ROUTE_PREFIX } from '../config.ts';
 import { state, save } from '../state.ts';
 import { immichJson, jsonBody, usersById, USERS } from './client.ts';
 import { sign } from '../peers.ts';
@@ -109,7 +109,7 @@ export async function ensureUtilityUser(displayName) {
 export async function syncAvatar(c, peerUrl, originUserId) {
   if (!peerUrl || !originUserId || c.avatarDone) return;
   try {
-    const av = await fetch(`${peerUrl}/sidecar/api/v1/users/${originUserId}/avatar`,
+    const av = await fetch(`${peerUrl}${ROUTE_PREFIX}/api/v1/users/${originUserId}/avatar`,
       { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(originUserId) }, signal: AbortSignal.timeout(30000) });
     if (av.ok) {
       const fd = new FormData();

--- a/src/immich/materialise.ts
+++ b/src/immich/materialise.ts
@@ -4,7 +4,7 @@
  * hard-guarded so only utility-owned proxies are ever deleted.
  */
 import crypto from 'node:crypto';
-import { log } from '../config.ts';
+import { log, ROUTE_PREFIX } from '../config.ts';
 import { state, seenHas, seenAdd } from '../state.ts';
 import { sign } from '../peers.ts';
 import { STUB_JPEG, immichJson, jsonBody, uploadAsset, addToAlbum, applyRefMetadata } from './client.ts';
@@ -22,7 +22,7 @@ export async function materialiseRef(mapping, peerUrl, fallbackName, ref) {
   // the owner's rendition so the tile carries a real poster and duration.
   let bytes: Buffer;
   if (ref.kind === 'video') {
-    const pr = await fetch(`${peerUrl}/sidecar/api/v1/assets/${ref.originAsset}/playback`,
+    const pr = await fetch(`${peerUrl}${ROUTE_PREFIX}/api/v1/assets/${ref.originAsset}/playback`,
       { ...sigHeaders(ref.originAsset), headers: { ...sigHeaders(ref.originAsset).headers, Range: 'bytes=0-2097151' }, signal: AbortSignal.timeout(120000) });
     if (!pr.ok) { log(`playback stub fetch failed for ${ref.originAsset}: ${pr.status}`); return false; }
     bytes = Buffer.concat([Buffer.from(await pr.arrayBuffer()), crypto.randomBytes(8)]);

--- a/src/media/interceptor.ts
+++ b/src/media/interceptor.ts
@@ -6,7 +6,7 @@
  * Returns true iff it wrote the response; false tells the router to fall through.
  */
 import { Readable } from 'node:stream';
-import { CFG, log } from '../config.ts';
+import { CFG, log, ROUTE_PREFIX } from '../config.ts';
 import { state, store } from '../state.ts';
 import { sign } from '../peers.ts';
 import { immich } from '../immich/client.ts';
@@ -34,7 +34,7 @@ export async function serveInterceptedBytes(req, res, assetId: string, rawKind: 
     const peer2 = mapping2 && state.peers.find(pe => pe.pub === mapping2.peer);
     if (peer2) {
       try {
-        const up = await fetch(`${peer2.url}/sidecar/api/v1/assets/${entry.o}/preview`,
+        const up = await fetch(`${peer2.url}${ROUTE_PREFIX}/api/v1/assets/${entry.o}/preview`,
           { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) },
             signal: AbortSignal.timeout(30000) });
         if (up.ok) {

--- a/src/media/proxy.ts
+++ b/src/media/proxy.ts
@@ -8,7 +8,7 @@
  * p2p/entitlement whether this specific peer was ever offered this specific asset. Without
  * that, "a valid peer" would mean "any asset in the library that it can name".
  */
-import { log } from '../config.ts';
+import { log, ROUTE_PREFIX } from '../config.ts';
 import { state, store } from '../state.ts';
 import { sign, callingPeer } from '../peers.ts';
 import { peerMayRead } from '../p2p/entitlement.ts';
@@ -39,7 +39,7 @@ export async function fetchTrueBytes(assetId: string, kind: 'preview' | 'origina
       const headers: Record<string, string> = { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) };
       if (range) headers.Range = range;
       try {
-        const up = await fetchWithHeaderTimeout(`${peer.url}/sidecar/api/v1/assets/${entry.o}/${kind}`, { headers });
+        const up = await fetchWithHeaderTimeout(`${peer.url}${ROUTE_PREFIX}/api/v1/assets/${entry.o}/${kind}`, { headers });
         if (up.ok) return up;
         log(`chained ${kind} fetch failed (${up.status}) — serving local stub`);
       } catch (e) { log(`chained ${kind} fetch error (${e.message}) — serving local stub`); }

--- a/src/p2p/join.ts
+++ b/src/p2p/join.ts
@@ -4,7 +4,7 @@
  * kicks off the first reconcile. Idempotent: re-joining just adds the user to the mirror.
  */
 import crypto from 'node:crypto';
-import { CFG, SIDECAR_VERSION, log } from '../config.ts';
+import { CFG, SIDECAR_VERSION, log, ROUTE_PREFIX } from '../config.ts';
 import { state, save } from '../state.ts';
 import { signedFetch, assertPeerUrlAllowed } from '../peers.ts';
 import { immichJson, jsonBody } from '../immich/client.ts';
@@ -19,7 +19,7 @@ export async function join(shareUrl, forUserId, password?: string) {
   await assertPeerUrlAllowed(origin);
   const body = JSON.stringify({ shareKey, protocol: 1, version: SIDECAR_VERSION, password,
     household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name } });
-  const r = await signedFetch(`${origin}/sidecar/api/v1/invites/redeem`, body);
+  const r = await signedFetch(`${origin}${ROUTE_PREFIX}/api/v1/invites/redeem`, body);
   if (!r.ok) {
     // Surface the other sidecar's own message (an expired link, a wrong password) but
     // never an arbitrary upstream body — that would make this a read primitive for

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -5,7 +5,7 @@
 import crypto from 'node:crypto';
 import dns from 'node:dns/promises';
 import { state } from './state.ts';
-import { CFG } from './config.ts';
+import { CFG, ROUTE_PREFIX } from './config.ts';
 
 const PRIVATE_V4 = [
   /^127\./, /^10\./, /^192\.168\./, /^169\.254\./, /^0\./,
@@ -77,7 +77,7 @@ export function nudgePeers(albumId: string, exceptPeerPub?: string) {
     if (mp.albumId !== albumId || mp.dead || mp.role !== 'owner' || mp.peer === exceptPeerPub) continue;
     const peer = state.peers.find(p => p.pub === mp.peer);
     if (!peer) continue;
-    signedFetch(`${peer.url}/sidecar/api/v1/albums/${albumId}/nudge`, JSON.stringify({ album: albumId }))
+    signedFetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${albumId}/nudge`, JSON.stringify({ album: albumId }))
       .catch(() => { /* fail-open */ });
   }
 }

--- a/src/sync/comments.ts
+++ b/src/sync/comments.ts
@@ -3,7 +3,7 @@
  * members pull the canonical list and push their own, gated by a cheap activity-count
  * statistic so messages land in seconds without heavy polling. startCommentLoop runs it.
  */
-import { CFG, log, UTILITY_SUFFIX } from '../config.ts';
+import { CFG, log, UTILITY_SUFFIX, ROUTE_PREFIX } from '../config.ts';
 import { state, save, seenActHas, seenActAdd } from '../state.ts';
 import { sign, signedFetch, nudgePeers, callingPeer, mappingFor } from '../peers.ts';
 import { immichJson, jsonBody, usersById } from '../immich/client.ts';
@@ -84,7 +84,7 @@ export async function syncCommentsOnce() {
       if (!comments.length) { if (stats) { mapping.commentCount = stats.comments; save(); } continue; }
       const targetMapping = mapping.role === 'member' ? (mapping.remoteMappingId || mapping.remoteAlbumId) : mapping.albumId;
       const payload = comments.map(a => ({ id: a.id, comment: a.comment, author: a.user?.name || CFG.name, authorUserId: a.user?.id }));
-      const r = await signedFetch(`${peer.url}/sidecar/api/v1/albums/${targetMapping}/activity`, JSON.stringify({ comments: payload }));
+      const r = await signedFetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${targetMapping}/activity`, JSON.stringify({ comments: payload }));
       if (r.ok) {
         comments.forEach(a => seenActAdd(`local:${a.id}`));
         // the origin answers with canonical ids for our comments — remember them so the
@@ -103,11 +103,11 @@ export async function syncCommentsOnce() {
 export async function pullCanonicalComments(mapping, peer) {
   const target = mapping.remoteMappingId || mapping.remoteAlbumId;
   const sig = { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(target) } };
-  const vr = await fetch(`${peer.url}/sidecar/api/v1/albums/${target}/version`, { ...sig, signal: AbortSignal.timeout(15000) });
+  const vr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/version`, { ...sig, signal: AbortSignal.timeout(15000) });
   if (!vr.ok) return;
   const v = await vr.json().catch(() => ({}));
   if (v.comments == null || v.comments === mapping.remoteCommentCount) return;
-  const cr = await fetch(`${peer.url}/sidecar/api/v1/albums/${target}/comments`, { ...sig, signal: AbortSignal.timeout(20000) });
+  const cr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/comments`, { ...sig, signal: AbortSignal.timeout(20000) });
   if (!cr.ok) return;
   const { comments = [] } = await cr.json().catch(() => ({}));
   await materialiseComments(mapping, peer.url, peer.name, comments);

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -4,7 +4,7 @@
  * refs, and propagate deletions. leaveAlbum is the full reverse of a join. startWatchLoop
  * runs it all on an overlap-guarded interval.
  */
-import { CFG, log } from '../config.ts';
+import { CFG, log, ROUTE_PREFIX } from '../config.ts';
 import type { Mapping, Peer } from '../store.ts';
 import { state, store, save, seenHas, seenAdd, wireChecksum } from '../state.ts';
 import { sign, signedFetch } from '../peers.ts';
@@ -64,7 +64,7 @@ export async function watchOnce() {
       const add = [];
       for (const a of fresh) add.push(await assetToRef(a));
       const body = JSON.stringify({ add });
-      const r = await signedFetch(`${peer.url}/sidecar/api/v1/albums/${targetMapping}/refs`, body);
+      const r = await signedFetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${targetMapping}/refs`, body);
       if (r.ok) {
         const failed = new Set((await r.json().catch(() => ({}))).failed || []);
         const landed = fresh.filter(a => !failed.has(wireChecksum(a)));
@@ -108,12 +108,12 @@ export async function reconcileMapping(mapping: Mapping, peer: Peer) {
       // handshake first: only pull the full manifest when the origin's version moved.
       // remoteVersion is only stored after a CLEAN pass so failures keep retrying.
       let version = null;
-      const vr = await fetch(`${peer.url}/sidecar/api/v1/albums/${target}/version`, { ...sig, signal: AbortSignal.timeout(15000) });
+      const vr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/version`, { ...sig, signal: AbortSignal.timeout(15000) });
       if (vr.ok) {
         version = (await vr.json().catch(() => ({}))).version || null;
         if (version && version === mapping.remoteVersion) return;
       }
-      const r = await fetch(`${peer.url}/sidecar/api/v1/albums/${target}/manifest`, { ...sig, signal: AbortSignal.timeout(30000) });
+      const r = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/manifest`, { ...sig, signal: AbortSignal.timeout(30000) });
       if (!r.ok) return;
       const { manifest = [] } = await r.json();
       // The version's asset count comes from the album table (instant); the manifest

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type AssetRef = {
   };
 };
 
-/** POST /sidecar/api/v1/invites/redeem — consume a share link as a household. */
+/** POST /immich-shared-albums/api/v1/invites/redeem — consume a share link as a household. */
 export type RedeemRequest = {
   shareKey: string;         // the Immich share-link key IS the capability
   household: Household;     // joiner introduces itself; key pinned on success
@@ -47,34 +47,34 @@ export type RedeemResponse = {
   mappingId: string;        // quote this in refs/activity/manifest calls
 };
 
-/** POST /sidecar/api/v1/albums/:mappingId/refs — offer new refs to a peer. */
+/** POST /immich-shared-albums/api/v1/albums/:mappingId/refs — offer new refs to a peer. */
 export type RefsUpdate = { add: AssetRef[] };
 /** Partial success: the sender re-offers only the failed checksums next cycle. */
 export type RefsResult = { ok: boolean; failed: string[] };
 
-/** GET /sidecar/api/v1/albums/:mappingId/version — cheap change handshake.
+/** GET /immich-shared-albums/api/v1/albums/:mappingId/version — cheap change handshake.
  *  Returns the album's updatedAt; members only pull the manifest on mismatch,
  *  so an idle album costs one tiny request per cycle instead of a full scan. */
 export type VersionResponse = { version: string };
 
-/** GET /sidecar/api/v1/albums/:mappingId/manifest — reconciliation sweep.
+/** GET /immich-shared-albums/api/v1/albums/:mappingId/manifest — reconciliation sweep.
  *  Members re-pull this each poll and materialise anything missing (heals
  *  refs missed at join time). Human-owned photos only — proxies are excluded
  *  so reconciliation can never echo a household's own photos back. */
 export type ManifestResponse = { manifest: AssetRef[] };
 
-/** POST /sidecar/api/v1/albums/:mappingId/activity — two-way comment sync. */
+/** POST /immich-shared-albums/api/v1/albums/:mappingId/activity — two-way comment sync. */
 export type ActivityUpdate = {
   comments: { id: string; comment: string; author: string; authorUserId: string }[];
 };
 
-/** POST /sidecar/api/v1/albums/:albumId/nudge — "this album moved, pull now".
+/** POST /immich-shared-albums/api/v1/albums/:albumId/nudge — "this album moved, pull now".
  *  A latency hint, not a data channel: receivers run their normal handshake+pull
  *  immediately instead of at the next tick. Lost nudges cost nothing (fail-open). */
 export type NudgeRequest = { album: string };
 
 /**
  * Byte endpoints (signed GETs — signature over the path parameter):
- *  /sidecar/api/v1/assets/:id/preview   — ~1440px preview of an origin asset
- *  /sidecar/api/v1/users/:id/avatar     — contributor profile image
+ *  /immich-shared-albums/api/v1/assets/:id/preview   — ~1440px preview of an origin asset
+ *  /immich-shared-albums/api/v1/users/:id/avatar     — contributor profile image
  */

--- a/src/web/banner.ts
+++ b/src/web/banner.ts
@@ -1,11 +1,16 @@
 /**
  * web/banner.ts — loads banner.js once at startup. It is both served at
- * /sidecar/banner.js and injected into an origin's /share pages (see passthrough.ts),
+ * <prefix>/banner.js and injected into an origin's /share pages (see passthrough.ts),
  * so it lives in one place. Empty string if not bundled (share pages serve un-injected).
  */
 import fs from 'node:fs';
-import { log } from '../config.ts';
+import { log, ROUTE_PREFIX } from '../config.ts';
 
 export let BANNER_JS = '';
-try { BANNER_JS = fs.readFileSync(new URL('./banner/banner.js', import.meta.url), 'utf8'); }
+try {
+  // banner.js hardcodes the default prefix so it stays valid standalone (see banner/preview.html);
+  // rewriting it here keeps config.ROUTE_PREFIX the single source of truth.
+  BANNER_JS = fs.readFileSync(new URL('./banner/banner.js', import.meta.url), 'utf8')
+    .replaceAll('/immich-shared-albums/', `${ROUTE_PREFIX}/`);
+}
 catch { log('banner.js not bundled — share pages will be served un-injected'); }

--- a/src/web/banner/banner.js
+++ b/src/web/banner/banner.js
@@ -140,7 +140,7 @@
       const canProbe = (sch) => !(location.protocol === 'https:' && sch === 'http');
       const probeOk = async (sch) => {
         try {
-          const r = await fetch(`${sch}://${domain}/sidecar/health`, { signal: AbortSignal.timeout(5000) });
+          const r = await fetch(`${sch}://${domain}/immich-shared-albums/health`, { signal: AbortSignal.timeout(5000) });
           return r.ok && (await r.json()).ok === true;
         } catch (_) { return false; }
       };
@@ -163,7 +163,7 @@
       localStorage.setItem('isa-my-server', raw);
       // Invite payload rides the fragment: never appears in any server's logs.
       const payload = encodeURIComponent(JSON.stringify({ v: 1, host: location.host, scheme: location.protocol.replace(':',''), key: SHARE_KEY }));
-      location.href = `${scheme}://${domain}/sidecar/accept#${payload}`;
+      location.href = `${scheme}://${domain}/immich-shared-albums/accept#${payload}`;
     });
 
     document.body.appendChild(host);

--- a/src/web/http-router.md
+++ b/src/web/http-router.md
@@ -7,7 +7,7 @@ The single process's one HTTP entry point and the HTML it serves.
 | `server.ts` | The router: a thin dispatch table mapping each path to a handler. Exports `server`; `index.ts` calls `.listen()`. |
 | `passthrough.ts` | The transparent fall-through proxy to Immich for anything that isn't a sidecar route (share pages, SPA bundles, `/api`), with join-banner injection on `/share/*` HTML. Streams both directions — uploads must never be buffered here. |
 | `upgrade.ts` | Websockets and any other protocol upgrade, piped at the socket level. Separate from `passthrough.ts` because `fetch()` cannot carry an upgrade at all: these never reach the router, arriving on the server's `upgrade` event instead. Two transports, two files. |
-| `banner.ts` | Loads `banner/banner.js` once — it's both served at `/sidecar/banner.js` and injected by `passthrough.ts`. |
+| `banner.ts` | Loads `banner/banner.js` once — it's both served at `/immich-shared-albums/banner.js` and injected by `passthrough.ts`. |
 | `pages.ts` | The two HTML surfaces: the admin **PANEL** (join box + status) and the **ACCEPT_PAGE** that turns a share link into a join (detects sign-in, prompts for an album password when the origin asks, then deeplinks into the app once the album has filled). |
 | `auth.ts` | Who is calling a human-facing route. Forwards the caller's own Immich credentials (session cookie or API key) to Immich's `/users/me` and believes the answer. The sidecar has no accounts of its own and must never invent any. |
 | `banner/` | `banner.js` — injected into an origin's `/share/*` page so a visitor can type their own server address and join. `preview.html` is a local harness for iterating on it. |
@@ -19,9 +19,9 @@ There are three tiers, and each is enforced server-side:
 
 | Tier | Routes | Gate |
 |---|---|---|
-| Public | `/sidecar/health`, `/sidecar/banner.js`, `/sidecar/accept` | none — liveness, a script, and a static page. `health` returns `{ok:true}` and nothing else, because the banner probes it cross-origin to discover a sidecar. |
-| Signed-in human | `/sidecar/join`, `/sidecar/leave`, the panel | `auth.ts` against the caller's Immich session. `join` takes the account from the **session**, not the request body; naming a different user requires admin. `leave` and the panel require admin. |
-| Peer | everything under `/sidecar/api/v1/*` | ed25519 signature (`peers.callingPeer`) **and**, for byte routes, entitlement (`p2p/entitlement`). |
+| Public | `/immich-shared-albums/health`, `/immich-shared-albums/banner.js`, `/immich-shared-albums/accept` | none — liveness, a script, and a static page. `health` returns `{ok:true}` and nothing else, because the banner probes it cross-origin to discover a sidecar. |
+| Signed-in human | `/immich-shared-albums/join`, `/immich-shared-albums/leave`, the panel | `auth.ts` against the caller's Immich session. `join` takes the account from the **session**, not the request body; naming a different user requires admin. `leave` and the panel require admin. |
+| Peer | everything under `/immich-shared-albums/api/v1/*` | ed25519 signature (`peers.callingPeer`) **and**, for byte routes, entitlement (`p2p/entitlement`). |
 
 The accept page's client-side `whoami` is UX only — it tells someone to sign in before
 they fill a form. The server never trusts it.
@@ -50,6 +50,6 @@ that is where the byte interceptors live. It also removes every same-origin ques
 stroke: banner injection, byte interception and the accept page's session cookie all just
 work, because there genuinely is one origin.
 
-**Path-routed (Immich stays the front).** Route only `/sidecar/*`, `/share/*` and the three
+**Path-routed (Immich stays the front).** Route only `/immich-shared-albums/*`, `/share/*` and the three
 GET byte paths to the sidecar, ahead of the catch-all. More proxy config, and the ordering
 matters, but Immich's traffic never traverses the sidecar. See [deploy/](../../deploy/).

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -2,12 +2,12 @@
  * web/pages.ts — the two HTML surfaces the sidecar serves: the admin PANEL and the
  * signed-out/signed-in ACCEPT_PAGE that turns a share link into a join.
  *
- * Both talk to /sidecar/join, which authenticates the caller's Immich session server-side
+ * Both talk to <prefix>/join, which authenticates the caller's Immich session server-side
  * (web/auth.ts). The client-side checks here are for UX only — telling someone they need
  * to sign in before they fill a form, and asking for an album password when the origin
  * says one is required. Nothing here is a security control.
  */
-import { CFG } from '../config.ts';
+import { CFG, ROUTE_PREFIX } from '../config.ts';
 import { state } from '../state.ts';
 
 export const PANEL = () => `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -39,7 +39,7 @@ export const PANEL = () => `<!doctype html><meta charset="utf-8"><meta name="vie
  const el=document.getElementById('msg'),pw=document.getElementById('pw');el.textContent='Joining…';
  const payload={url:document.getElementById('u').value};
  if(pw.style.display!=='none'&&pw.value)payload.password=pw.value;
- const r=await fetch('join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+ const r=await fetch('${ROUTE_PREFIX}/join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
  const d=await r.json().catch(()=>({error:'failed'}));
  if(d&&d.needsAuth){location.href=d.signInUrl||'/auth/login';return}
  if(d&&d.passwordRequired){pw.style.display='block';pw.focus();
@@ -98,7 +98,7 @@ document.getElementById('go').onclick=async()=>{
  const pw=document.getElementById('pw');
  const body={url:scheme+'://'+frag.host+'/share/'+frag.key,forUserId:ME.id};
  if(pw.style.display!=='none'&&pw.value)body.password=pw.value;
- const r=await fetch('/sidecar/join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+ const r=await fetch('${ROUTE_PREFIX}/join',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
  const d=await r.json().catch(()=>({error:'failed'}));
  var reset=function(){go.disabled=false;go.classList.remove('busy');go.textContent='Accept & join';};
  // the session went away between page load and click — send them to sign in and back

--- a/src/web/passthrough.ts
+++ b/src/web/passthrough.ts
@@ -12,7 +12,7 @@
  * /share HTML is buffered, because injecting the banner means rewriting the document.
  */
 import { Readable } from 'node:stream';
-import { CFG } from '../config.ts';
+import { CFG, ROUTE_PREFIX } from '../config.ts';
 import { BANNER_JS } from './banner.ts';
 
 export async function proxyToImmich(req, res, pathname: string): Promise<void> {
@@ -37,8 +37,8 @@ export async function proxyToImmich(req, res, pathname: string): Promise<void> {
   const ct = up.headers.get('content-type') || '';
   if (req.method === 'GET' && pathname.startsWith('/share/') && ct.includes('text/html') && BANNER_JS) {
     let html = Buffer.from(await up.arrayBuffer()).toString();
-    html = html.includes('</body>') ? html.replace('</body>', '<script src="/sidecar/banner.js" defer></script></body>')
-                                    : html + '<script src="/sidecar/banner.js" defer></script>';
+    html = html.includes('</body>') ? html.replace('</body>', `<script src="${ROUTE_PREFIX}/banner.js" defer></script></body>`)
+                                    : html + `<script src="${ROUTE_PREFIX}/banner.js" defer></script>`;
     res.writeHead(up.status, outHeaders); res.end(html); return;
   }
   res.writeHead(up.status, outHeaders);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -14,7 +14,7 @@
  */
 import http from 'node:http';
 import { Readable } from 'node:stream';
-import { CFG, log } from '../config.ts';
+import { CFG, log, ROUTE_PREFIX } from '../config.ts';
 import { state } from '../state.ts';
 import { immich } from '../immich/client.ts';
 import { verify } from '../peers.ts';
@@ -55,10 +55,11 @@ export const server = http.createServer(async (req, res) => {
   const send = (code, obj) => { res.writeHead(code, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(obj)); };
   try {
     const u = new URL(req.url, 'http://x');
+    const path = u.pathname;
     let m;
     // Peer-facing avatar read. Signed like every other peer route — a bare public key is
     // not a credential, it is published in every redeem response.
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/users\/([^/]+)\/avatar$/))) {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/users\/([^/]+)\/avatar$/))) {
       if (req.method !== 'GET') return send(405, { error: 'method not allowed' });
       const peerKey = req.headers['x-isa-key'] as string;
       const peer = state.peers.find(pp => pp.pub === peerKey);
@@ -72,10 +73,10 @@ export const server = http.createServer(async (req, res) => {
         return res.end(Buffer.from(await av.arrayBuffer()));
       } catch { return send(404, { error: 'no avatar' }); }
     }
-    if (u.pathname === '/sidecar/banner.js') {
+    if (path === `${ROUTE_PREFIX}/banner.js`) {
       res.writeHead(200, { 'Content-Type': 'application/javascript' }); return res.end(BANNER_JS);
     }
-    if (u.pathname === '/sidecar/accept') {
+    if (path === `${ROUTE_PREFIX}/accept`) {
       res.writeHead(200, { 'Content-Type': 'text/html' }); return res.end(ACCEPT_PAGE());
     }
     // Byte interceptors (hotlink model): the app's own asset URLs are served with true
@@ -84,13 +85,13 @@ export const server = http.createServer(async (req, res) => {
     if (assetHit && req.method === 'GET' && await serveInterceptedBytes(req, res, assetHit[1], assetHit[2])) return;
     // Everything that isn't a sidecar route -> transparent proxy to Immich (banner-injected
     // on /share pages). Streams both ways: uploads must not be buffered here.
-    if (!u.pathname.startsWith('/sidecar')) return proxyToImmich(req, res, u.pathname);
+    if (!path.startsWith(ROUTE_PREFIX)) return proxyToImmich(req, res, u.pathname);
 
     // ---- the sidecar's own routes: cap the body, then authorise ----
     const body = await readCappedBody(req);
     if (body === null) return send(413, { error: `request body exceeds ${CFG.maxBodyKb}KB` });
 
-    if (u.pathname === '/sidecar/' || u.pathname === '/sidecar') {
+    if (path === `${ROUTE_PREFIX}/` || path === ROUTE_PREFIX) {
       const caller = await callerIdentity(req);
       if (!caller?.isAdmin) {
         res.writeHead(caller ? 403 : 401, { 'Content-Type': 'text/html' });
@@ -98,7 +99,7 @@ export const server = http.createServer(async (req, res) => {
       }
       res.writeHead(200, { 'Content-Type': 'text/html' }); return res.end(PANEL());
     }
-    if (u.pathname === '/sidecar/join' && req.method === 'POST') {
+    if (path === `${ROUTE_PREFIX}/join` && req.method === 'POST') {
       // The account being joined is the SIGNED-IN one. The request body may name a
       // different user only if the caller is an admin acting on their behalf.
       const caller = await callerIdentity(req);
@@ -115,32 +116,32 @@ export const server = http.createServer(async (req, res) => {
           e.passwordRequired ? { error: e.message, passwordRequired: true } : { error: e.message });
       }
     }
-    if (u.pathname === '/sidecar/leave' && req.method === 'POST') {
+    if (path === `${ROUTE_PREFIX}/leave` && req.method === 'POST') {
       const caller = await callerIdentity(req);
       if (!caller) return send(401, signInRequired('leave a shared album'));
       if (!caller.isAdmin) return send(403, { error: 'only an admin can remove a shared album' });
       try { const b = JSON.parse(body); return send(200, await leaveAlbum(b.mappingId)); }
       catch (e) { return send(400, { error: e.message }); }
     }
-    if (u.pathname === '/sidecar/api/v1/invites/redeem' && req.method === 'POST') {
+    if (path === `${ROUTE_PREFIX}/api/v1/invites/redeem` && req.method === 'POST') {
       const [code, obj] = await handleRedeem(req, body); return send(code, obj);
     }
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/albums\/([^/]+)\/activity$/)) && req.method === 'POST') {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/activity$/)) && req.method === 'POST') {
       const [code, obj] = await handleActivity(req, body, m[1]); return send(code, obj);
     }
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/albums\/([^/]+)\/refs$/)) && req.method === 'POST') {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/refs$/)) && req.method === 'POST') {
       const [code, obj] = await handleRefs(req, body, m[1]); return send(code, obj);
     }
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/albums\/([^/]+)\/version$/)) && req.method === 'GET') {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/version$/)) && req.method === 'GET') {
       const [code, obj] = await handleVersion(req, m[1]); return send(code, obj);
     }
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/albums\/([^/]+)\/manifest$/)) && req.method === 'GET') {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/manifest$/)) && req.method === 'GET') {
       const [code, obj] = await handleManifest(req, m[1]); return send(code, obj);
     }
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/albums\/([^/]+)\/comments$/)) && req.method === 'GET') {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/comments$/)) && req.method === 'GET') {
       const [code, obj] = await handleComments(req, m[1]); return send(code, obj);
     }
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/albums\/([^/]+)\/nudge$/)) && req.method === 'POST') {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/nudge$/)) && req.method === 'POST') {
       const [code, obj] = await handleNudge(req, body, m[1]); return send(code, obj);
     }
     const streamOut = (out) => { // stream byte responses through — never buffer (Pi-friendly)
@@ -152,13 +153,13 @@ export const server = http.createServer(async (req, res) => {
       res.writeHead(out.status || 200, headers);
       Readable.fromWeb(out.body).pipe(res);
     };
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/assets\/([^/]+)\/original$/))) {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/assets\/([^/]+)\/original$/))) {
       return streamOut(await handleOriginal(req, m[1]));
     }
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/assets\/([^/]+)\/playback$/))) {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/assets\/([^/]+)\/playback$/))) {
       return streamOut(await handlePlayback(req, m[1]));
     }
-    if ((m = u.pathname.match(/^\/sidecar\/api\/v1\/assets\/([^/]+)\/preview$/))) {
+    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/assets\/([^/]+)\/preview$/))) {
       const out = await handlePreview(req, m[1]);
       if (Array.isArray(out)) return send(out[0], out[1]);
       res.writeHead(200, { 'Content-Type': out.headers.get('content-type') || 'image/jpeg' });
@@ -166,7 +167,7 @@ export const server = http.createServer(async (req, res) => {
     }
     // Liveness only. The join banner probes this cross-origin to discover a sidecar, so
     // it stays open — which is exactly why it must not name the household or count peers.
-    if (u.pathname === '/sidecar/health') {
+    if (path === `${ROUTE_PREFIX}/health`) {
       res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
       return res.end(JSON.stringify({ ok: true }));
     }

--- a/src/web/upgrade.ts
+++ b/src/web/upgrade.ts
@@ -13,7 +13,7 @@
  * regardless and why the gap went unnoticed for so long.
  */
 import net from 'node:net';
-import { CFG, log } from '../config.ts';
+import { CFG, log, ROUTE_PREFIX } from '../config.ts';
 
 /**
  * Pipe an upgrade straight through to Immich.
@@ -24,8 +24,8 @@ import { CFG, log } from '../config.ts';
  * dropping it truncates the first frame.
  */
 export function proxyUpgrade(req, socket, head: Buffer): void {
-  // nothing under /sidecar speaks a websocket — refuse rather than open a socket to Immich
-  if ((req.url || '').startsWith('/sidecar')) { socket.destroy(); return; }
+  // nothing under our own prefix speaks a websocket — refuse rather than open a socket
+  if ((req.url || '').startsWith(ROUTE_PREFIX)) { socket.destroy(); return; }
   let target: URL;
   try { target = new URL(CFG.immichUrl); } catch { socket.destroy(); return; }
 


### PR DESCRIPTION
**BREAKING.** The URL prefix moves from `/sidecar/*` to `/immich-shared-albums/*` with **no
compatibility shim**. Both peers must run a version that agrees on it, and every reverse-proxy
route needs updating.

## Why

`sidecar` is a generic term staking a claim on the Immich origin that another Immich addon could
reasonably want. The new prefix matches the project name and can't collide. Doing it now, while
the install base is small enough that a clean break beats carrying a second route surface
indefinitely.

An inbound shim *was* written and then deliberately removed — it only smoothed an origin-first
rollout while still requiring both sides to upgrade, so it bought a half-working state rather
than compatibility.

## One source of truth

`ROUTE_PREFIX` in `config.ts`. Routes, outbound peer URLs, the injected `<script src>` and both
HTML pages all derive from it. `banner.js` keeps a literal so it stays valid standalone for
`banner/preview.html`, and `banner.ts` rewrites it from the constant at load — so the two can't
drift.

## A latent bug the rename surfaced

The panel's join form used a **relative** `fetch('join')`. That resolves correctly at
`/sidecar/`, but at `/sidecar` with no trailing slash it would have hit `/join` and 404'd. Both
pages now use absolute paths, and the router matches the prefix with *and* without a trailing
slash — so `/immich-shared-albums` works as well as `/immich-shared-albums/`.

## Verification

93 checks green on the mock rig. New assertions cover:

- the old prefix no longer reaches our handler — asserted on the **response body**, not a status
  code, because without a shim `/sidecar/*` falls through to Immich and gets served its SPA shell
  (my first attempt asserted `404` and would have failed for the wrong reason)
- the panel answers, and stays auth-gated, on both slash forms
- the served `banner.js` carries no stale `/sidecar/` paths

`tsc` clean. Both Caddy configs in `deploy/` re-validated with `caddy validate` after the rename.

## Upgrade note for anyone running this

Update your reverse-proxy route from `/sidecar/*` to `/immich-shared-albums/*`, and make sure
every household upgrades — a mismatched pair will not sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)