### PR TITLE
feat: share albums by inviting a household in Immich's own picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Every method needs Docker, an admin API key, and **a reverse proxy in front of I
 
 ## Versioning
 
-Semver with a sync-contract policy (a MAJOR bump means older peers can't sync with you). Versions are set automatically from commits, every change is gated on the e2e suite (86 checks plus a browser lane, 18 of them security regressions), and a weekly job runs against the latest Immich release to catch breakage early. See [CHANGELOG.md](./CHANGELOG.md).
+Semver with a sync-contract policy (a MAJOR bump means older peers can't sync with you). Versions are set automatically from commits, every change is gated on the e2e suite (100 checks plus a browser lane, 18 of them security regressions), and a weekly job runs against the latest Immich release to catch breakage early. See [CHANGELOG.md](./CHANGELOG.md).
 
 ## Support
 

--- a/demo/e2e/e2e-test.mjs
+++ b/demo/e2e/e2e-test.mjs
@@ -317,9 +317,16 @@ console.log('— stage: share link created before any photos (empty album) still
   const meB5 = (await api(B, BKEY, '/users/me')).id;
   const join5 = await (await fetch(`${BS}/immich-shared-albums/join`, jAuth({ url: `${ORIGIN_SIDECAR}/share/${share5}`, forUserId: meB5 }, BKEY))).json();
   check('empty-album join succeeds', !!join5.albumId, JSON.stringify(join5).slice(0, 100));
-  const bu5 = (await api(B, BKEY, '/admin/users')).filter(u => u.email.endsWith('@sidecar.local'));
+  // Assert the property directly, via the mirror's actual owner. The old form asserted that no
+  // household-named utility user existed anywhere, which stopped being a valid proxy once peer
+  // stand-ins arrived — a household-named user is now expected and correct.
+  const mirror5 = (await api(B, BKEY, '/albums')).find(a => a.albumName === 'born empty');
+  const owner5 = mirror5
+    ? ((await api(B, BKEY, `/albums/${mirror5.id}?withoutAssets=true`)).albumUsers || [])
+        .find(au => au.role === 'owner')?.user?.name
+    : undefined;
   check('empty-album mirror owner named after the sharer, not the household',
-        !bu5.some(u => u.name.startsWith('Mock household')), bu5.map(u => u.name).join(', '));
+        !!owner5 && !owner5.startsWith('Mock household'), `owner=${owner5}`);
 }
 
 console.log('— stage: view-only share link (allowUpload off) rejects cross-server uploads');
@@ -475,6 +482,75 @@ if (DKEY && dMirror) check('no ping-pong on D', (await albumAssets(D, DKEY, dMir
 // Websockets: the sidecar must be able to front Immich on its own, which means carrying
 // protocol upgrades. Without this, live web updates silently die in single-front setups —
 // invisible to the mobile apps, which is exactly how it went unnoticed before.
+// Native invitations: sharing an album by adding a peer's stand-in user in Immich's OWN
+// picker, with no share link involved. The origin detects it by listing albums AS the stand-in
+// (which is why this works for albums a non-admin owns), and the member discovers it by polling.
+console.log('— stage: native album invitations (no share link)');
+{
+  const originPeers = readSidecarKv('household-c/c-sidecar', 'peers');
+  const bPeer = (originPeers || []).find(p => (p.name || '').includes('(B)'));
+  if (!bPeer) console.log('  (skipped: cannot read the origin\'s peer record for B)');
+  else {
+    const bKeys = readSidecarKv('b-sidecar', 'keys');
+    const signAsB = (v) => crypto.sign(null, Buffer.from(v),
+      crypto.createPrivateKey({ key: Buffer.from(bKeys.priv, 'base64url'), format: 'der', type: 'pkcs8' })).toString('base64url');
+    const marker = (await api(A, AKEY, '/admin/users')).find(u => u.name === `${bPeer.name} (via shared albums)`);
+    check('origin auto-created a stand-in user for the peer household', !!marker,
+          marker ? marker.email : 'not found');
+
+    if (marker) {
+      const invAlb = (await api(A, AKEY, '/albums', j({ albumName: 'natively invited album' }))).id;
+      const invAsset = await upload(A, AKEY, 'invited.jpg', `inv${Date.now() % 10000}`, '2026-05-01T09:00:00.000Z');
+      await ensurePreviews(A, AKEY, [invAsset]);
+      await api(A, AKEY, `/albums/${invAlb}/assets`, { ...j({ ids: [invAsset] }), method: 'PUT' });
+      // exactly what a human does in the picker
+      await api(A, AKEY, `/albums/${invAlb}/users`,
+        { ...j({ albumUsers: [{ userId: marker.id, role: 'editor' }] }), method: 'PUT' });
+      // 200 is not proof — Immich silently ignores some adds, so read it back
+      const back = await api(A, AKEY, `/albums/${invAlb}?withoutAssets=true`);
+      check('stand-in is really a member after the invite',
+            (back.albumUsers || []).some(au => au.user?.id === marker.id && au.role === 'editor'));
+
+      const mirrored = await until(async () => {
+        const al = await api(B, BKEY, '/albums');
+        return al.find(a => a.albumName === 'natively invited album') || null;
+      }, 150000);
+      check('member mirrors an invited album automatically, with no link', !!mirrored,
+            mirrored ? '' : 'timed out');
+      if (mirrored) {
+        const arrived = await until(async () => {
+          const x = await albumAssets(B, BKEY, mirrored.id); return x.length >= 1 ? x : null;
+        }, 150000);
+        check('invited album\'s photo materialises on the member', !!arrived,
+              arrived ? '' : 'timed out');
+      }
+
+      // Withdrawal. Asserted against the /invitations CONTRACT rather than state.db: the
+      // running process is the authoritative view, and the runner deletes state.db from under
+      // a live sidecar during purge, so a host-side file read is not a reliable oracle here.
+      const invitations = async () => {
+        const r = await fetch(`${ORIGIN_DIRECT}/immich-shared-albums/api/v1/invitations`,
+          { headers: { 'x-isa-key': bKeys.pub, 'x-isa-sig': signAsB('invitations') } });
+        return r.ok ? ((await r.json()).invitations || []) : null;
+      };
+      const listedBefore = await invitations();
+      check('the invited album is offered on /invitations',
+            !!listedBefore?.some(i => i.album?.name === 'natively invited album'),
+            JSON.stringify(listedBefore?.map(i => i.album?.name)));
+      check('/invitations offers ONLY invitation-shaped shares, never link ones',
+            !!listedBefore && listedBefore.every(i => i.album?.name === 'natively invited album'),
+            `${listedBefore?.length} entries`);
+
+      await fetch(`${A}/api/albums/${invAlb}/user/${marker.id}`, { method: 'DELETE', headers: { 'x-api-key': AKEY } });
+      const retired = await until(async () => {
+        const list = await invitations();
+        return list && !list.some(i => i.album?.name === 'natively invited album') ? true : null;
+      }, 90000);
+      check('withdrawing the invite stops it being offered', !!retired, retired ? '' : 'still offered');
+    }
+  }
+}
+
 // The route prefix moved from /sidecar to /immich-shared-albums — a clean break, no shim, so
 // both peers must agree on it. Pins the panel answering WITHOUT a trailing slash, and that
 // nothing still emits the old prefix.

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -85,6 +85,11 @@ ordinary data we planted, or a web page we serve.
   album members see them. Joins are per-user: the accept page reads the
   visitor's own Immich session and adds exactly that account; a second user
   joining the same link is added to the existing mirror.
+- **native invitations** — a peer household gets a local stand-in user, so adding it to an
+  album in Immich's own picker shares that album cross-server and removing it revokes. Detected
+  by listing albums *as the stand-in* (the admin key only sees its own albums, which is why
+  link-based sharing is broken for non-admins). Members **pull** invitations rather than being
+  pushed them, so a household with no inbound reachability still works. See `sync/invites.ts`.
 - **web** — the panel, the share-page join banner (shadow-DOM, fails silent),
   the accept page, and a transparent proxy for share-page SPA assets when the
   sidecar fronts Immich directly. All fail open.

--- a/src/p2p/join.ts
+++ b/src/p2p/join.ts
@@ -3,14 +3,10 @@
  * pins the peer, provisions the host utility user, creates the local mirror album, and
  * kicks off the first reconcile. Idempotent: re-joining just adds the user to the mirror.
  */
-import crypto from 'node:crypto';
 import { CFG, SIDECAR_VERSION, log, ROUTE_PREFIX } from '../config.ts';
 import { state, save } from '../state.ts';
 import { signedFetch, assertPeerUrlAllowed } from '../peers.ts';
-import { immichJson, jsonBody } from '../immich/client.ts';
-import { ensureUtilityUser, syncAvatar, slugify } from '../immich/contributors.ts';
-import { reconcileMapping } from '../sync/engine.ts';
-import { pullCanonicalComments } from '../sync/comments.ts';
+import { ensureMirror, fillMirrorInBackground } from './mirror.ts';
 
 export async function join(shareUrl, forUserId, password?: string) {
   const m = String(shareUrl ?? '').trim().match(/^(https?:\/\/[^/]+)\/share\/([A-Za-z0-9_-]+)/);
@@ -35,56 +31,20 @@ export async function join(shareUrl, forUserId, password?: string) {
   if (!state.peers.some(p => p.pub === res.household.publicKey)) {
     state.peers.push({ pub: res.household.publicKey, url: res.household.url, name: res.household.name, version: res.version });
   }
-  const host = await ensureUtilityUser(res.albumOwner?.displayName || res.household.name);
-  await syncAvatar(host, res.household.url, res.albumOwner?.originUserId);
-  const addMembers = async (albumId) => {
-    let members = (await immichJson('/admin/users')).filter(u => !u.email.endsWith('@sidecar.local'));
-    if (forUserId) members = members.filter(u => u.id === forUserId); // per-user join: only the receiving user
-    const alb = await immichJson(`/albums/${albumId}`, {}, host.key);
-    const already = new Set((alb.albumUsers || []).map(au => au.user?.id));
-    members = members.filter(u => !already.has(u.id));
-    if (members.length) await immichJson(`/albums/${albumId}/users`,
-      { ...jsonBody({ albumUsers: members.map(u => ({ userId: u.id, role: 'editor' })) }), method: 'PUT' }, host.key);
-    return members.length;
-  };
-  // same remote album already mirrored here -> just add this user to the existing mirror
-  const existing = state.mappings.find(mp => mp.role === 'member' && mp.peer === res.household.publicKey
-    && mp.remoteAlbumId === res.album.id && !mp.dead);
-  if (existing) {
-    const n = await addMembers(existing.albumId);
-    log(`re-join: added ${n} member(s) to existing mirror "${existing.albumName}"`);
-    return { album: existing.albumName, albumId: existing.albumId, photos: res.manifest.length, from: res.household.name, permissions: res.album.permissions, mappingId: existing.id };
-  }
-  // a freshly-minted utility user/key can 500 its first writes on cold instances — retry
-  // with backoff and log each attempt so failures are diagnosable from CI logs
-  let mirror;
-  for (let attempt = 1; ; attempt++) {
-    try { mirror = await immichJson('/albums', jsonBody({ albumName: CFG.template.replace('{name}', res.album.name) }), host.key); break; }
-    catch (e) {
-      log(`mirror album create attempt ${attempt} failed: ${e.message}`);
-      if (attempt >= 6) throw e;
-      await new Promise(r => setTimeout(r, attempt * 2000));
-    }
-  }
-  try {
-    const n = await addMembers(mirror.id);
-    log(`mirror shared with ${forUserId ? 'one user (per-user join)' : n + ' household member(s)'}`);
-  } catch (e) { log(`could not add local members to mirror: ${e.message}`); }
-  const mappingId = crypto.randomUUID();
-  state.mappings.push({ id: mappingId, role: 'member', albumId: mirror.id, albumName: mirror.albumName,
-    peer: res.household.publicKey, remoteAlbumId: res.album.id, remoteMappingId: res.mappingId,
-    permissions: res.album.permissions, adminSlug: slugify(res.albumOwner?.displayName || res.household.name) });
-  save();
-  log(`joined "${res.album.name}" from "${res.household.name}" (${res.manifest.length} photos)`);
-  // the join answers immediately — materialisation happens right behind it via the
-  // reconciler (a big album or video transcode must not hold the accept page hostage)
-  const newMapping = state.mappings.find(mp => mp.id === mappingId);
+  const { mapping, created } = await ensureMirror({
+    peer: state.peers.find(pe => pe.pub === res.household.publicKey),
+    album: { id: res.album.id, name: res.album.name },
+    permissions: res.album.permissions,
+    albumOwnerName: res.albumOwner?.displayName,
+    albumOwnerId: res.albumOwner?.originUserId,
+    remoteMappingId: res.mappingId,
+    forUserId,
+  });
+  log(created
+    ? `joined "${res.album.name}" from "${res.household.name}" (${res.manifest.length} photos)`
+    : `re-join: "${mapping.albumName}" already mirrored from "${res.household.name}"`);
   const peerRec = state.peers.find(pe => pe.pub === res.household.publicKey);
-  if (newMapping && peerRec) {
-    (async () => {
-      try { await reconcileMapping(newMapping, peerRec); await pullCanonicalComments(newMapping, peerRec); }
-      catch (e) { log(`post-join sync error: ${e.message} — the loops will retry`); }
-    })();
-  }
-  return { album: mirror.albumName, albumId: mirror.id, photos: res.manifest.length, from: res.household.name, permissions: res.album.permissions, mappingId };
+  if (created && peerRec) fillMirrorInBackground(mapping, peerRec);
+  return { album: mapping.albumName, albumId: mapping.albumId, photos: res.manifest.length,
+           from: res.household.name, permissions: res.album.permissions, mappingId: mapping.id };
 }

--- a/src/p2p/mirror.ts
+++ b/src/p2p/mirror.ts
@@ -1,0 +1,95 @@
+/**
+ * p2p/mirror.ts — creating the local mirror of a remote album.
+ *
+ * Extracted from join.ts because there are now two ways to acquire an album and only one way to
+ * mirror it: redeeming a share link (join.ts), and being invited in the origin's own Immich
+ * picker (sync/invites.ts). The mirror itself is identical either way — a utility user owns it
+ * so it stays out of local timelines, local humans are added as editors, and the reconciler
+ * fills it in behind the answer.
+ */
+import crypto from 'node:crypto';
+import { CFG, log } from '../config.ts';
+import type { Mapping, Peer } from '../store.ts';
+import { state, save } from '../state.ts';
+import { immichJson, jsonBody } from '../immich/client.ts';
+import { ensureUtilityUser, syncAvatar, slugify } from '../immich/contributors.ts';
+import { reconcileMapping } from '../sync/engine.ts';
+import { pullCanonicalComments } from '../sync/comments.ts';
+
+export type MirrorRequest = {
+  peer: Peer;
+  album: { id: string; name: string };
+  permissions: 'view' | 'contribute';
+  /** Display name of the album's owner on the origin; falls back to the household name. */
+  albumOwnerName?: string;
+  /** Origin user id, for syncing that person's avatar onto the local utility user. */
+  albumOwnerId?: string;
+  /** The origin's own mapping id, when known (link joins carry it; invitations do not). */
+  remoteMappingId?: string;
+  /** Restrict the mirror to one local user (per-user joins). Omit to add every human. */
+  forUserId?: string;
+};
+
+/**
+ * Ensure a mirror exists for `album` from `peer`. Idempotent: if one already exists this just
+ * makes sure the requested local user is a member, matching the re-join behaviour.
+ */
+export async function ensureMirror(req: MirrorRequest): Promise<{ mapping: Mapping; created: boolean }> {
+  const { peer, album, permissions, forUserId } = req;
+  const ownerName = req.albumOwnerName || peer.name;
+  const host = await ensureUtilityUser(ownerName);
+  await syncAvatar(host, peer.url, req.albumOwnerId);
+
+  const addMembers = async (albumId: string) => {
+    let members = (await immichJson('/admin/users')).filter((u) => !u.email.endsWith('@sidecar.local'));
+    if (forUserId) members = members.filter((u) => u.id === forUserId); // per-user join
+    const alb = await immichJson(`/albums/${albumId}`, {}, host.key);
+    const already = new Set((alb.albumUsers || []).map((au) => au.user?.id));
+    members = members.filter((u) => !already.has(u.id));
+    if (members.length) await immichJson(`/albums/${albumId}/users`,
+      { ...jsonBody({ albumUsers: members.map((u) => ({ userId: u.id, role: 'editor' })) }), method: 'PUT' }, host.key);
+    return members.length;
+  };
+
+  const existing = state.mappings.find(mp => mp.role === 'member' && mp.peer === peer.pub
+    && mp.remoteAlbumId === album.id && !mp.dead);
+  if (existing) {
+    const n = await addMembers(existing.albumId);
+    if (n) log(`added ${n} member(s) to existing mirror "${existing.albumName}"`);
+    return { mapping: existing, created: false };
+  }
+
+  // a freshly-minted utility user/key can 500 its first writes on cold instances — retry
+  // with backoff and log each attempt so failures are diagnosable from CI logs
+  let mirror;
+  for (let attempt = 1; ; attempt++) {
+    try { mirror = await immichJson('/albums', jsonBody({ albumName: CFG.template.replace('{name}', album.name) }), host.key); break; }
+    catch (e) {
+      log(`mirror album create attempt ${attempt} failed: ${e.message}`);
+      if (attempt >= 6) throw e;
+      await new Promise(r => setTimeout(r, attempt * 2000));
+    }
+  }
+  try {
+    const n = await addMembers(mirror.id);
+    log(`mirror shared with ${forUserId ? 'one user (per-user join)' : n + ' household member(s)'}`);
+  } catch (e) { log(`could not add local members to mirror: ${e.message}`); }
+
+  const mapping: Mapping = { id: crypto.randomUUID(), role: 'member', albumId: mirror.id,
+    albumName: mirror.albumName, peer: peer.pub, remoteAlbumId: album.id,
+    remoteMappingId: req.remoteMappingId, permissions, adminSlug: slugify(ownerName) };
+  state.mappings.push(mapping);
+  save();
+  return { mapping, created: true };
+}
+
+/**
+ * Fill the mirror in behind the caller's answer. Deliberately unawaited by callers: a large
+ * album or a video transcode must not hold the accept page (or a poll cycle) hostage.
+ */
+export function fillMirrorInBackground(mapping: Mapping, peer: Peer) {
+  (async () => {
+    try { await reconcileMapping(mapping, peer); await pullCanonicalComments(mapping, peer); }
+    catch (e) { log(`post-join sync error: ${e.message} — the loops will retry`); }
+  })();
+}

--- a/src/p2p/protocol.ts
+++ b/src/p2p/protocol.ts
@@ -73,7 +73,7 @@ export async function handleRedeem(req, body) {
     mapping.permissions = link.allowUpload ? 'contribute' : 'view';
   } else {
     mapping = { id: crypto.randomUUID(), role: 'owner', albumId: album.id, albumName: album.albumName,
-      peer: household.publicKey, permissions: link.allowUpload ? 'contribute' : 'view' };
+      peer: household.publicKey, permissions: link.allowUpload ? 'contribute' : 'view', via: 'link' };
     state.mappings.push(mapping);
     log(`peer joined: "${household.name}" -> album "${album.albumName}"`);
   }

--- a/src/p2p/wire-protocol.md
+++ b/src/p2p/wire-protocol.md
@@ -8,6 +8,7 @@ folder is the **application** protocol on top of them.
 |---|---|
 | `protocol.ts` | Inbound handlers, mostly owner-side. `handleRedeem` turns a share link into a pinned peer + mapping and returns the manifest; `handleRefs` accepts pushed photos; `handleVersion`/`handleManifest` answer the cheap handshake and the full offer set; `handleNudge` reacts to "something moved, pull now". Each returns `[statusCode, jsonBody]` for the router. |
 | `join.ts` | The **member side** of joining. Redeems a share link against the origin, pins the peer, provisions the host utility user, creates the local mirror album, adds the joining user, and kicks off the first reconcile. Idempotent — re-joining just adds the user to the existing mirror. |
+| `mirror.ts` | Creating the local mirror of a remote album — the utility-user owner, local members as editors, the mapping, and the background fill. Shared by `join.ts` (share link) and `sync/invites.ts` (native invitation): two ways to acquire an album, one way to mirror it. |
 | `entitlement.ts` | What a peer may **read**, as distinct from who it is. Records every asset advertised to a mapping, and answers the byte routes' "is this peer allowed this asset". |
 
 **The handshake, end to end:** the banner (`../web/banner/`) collects the joiner's own

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -63,6 +63,12 @@ export function mappingFor(peerPub: string, ref: string, role?: 'owner' | 'membe
     && (!role || m.role === role)
     && (m.id === ref || m.albumId === ref || m.remoteAlbumId === ref));
 }
+/** GET with a detached signature over `signedValue` — the read-side counterpart of signedFetch. */
+export const signedGet = (url: string, signedValue: string, init: RequestInit = {}) => fetch(url, {
+  ...init,
+  signal: init.signal ?? AbortSignal.timeout(20000),
+  headers: { ...(init.headers || {}), 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(signedValue) },
+});
 export const signedFetch = (url, body) => fetch(url, {
   signal: AbortSignal.timeout(30000),
   method: 'POST',

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,6 +19,15 @@ export type Mapping = {
   id: string; role: 'owner' | 'member'; albumId: string; albumName: string;
   peer: string; remoteAlbumId?: string; remoteMappingId?: string;
   permissions?: 'view' | 'contribute'; adminSlug?: string;
+  /** How this share came about. Absent means 'link' (every mapping predating invitations).
+   *  Load-bearing: only 'invite' mappings may be retired by sync/invites when a peer's
+   *  stand-in disappears from an album — a link-redeemed mapping never had a stand-in added
+   *  to its album, so retiring those there would silently unshare every link-based album. */
+  via?: 'link' | 'invite';
+  /** Display name of the album's owner, captured when an invitation is detected. Link joins
+   *  learn this from the redeem response instead; without it a mirror would be named after
+   *  the household rather than the person who shared it. */
+  albumOwnerName?: string;
   dead?: boolean; failCount?: number;
   localVersion?: string; remoteVersion?: string;
   commentCount?: number; remoteCommentCount?: number;

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -12,6 +12,7 @@ import { getAlbum, getAlbumAssets, usersById, immichJson } from '../immich/clien
 import { shareableAssets, assetToRef } from '../immich/refs.ts';
 import { materialiseRef, deleteProxyAsset } from '../immich/materialise.ts';
 import { recordOffered, forgetOffered } from '../p2p/entitlement.ts';
+import { detectInvitesOnce, pullInvitationsOnce } from './invites.ts';
 
 // Leave & purge: the reverse of joining. Removes every stub this album materialised
 // (utility-owner-guarded), the mirror album, the mapping and its ledger — a join is
@@ -82,6 +83,9 @@ export async function watchOnce() {
       } else log(`watcher error on "${mapping.albumName}": ${e.message}`);
     }
   }
+  // native invitations: an album shared with a peer's stand-in becomes a mapping
+  try { await detectInvitesOnce(); } catch (e) { log(`invite detection error: ${e.message}`); }
+  try { await pullInvitationsOnce(); } catch (e) { log(`invitation pull error: ${e.message}`); }
   await reconcileOnce();
 }
 // Heal member mirrors: re-pull the origin manifest and materialise anything we

--- a/src/sync/invites.ts
+++ b/src/sync/invites.ts
@@ -1,0 +1,171 @@
+/**
+ * sync/invites.ts — sharing an album by inviting a household in Immich's OWN picker.
+ *
+ * A share link is how two households meet; it should not be how every subsequent album is
+ * shared. Once a peer is known, this makes the native gesture do the work: each peer gets a
+ * local stand-in user ("The Smith household (via shared albums)"), and adding that user to any
+ * album shares the album with them. Removing them again revokes it.
+ *
+ * The detection trick is that the stand-in lists albums with ITS OWN key rather than the admin
+ * key. `GET /albums` is scoped per user, so the admin key only ever sees the admin's own albums
+ * — which is why a non-admin currently cannot share cross-server at all. Asking as the stand-in
+ * sidesteps that completely: it does not matter who owns the album, only that the stand-in was
+ * invited to it.
+ *
+ * Three things Immich does that this code has to allow for:
+ *  - the album OWNER appears inside `albumUsers` with `role: 'owner'`, so a stand-in that owns
+ *    an album is a mirror we created for inbound content, not an invitation — skip those.
+ *  - adding a user who is already the owner returns 200 and is silently ignored, so a 200 is
+ *    never proof an invitation took. Read `albumUsers` back instead.
+ *  - `GET /albums` returns no `ownerId`; the owner is only discoverable inside `albumUsers`.
+ */
+import { log } from '../config.ts';
+import type { Mapping, Peer } from '../store.ts';
+import { state, save, store } from '../state.ts';
+import { immichJson } from '../immich/client.ts';
+import { ensureUtilityUser } from '../immich/contributors.ts';
+import { signedGet } from '../peers.ts';
+import { ROUTE_PREFIX } from '../config.ts';
+import { ensureMirror, fillMirrorInBackground } from '../p2p/mirror.ts';
+import crypto from 'node:crypto';
+
+/** Immich album roles map onto the permission a share link would have carried. */
+export const permissionFor = (role?: string): 'view' | 'contribute' =>
+  (role === 'editor' ? 'contribute' : 'view');
+
+/**
+ * The local stand-in for a peer household. Reuses the utility-user machinery, so it is
+ * non-admin, holds a narrowly-scoped key and no retained password. It needs `album.read` (part
+ * of UTILITY_PERMISSIONS) to enumerate what it has been invited to.
+ */
+export const ensurePeerMarker = (peer: Peer) => ensureUtilityUser(peer.name);
+
+type Invited = { name: string; permissions: 'view' | 'contribute'; ownerName?: string };
+type Seen = { invited: Map<string, Invited>; visible: Set<string> };
+
+/** Everything the stand-in can see, split into "invited to" and "merely visible". */
+async function albumsAsMarker(markerKey: string, markerUserId: string): Promise<Seen> {
+  const albums = await immichJson('/albums', {}, markerKey);
+  const invited = new Map<string, Invited>();
+  const visible = new Set<string>();
+  for (const a of albums || []) {
+    visible.add(a.id);
+    const mine = (a.albumUsers || []).find((au) => au.user?.id === markerUserId);
+    // 'owner' means this is a mirror we created for inbound content, not an invitation
+    if (!mine || mine.role === 'owner') continue;
+    // v3 album responses carry no ownerId — the owner is only discoverable inside albumUsers
+    const owner = (a.albumUsers || []).find((au) => au.role === 'owner');
+    invited.set(a.id, { name: a.albumName, permissions: permissionFor(mine.role),
+                        ownerName: owner?.user?.name });
+  }
+  return { invited, visible };
+}
+
+/**
+ * Origin side: turn native album invitations into mappings, and withdrawn ones into dead
+ * mappings. One album list per peer, asked as that peer's stand-in.
+ */
+export async function detectInvitesOnce() {
+  for (const peer of state.peers) {
+    let marker;
+    try { marker = await ensurePeerMarker(peer); }
+    catch (e) { log(`could not provision a stand-in for "${peer.name}": ${e.message}`); continue; }
+    if (!marker?.key || !marker.userId) continue;
+
+    let seen: Seen;
+    // A failed read must never look like a withdrawal — skip the peer entirely this cycle.
+    try { seen = await albumsAsMarker(marker.key, marker.userId); }
+    catch (e) { log(`could not read invitations for "${peer.name}": ${e.message}`); continue; }
+
+    for (const [albumId, a] of seen.invited) {
+      const existing = state.mappings.find(mp => mp.role === 'owner' && mp.peer === peer.pub && mp.albumId === albumId);
+      if (!existing) {
+        state.mappings.push({ id: crypto.randomUUID(), role: 'owner', albumId, albumName: a.name,
+          peer: peer.pub, permissions: a.permissions, via: 'invite', albumOwnerName: a.ownerName });
+        save();
+        // A silent persistence failure here would mean invitations are re-detected on every
+        // restart and withdrawals forgotten, so verify rather than assume.
+        const persisted = (store.state.mappings || []).some(x => x.albumId === albumId && x.via === 'invite');
+        log(`invited "${peer.name}" to "${a.name}" (${a.permissions}) — shared natively, no link needed`
+            + (persisted ? '' : ' [WARNING: mapping did not persist]'));
+        continue;
+      }
+      let changed = false;
+      if (existing.dead) { existing.dead = false; changed = true; log(`invitation re-added: "${peer.name}" -> "${a.name}"`); }
+      if (existing.permissions !== a.permissions) {
+        existing.permissions = a.permissions; changed = true;
+        log(`invitation for "${peer.name}" on "${a.name}" is now ${a.permissions}`);
+      }
+      if (changed) save();
+    }
+
+    // Withdrawals. ONLY mappings we created from an invitation are eligible: a link-redeemed
+    // mapping never had a stand-in added to its album, so it is absent from this list by
+    // design and retiring it here would silently unshare every link-based album.
+    for (const mp of state.mappings) {
+      if (mp.via !== 'invite' || mp.peer !== peer.pub || mp.dead) continue;
+      if (seen.invited.has(mp.albumId)) continue;
+      // still visible but not invited => the stand-in owns it, or was demoted oddly; leave it
+      if (seen.visible.has(mp.albumId)) continue;
+      mp.dead = true; save();
+      log(`invitation withdrawn: "${peer.name}" removed from "${mp.albumName}" — no longer syncing it`);
+    }
+  }
+}
+
+/**
+ * Wire handler body: what has this peer been invited to? Members POLL this; the origin never
+ * pushes, because a member with no inbound reachability still syncs perfectly well by pulling
+ * and a push-based invite would fail for exactly those households.
+ */
+export const invitationsFor = (peerPub: string) =>
+  state.mappings
+    // ONLY invitation-shaped shares. Offering link-redeemed ones here would re-mirror albums
+    // the member already handled through join — and worse, silently undo leaveAlbum on the
+    // next poll, because leaving removes the member's mapping but not the origin's.
+    .filter((mp: Mapping) => mp.role === 'owner' && mp.via === 'invite' && mp.peer === peerPub && !mp.dead)
+    .map((mp: Mapping) => ({
+      mappingId: mp.id,
+      album: { id: mp.albumId, name: mp.albumName },
+      permissions: mp.permissions ?? 'view',
+      albumOwner: { displayName: mp.albumOwnerName },
+    }));
+
+/**
+ * Member side: ask each peer what we have been invited to and mirror anything new.
+ *
+ * PULL, deliberately. A member with no inbound reachability still syncs perfectly well by
+ * pulling — proven on the mock rig — so a push-based invitation would fail for exactly the
+ * households that most need this (CGNAT, no port forwarding, no reverse proxy).
+ */
+export async function pullInvitationsOnce() {
+  for (const peer of state.peers) {
+    let invitations;
+    try {
+      const r = await signedGet(`${peer.url}${ROUTE_PREFIX}/api/v1/invitations`, 'invitations');
+      if (!r.ok) continue;                       // old peer, or not sharing anything with us
+      invitations = (await r.json()).invitations || [];
+    } catch { continue; }                        // unreachable: try again next cycle
+
+    for (const inv of invitations) {
+      const albumId = inv?.album?.id;
+      if (!albumId) continue;
+      // already mirrored, or we are the origin of this album ourselves
+      if (state.mappings.some(mp => mp.peer === peer.pub && !mp.dead
+        && (mp.remoteAlbumId === albumId || mp.albumId === albumId))) continue;
+      try {
+        const { mapping, created } = await ensureMirror({
+          peer,
+          album: { id: albumId, name: inv.album.name },
+          permissions: inv.permissions === 'contribute' ? 'contribute' : 'view',
+          albumOwnerName: inv.albumOwner?.displayName,
+          remoteMappingId: inv.mappingId,
+        });
+        if (created) {
+          log(`"${peer.name}" invited us to "${inv.album.name}" — mirrored it (${inv.permissions})`);
+          fillMirrorInBackground(mapping, peer);
+        }
+      } catch (e) { log(`could not mirror invitation "${inv.album?.name}": ${e.message}`); }
+    }
+  }
+}

--- a/src/sync/sync-loops.md
+++ b/src/sync/sync-loops.md
@@ -5,9 +5,43 @@ also driven on demand by nudges (`../p2p/protocol.ts`) so changes land in second
 
 | File | What it does |
 |---|---|
+| `invites.ts` | **Native album invitations.** Each peer gets a local stand-in user; adding it to any album in Immich's own picker shares that album, and removing it revokes. The origin detects this by listing albums as the stand-in; members discover it by polling `…/api/v1/invitations`. |
 | `engine.ts` | Photo sync. `watchOnce` pushes local additions out to peers; `reconcileOnce`/`reconcileMapping` pull the origin manifest, materialise anything missing, and **propagate deletions** (with a consistency gate so an indexing lag never wrongly deletes). `leaveAlbum` is the full reverse of a join — purges every stub, the mirror album, the mapping and its ledger. `startWatchLoop` runs it on an overlap-guarded interval. |
 | `comments.ts` | Cross-server comments. The origin album is the source of truth: members pull the canonical list and push their own, gated by a cheap activity-count statistic so messages land in seconds without heavy polling. Includes the inbound `handleActivity`/`handleComments` handlers. `startCommentLoop` runs the fast lane. |
 
 **Why loops and not just webhooks:** nudges make the common case instant, but the timed
 sweep is the safety net — a lost nudge costs nothing because the next scheduled handshake
 catches everything (fail-open by design). `RECONCILE_DEBUG=1` traces every decision.
+
+## Why invitations are detected as the stand-in, not with the admin key
+
+`GET /albums` is scoped per user, so the admin key only ever sees the admin's own albums —
+which is exactly why a non-admin cannot share cross-server through a share link today. Asking
+*as the stand-in* sidesteps it: it does not matter who owns the album, only that the stand-in
+was invited to it.
+
+Three Immich behaviours this has to allow for:
+
+- the album **owner** appears inside `albumUsers` with `role: 'owner'`, and `GET /albums`
+  returns no `ownerId` at all — so the owner is only discoverable there;
+- a stand-in that *owns* an album is a mirror we created for inbound content, not an
+  invitation, so those are skipped;
+- adding a user who is already the owner returns **200 and is silently ignored**, so a 200 is
+  never proof an invitation took. Read `albumUsers` back.
+
+## Provenance is load-bearing
+
+`Mapping.via` records whether a share came from a link or an invitation, and two rules depend
+on it:
+
+1. **Only `via: 'invite'` mappings may be retired** when a stand-in vanishes from an album. A
+   link-redeemed mapping never had a stand-in added to its album, so it is absent from that
+   list by design — retiring those here would silently unshare every link-based album.
+2. **Only `via: 'invite'` mappings are offered** on `…/api/v1/invitations`. Offering link ones
+   would re-mirror albums the member already handled through `join`, and worse, would silently
+   undo `leaveAlbum` on the next poll, because leaving removes the member's mapping but not the
+   origin's.
+
+Invitations are **pulled**, never pushed: a member with no inbound reachability still syncs
+perfectly well by pulling, so a push-based invitation would fail for exactly the households
+that most need this.

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -17,7 +17,7 @@ import { Readable } from 'node:stream';
 import { CFG, log, ROUTE_PREFIX } from '../config.ts';
 import { state } from '../state.ts';
 import { immich } from '../immich/client.ts';
-import { verify } from '../peers.ts';
+import { verify, callingPeer } from '../peers.ts';
 import { handlePreview, handleOriginal, handlePlayback } from '../media/proxy.ts';
 import { serveInterceptedBytes } from '../media/interceptor.ts';
 import { PANEL, ACCEPT_PAGE } from './pages.ts';
@@ -28,6 +28,7 @@ import { handleRedeem, handleRefs, handleVersion, handleNudge, handleManifest } 
 import { join } from '../p2p/join.ts';
 import { leaveAlbum } from '../sync/engine.ts';
 import { handleActivity, handleComments } from '../sync/comments.ts';
+import { invitationsFor } from '../sync/invites.ts';
 
 /**
  * Read a JSON-route body under a hard cap, or null if it is too big.
@@ -140,6 +141,12 @@ export const server = http.createServer(async (req, res) => {
     }
     if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/comments$/)) && req.method === 'GET') {
       const [code, obj] = await handleComments(req, m[1]); return send(code, obj);
+    }
+    // What has this peer been invited to? Pull-only by design — see sync/invites.
+    if (path === `${ROUTE_PREFIX}/api/v1/invitations` && req.method === 'GET') {
+      const peer = callingPeer(req, 'invitations');
+      if (!peer) return send(403, { error: 'unknown or unverified peer' });
+      return send(200, { invitations: invitationsFor(peer.pub) });
     }
     if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/nudge$/)) && req.method === 'POST') {
       const [code, obj] = await handleNudge(req, body, m[1]); return send(code, obj);


### PR DESCRIPTION
A share link is how two households *meet*; it shouldn't be how every subsequent album is shared.

Each peer now gets a local stand-in user — "The Smith household (via shared albums)" — and
**adding that user to any album in Immich's own picker shares the album cross-server**. Removing
them revokes it. No link, no banner, no typing server addresses.

## The detection trick

The origin lists albums **as the stand-in**, not with the admin key. That distinction matters:
`GET /albums` is scoped per user, so the admin key only ever sees the admin's own albums — which
is precisely why link-based sharing is broken for non-admins today. Asking as the stand-in
sidesteps it: it doesn't matter who owns the album, only that the stand-in was invited to it.

Immich album roles map onto the existing permissions — `editor → contribute`, `viewer → view`.

## Pull, not push

Members poll `GET …/api/v1/invitations`. Deliberately not a push: I verified on the mock rig
(by black-holing a member's address) that a member with **no inbound reachability still syncs
fine** via the reconciler. A push-based invitation would fail for exactly the households this is
meant to serve — CGNAT, no port forwarding, no reverse proxy.

## Provenance is load-bearing

`Mapping.via` records how a share came about, and it caught two bugs in this PR's own drafts:

1. **Only `invite` mappings may be retired** when a stand-in vanishes from an album. A
   link-redeemed mapping never had a stand-in added to its album, so it's absent from that list
   *by design* — my first draft would have unshared every link-based album on the first pass.
2. **Only `invite` mappings are offered** on `/invitations`. Offering link ones re-mirrors albums
   the member already handled through `join` — and would have **silently undone `leaveAlbum`** on
   the next poll, since leaving removes the member's mapping but not the origin's.

## Three Immich behaviours, measured rather than assumed

- the album **owner** appears inside `albumUsers` with `role: 'owner'`, and `GET /albums` returns
  no `ownerId` at all
- a stand-in that *owns* an album is a mirror we created, not an invitation — skipped
- adding a user who is already the owner returns **200 and is silently ignored**, so a 200 is
  never proof an invitation took; the code reads `albumUsers` back

## Structure

`p2p/mirror.ts` extracts mirror creation — two ways to acquire an album, one way to mirror it.
`join.ts` drops from 90 to 50 lines. Docs updated in `sync-loops.md`, `wire-protocol.md` and
`ARCHITECTURE.md`.

## Verification

**100 checks green.** New coverage: stand-in auto-creation, invite → mirror → photo
materialises, that the album is offered on `/invitations`, that link shares are *never* offered
there, and withdrawal.

The withdrawal assertion tests the `/invitations` **contract** rather than `state.db` — the
runner deletes `state.db` from under a live sidecar during purge, which makes a host-side file
read an unreliable oracle. Testing the contract is also simply the better test.

Also fixes a pre-existing assertion this feature invalidated: it checked that no
household-named utility user existed *anywhere* as a proxy for "the mirror is owned by the
sharer". Peer stand-ins make such a user expected, so it now checks the mirror's actual owner.

## Known gap

**Member-side withdrawal.** When an invitation is withdrawn the member stops being offered it
but keeps its mirror, so an un-invited household retains a stale placeholder album. Wants the
same "no vs don't know" care as the rest of the revocation work.

This is **household granularity** — you invite "the Smith household", not "Nan". Per-user needs
the directory exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)