### PR TITLE
chore: add a fast gate — unit tests, lint, prettier, cycles, on save and in CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Fast gate on every commit: seconds, no containers. The e2e suite stays in CI and in
+# `bash demo/run-mock-e2e.sh` — putting a seven-minute run in a hook is how hooks get bypassed.
+#
+# Enable once per clone:  git config core.hooksPath .githooks
+set -e
+echo "pre-commit: format check, lint, typecheck, cycles"
+npx prettier --check "src/**/*.ts" "scripts/**/*.mjs" >/dev/null || {
+  echo "  ✗ formatting — run: npm run format"; exit 1; }
+npx eslint src || exit 1
+npx tsc --noEmit || exit 1
+node scripts/check-cycles.mjs >/dev/null || exit 1
+echo "pre-commit: ok"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,26 @@ on:
     - cron: '0 6 * * 1' # weekly: catch breakage in immich-server:release before users do
 
 jobs:
+  # Its own job, not a step in e2e: a lint failure should report as "checks", not as a
+  # confusing e2e failure, and it finishes in ~1 minute instead of waiting on Immich to boot.
+  # Worth marking as a required status check in branch protection alongside e2e.
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install --silent
+      - name: Formatting (prettier)
+        run: npm run format:check
+      - name: Lint (eslint)
+        run: npm run lint
+      - name: Types (tsc)
+        run: npm run typecheck
+      - name: Import cycles
+        run: npm run cycles
+      - name: Unit tests
+        run: npm test
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -17,11 +37,6 @@ jobs:
       IMMICH_REF: ${{ github.event_name == 'schedule' && ':release' || '@sha256:b434cb9287eea1471c9974845914d4dd328c9c2d652e446ed4930f99944f0ceb' }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Typecheck (contract enforcement)
-        run: |
-          npm install --silent
-          npx tsc --noEmit
 
       - name: Start mock Immich instances (B + C + D)
         run: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+# The mock rig is a test harness with its own dense style, and reformatting the 880-line e2e
+# suite would make the history of every future test change unreadable. Kept deliberately out.
+demo/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 110,
+  "singleQuote": true,
+  "arrowParens": "avoid",
+  "trailingComma": "es5"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,1 @@
+{ "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"] }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
+  "eslint.useFlatConfig": true,
+  "eslint.validate": ["typescript", "javascript"],
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,60 @@ especially to AI coding agents — read it before you make changes.
 
 ## How changes land
 
-- **Everything goes through a pull request**, gated on the e2e suite (66 checks + a browser
-  lane). Branch protection enforces it; merges are squash-only.
+- **Everything goes through a pull request**, gated on the e2e suite (123 checks + a browser
+  lane) and the fast gate below. Branch protection enforces it; merges are squash-only.
 - **Conventional commits** decide the version automatically via release-please
   (`fix:` → patch, `feat:` → minor, `feat!:` → major). Don't hand-edit version numbers.
-- **Before pushing:** `npx tsc --noEmit` clean, and the suite green
-  (`bash demo/run-mock-e2e.sh`). CI runs both; run them locally first when you can.
+- **Before pushing:** `npm run verify` clean (format, lint, types, import cycles, unit tests —
+  seconds), then the e2e suite green (`bash demo/run-mock-e2e.sh` — minutes). CI runs the fast
+  gate first so a formatting slip fails in seconds rather than after booting four Immich stacks.
+- **Enable the hook once per clone:** `git config core.hooksPath .githooks`. It runs the fast
+  gate on commit. The e2e suite is deliberately NOT in the hook — a seven-minute hook is a hook
+  people bypass.
+- **Formatting is Prettier's, correctness is ESLint's.** They do not overlap: `eslint.config.mjs`
+  contains zero formatting rules, and that is a property to preserve. Never add
+  `tseslint.configs.stylistic`/`recommended` or a whitespace rule there.
+
+## Write the test first
+
+Two lanes, and the right one depends on whether Immich is involved.
+
+- **Pure logic → strict TDD.** Add the case to `src/*.test.ts`, watch it fail, then implement.
+  The loop is sub-second (`npm test`), so there is no excuse to skip it. Anything that can be a
+  pure function should be one, precisely so it can be tested this way — see `sync/invitees.ts`,
+  which was extracted from the one code path that removes a real person from a real album.
+- **Immich-facing behaviour → discover, then pin, then implement.** You cannot write a correct
+  test against an API whose behaviour you are guessing at, and guessing has caused real bugs
+  here: `GET /albums` is scoped per user, adding a user who is already the owner returns 200 and
+  is silently ignored, and album responses carry no `ownerId`. So probe the real thing on the
+  mock rig first, write the e2e assertion, then implement. The test still precedes the
+  implementation — it just follows the discovery.
+
+**Assert invariants, not strings.** "No two users share a display name" survives every future
+rename; a test pinning one literal name has to be edited whenever behaviour changes, and a test
+edited to match new behaviour has stopped being a test. **Print real state on failure** — a
+message showing what was actually found saves a whole debugging cycle, and the e2e suite's
+`check(name, ok, detail)` takes that detail for exactly this reason.
+
+## Invariants that will bite you
+
+These are enforced by lint or tests where possible, because each one has already caused a bug.
+
+- **Bot users live in disjoint namespaces** (`BOT_PREFIX` in `config.ts`). Invitation detection
+  reads "this bot is an album member" as a human's intent to share, which is only sound for bots
+  the sidecar *never* adds itself. Attribution contributors are the opposite — the sidecar adds
+  those. One user once served both roles, and origin and member ping-ponged mirror/withdraw every
+  poll, each offering the other a mirror of the other's album.
+- **Never reassign shared state arrays.** `state.mappings = state.mappings.filter(...)` discards
+  whatever a concurrent loop pushed onto the old reference. Splice in place. (ESLint enforces it.)
+- **Never inline a single-source-of-truth constant** — the bot email domain, `PROTOCOL_VERSION`.
+  The last naming bug was one predicate inlined in eleven places that drifted apart. (ESLint
+  enforces both.)
+- **Owner and member mappings are not interchangeable.** Origin-side logic must filter
+  `role === 'owner'`; a member's mirror always looks "withdrawn" to origin-side checks, and
+  retiring it kills a live album one poll after it was created.
+- **Route before reading a body** in `web/server.ts`, and mark deliberate fire-and-forget with
+  `void` so it is distinguishable from a forgotten `await`.
 
 ## Layout
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,70 @@
+// ESLint config — deliberately small.
+//
+// This is NOT a style linter: Prettier owns formatting, and `tseslint.configs.recommended` was
+// left off on purpose. On a codebase written without it, "recommended" fires mostly on `any` and
+// idioms that are fine here, and a gate that cries wolf gets switched off. Every rule below either
+// catches a class of bug that has actually shipped, or encodes an invariant that previously lived
+// only in a code comment — which is to say, in a place an agent can edit without ever reading.
+//
+// If a rule here starts producing false positives, fix or delete it. A lint gate that people learn
+// to ignore is worse than no gate.
+//
+// PRETTIER: this config contains ZERO formatting rules, which is why the two cannot clash. That is
+// a property to preserve — do not add `tseslint.configs.stylistic`, `recommended`, or any
+// whitespace/quote/semicolon rule here. Formatting is Prettier's job, correctness is ESLint's.
+// `npm run verify` runs both and is a fixed point; if you change this, re-check that it still is.
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['node_modules/**', 'demo/**', 'scripts/**', 'eslint.config.mjs'],
+  },
+  {
+    files: ['src/**/*.ts'],
+    extends: [tseslint.configs.base],
+    languageOptions: { parserOptions: { projectService: true } },
+    rules: {
+      // This whole codebase is concurrent async loops sharing one state object. An unawaited
+      // promise here does not just lose an error — it reorders writes to that shared state.
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
+      eqeqeq: ['error', 'smart'],
+      'no-restricted-syntax': [
+        'error',
+        {
+          // The concurrency bug: replacing a shared array discards whatever another loop pushed
+          // onto the old reference. Splice in place instead.
+          selector:
+            "AssignmentExpression[left.object.name='state'][left.property.name=/^(mappings|peers|contributors)$/]",
+          message:
+            'Never reassign state.mappings/peers/contributors — mutate in place (splice/push). Concurrent loops hold the old reference, so a reassignment silently discards their writes.',
+        },
+        {
+          // The drift bug: this predicate was inlined in 11 places and the copies diverged.
+          selector: "Literal[value=/@(sidecar|immich-shared-albums)\\.local$/]",
+          message:
+            'Do not inline the bot email domain. Use UTILITY_EMAIL_DOMAIN / isUtilityEmail from config.ts — inlined copies are how the last naming bug happened.',
+        },
+        {
+          // Same class: a wire constant with four inlined copies and an unused export.
+          selector: "Property[key.name='protocol'][value.type='Literal']",
+          message:
+            'Use PROTOCOL_VERSION from types.ts rather than a literal protocol number.',
+        },
+      ],
+    },
+  },
+  {
+    // config.ts and types.ts are where those single sources of truth are declared.
+    files: ['src/config.ts', 'src/types.ts'],
+    rules: { 'no-restricted-syntax': 'off' },
+  },
+  {
+    // Tests assert on the literals precisely because production code must not inline them.
+    // node:test's `test()` returns a promise that is designed to be left unawaited, so the
+    // floating-promise rule is pure noise here — the one exemption, and a deliberate one.
+    files: ['src/**/*.test.ts'],
+    rules: { 'no-restricted-syntax': 'off', '@typescript-eslint/no-floating-promises': 'off' },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,205 @@
       "name": "immich-shared-albums",
       "devDependencies": {
         "@types/node": "^24.0.0",
-        "typescript": "^5.6.0"
+        "eslint": "^10.8.1",
+        "prettier": "^3.9.6",
+        "typescript": "^5.6.0",
+        "typescript-eslint": "^8.67.0"
       }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.13.3",
@@ -18,6 +215,949 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.67.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/typescript": {
@@ -34,12 +1174,85 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,20 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\" \"scripts/**/*.mjs\" \"*.json\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"scripts/**/*.mjs\" \"*.json\"",
+    "cycles": "node scripts/check-cycles.mjs",
+    "test": "docker run --rm -e IMMICH_API_KEY=test-only -v \"$PWD/src\":/app/src -w /app node:24-alpine node --test \"src/**/*.test.ts\"",
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run cycles && npm test"
   },
   "devDependencies": {
+    "@types/node": "^24.0.0",
+    "eslint": "^10.8.1",
+    "prettier": "^3.9.6",
     "typescript": "^5.6.0",
-    "@types/node": "^24.0.0"
+    "typescript-eslint": "^8.67.0"
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,9 +5,7 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
-      "extra-files": [
-        "src/config.ts"
-      ]
+      "extra-files": ["src/config.ts"]
     }
   }
 }

--- a/scripts/check-cycles.mjs
+++ b/scripts/check-cycles.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * check-cycles.mjs — enforce the rule ARCHITECTURE.md already states: dependencies point
+ * downward, and there are no load-time import cycles.
+ *
+ * This existed only as prose until a cycle (engine -> invites -> mirror -> engine) was introduced
+ * and then verified by hand. A convention nothing checks is a convention that breaks again.
+ *
+ * Deliberately dumb: a regex over static import statements, no parser, no dependencies. It only
+ * needs to catch the load-time cycles that actually bite, so `import type` (erased at runtime)
+ * and dynamic `await import()` (evaluated later) are both ignored on purpose.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..', 'src');
+
+const files = [];
+(function walk(dir) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p);
+    else if (e.name.endsWith('.ts') && !e.name.endsWith('.test.ts')) files.push(p);
+  }
+})(ROOT);
+
+const rel = p => path.relative(ROOT, p).replaceAll(path.sep, '/');
+const graph = new Map();
+
+for (const file of files) {
+  const src = fs.readFileSync(file, 'utf8');
+  const deps = new Set();
+  // `import ... from './x.ts'` / `export ... from './x.ts'`, but never `import type`
+  const re = /^\s*(?:import|export)\s+(?!type\s)(?:[^;'"]*?\sfrom\s+)?['"](\.[^'"]+)['"]/gm;
+  for (const m of src.matchAll(re)) {
+    const target = path.resolve(path.dirname(file), m[1]);
+    if (fs.existsSync(target)) deps.add(rel(target));
+  }
+  graph.set(rel(file), deps);
+}
+
+// iterative DFS with an explicit stack, so the cycle can be printed as a readable path
+const state = new Map(); // 0 = unvisited, 1 = on stack, 2 = done
+const cycles = [];
+for (const start of graph.keys()) {
+  if (state.get(start)) continue;
+  const stack = [[start, [...(graph.get(start) ?? [])]]];
+  const pathStack = [start];
+  state.set(start, 1);
+  while (stack.length) {
+    const frame = stack[stack.length - 1];
+    const next = frame[1].shift();
+    if (next === undefined) {
+      state.set(frame[0], 2);
+      stack.pop();
+      pathStack.pop();
+      continue;
+    }
+    if (state.get(next) === 1) {
+      const at = pathStack.indexOf(next);
+      cycles.push([...pathStack.slice(at), next].join(' -> '));
+      continue;
+    }
+    if (state.get(next) === 2) continue;
+    state.set(next, 1);
+    pathStack.push(next);
+    stack.push([next, [...(graph.get(next) ?? [])]]);
+  }
+}
+
+if (cycles.length) {
+  console.error(`import cycles found (${cycles.length}):\n`);
+  for (const c of [...new Set(cycles)]) console.error(`  ${c}`);
+  console.error('\nBreak the cycle by extracting the shared piece into its own module.');
+  console.error('See src/ARCHITECTURE.md — dependencies point downward.');
+  process.exit(1);
+}
+console.log(`no import cycles (${files.length} modules)`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,6 @@
  * config.ts — process configuration, the shared logger, and small string constants.
  * The single source of truth for env-derived settings; every other module reads CFG here.
  */
-import crypto from 'node:crypto';
 
 export const SIDECAR_VERSION = '0.5.0'; // x-release-please-version
 export const CFG = {
@@ -39,7 +38,10 @@ export const CFG = {
   // at internal services.
   allowPrivatePeers: process.env.ALLOW_PRIVATE_PEERS !== 'false',
 };
-if (!CFG.apiKey) { console.error('IMMICH_API_KEY required'); process.exit(1); }
+if (!CFG.apiKey) {
+  console.error('IMMICH_API_KEY required');
+  process.exit(1);
+}
 export const log = (...a) => console.log(new Date().toISOString(), ...a);
 export const UTILITY_SUFFIX = ' (via shared albums)';
 

--- a/src/immich/client.ts
+++ b/src/immich/client.ts
@@ -10,7 +10,8 @@ import type { AssetRef } from '../types.ts';
 export const immich = async (p: string, init: RequestInit = {}, key: string = CFG.apiKey) => {
   const r = await fetch(`${CFG.immichUrl}/api${p}`, {
     signal: AbortSignal.timeout(60000),
-    ...init, headers: { 'x-api-key': key, Accept: 'application/json', ...(init.headers || {}) },
+    ...init,
+    headers: { 'x-api-key': key, Accept: 'application/json', ...(init.headers || {}) },
   });
   if (!r.ok) throw new Error(`immich ${p} -> ${r.status} ${await r.text().catch(() => '')}`);
   return r;
@@ -21,37 +22,56 @@ export const immichJson = async (p: string, init?: RequestInit, key?: string) =>
   const text = await r.text();
   return text ? JSON.parse(text) : null;
 };
-export const jsonBody = (obj) => ({ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(obj) });
+export const jsonBody = obj => ({
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(obj),
+});
 
 export const UTILITY_SUFFIX = ' (via shared albums)';
-export let USERS = {}; let USERS_AT = 0;
+export let USERS = {};
+let USERS_AT = 0;
 export async function usersById(maxAgeMs = 60000) {
   if (Date.now() - USERS_AT > maxAgeMs) {
     try {
-      USERS = Object.fromEntries((await immichJson('/admin/users'))
-        .map(u => [u.id, { name: u.name, utility: isUtilityEmail(u.email) }]));
+      USERS = Object.fromEntries(
+        (await immichJson('/admin/users')).map(u => [
+          u.id,
+          { name: u.name, utility: isUtilityEmail(u.email) },
+        ])
+      );
       USERS_AT = Date.now();
-    } catch { /* keep stale map */ }
+    } catch {
+      /* keep stale map */
+    }
   }
   return USERS;
 }
-export async function ownerName(ownerId) { const u = (await usersById())[ownerId]; return u && !u.utility ? u.name : null; }
-export const getSharedLinkByKey = async (key) => (await immichJson('/shared-links')).find(l => l.key === key);
-export const getAlbum = (id) => immichJson(`/albums/${id}?withoutAssets=true`);
+export async function ownerName(ownerId) {
+  const u = (await usersById())[ownerId];
+  return u && !u.utility ? u.name : null;
+}
+export const getSharedLinkByKey = async key => (await immichJson('/shared-links')).find(l => l.key === key);
+export const getAlbum = id => immichJson(`/albums/${id}?withoutAssets=true`);
 // Immich v3 removed embedded assets from the album endpoint; search/metadata is the stable enumerator.
-export const getAlbumAssets = async (albumId) => {
-  const out = []; let page = 1;
+export const getAlbumAssets = async albumId => {
+  const out = [];
+  let page = 1;
   while (page) {
-    const res = await immichJson('/search/metadata', jsonBody({ albumIds: [albumId], page, size: 500, withExif: true }));
+    const res = await immichJson(
+      '/search/metadata',
+      jsonBody({ albumIds: [albumId], page, size: 500, withExif: true })
+    );
     out.push(...(res.assets?.items || []));
     page = res.assets?.nextPage ? Number(res.assets.nextPage) : 0;
   }
   return out;
 };
-export const createAlbum = (albumName) => immichJson('/albums', jsonBody({ albumName }));
-export const addToAlbum = (albumId, ids, key) => immichJson(`/albums/${albumId}/assets`, { ...jsonBody({ ids }), method: 'PUT' }, key);
-export const previewStream = (assetId) => immich(`/assets/${assetId}/thumbnail?size=preview`);
-export const originalStream = (assetId) => immich(`/assets/${assetId}/original`);
+export const createAlbum = albumName => immichJson('/albums', jsonBody({ albumName }));
+export const addToAlbum = (albumId, ids, key) =>
+  immichJson(`/albums/${albumId}/assets`, { ...jsonBody({ ids }), method: 'PUT' }, key);
+export const previewStream = assetId => immich(`/assets/${assetId}/thumbnail?size=preview`);
+export const originalStream = assetId => immich(`/assets/${assetId}/original`);
 export async function uploadAsset(bytes, filename, key = CFG.apiKey, takenAt) {
   const fd = new FormData();
   const stamp = takenAt || new Date().toISOString();
@@ -60,7 +80,12 @@ export async function uploadAsset(bytes, filename, key = CFG.apiKey, takenAt) {
   fd.set('fileCreatedAt', stamp);
   fd.set('fileModifiedAt', stamp);
   fd.set('assetData', new Blob([bytes], { type: 'application/octet-stream' }), filename);
-  const r = await fetch(`${CFG.immichUrl}/api/assets`, { method: 'POST', headers: { 'x-api-key': key }, body: fd, signal: AbortSignal.timeout(180000) });
+  const r = await fetch(`${CFG.immichUrl}/api/assets`, {
+    method: 'POST',
+    headers: { 'x-api-key': key },
+    body: fd,
+    signal: AbortSignal.timeout(180000),
+  });
   if (!r.ok) throw new Error(`upload -> ${r.status} ${await r.text().catch(() => '')}`);
   return r.json(); // { id, status }
 }
@@ -69,19 +94,33 @@ export async function uploadAsset(bytes, filename, key = CFG.apiKey, takenAt) {
 // Immich dedupes identical bytes per user, and every proxy must stay a distinct asset.
 export const STUB_JPEG = Buffer.from(
   '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a' +
-  'HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAA' +
-  'AAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q==', 'base64');
+    'HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAA' +
+    'AAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q==',
+  'base64'
+);
 
 export async function applyRefMetadata(assetId: string, ref: AssetRef, key: string) {
-  const meta: { latitude?: number; longitude?: number; description?: string; rating?: number; dateTimeOriginal?: string } = {};
-  if (ref.exif?.latitude != null && ref.exif?.longitude != null) { meta.latitude = ref.exif.latitude; meta.longitude = ref.exif.longitude; }
+  const meta: {
+    latitude?: number;
+    longitude?: number;
+    description?: string;
+    rating?: number;
+    dateTimeOriginal?: string;
+  } = {};
+  if (ref.exif?.latitude != null && ref.exif?.longitude != null) {
+    meta.latitude = ref.exif.latitude;
+    meta.longitude = ref.exif.longitude;
+  }
   const credit = ref.contributor?.displayName ? `Shared by ${ref.contributor.displayName}` : '';
   meta.description = [ref.exif?.description, credit].filter(Boolean).join('\n\n') || undefined;
   if (!meta.description) delete meta.description;
   if (ref.exif?.rating) meta.rating = ref.exif.rating;
   if (ref.takenAt) meta.dateTimeOriginal = ref.takenAt;
   if (Object.keys(meta).length) {
-    try { await immichJson(`/assets/${assetId}`, { ...jsonBody(meta), method: 'PUT' }, key); }
-    catch (e) { log(`metadata apply failed for ${assetId}: ${e.message}`); }
+    try {
+      await immichJson(`/assets/${assetId}`, { ...jsonBody(meta), method: 'PUT' }, key);
+    } catch (e) {
+      log(`metadata apply failed for ${assetId}: ${e.message}`);
+    }
   }
 }

--- a/src/immich/contributors.ts
+++ b/src/immich/contributors.ts
@@ -9,7 +9,11 @@ import { state, save } from '../state.ts';
 import { immichJson, jsonBody, usersById, USERS } from './client.ts';
 import { sign } from '../peers.ts';
 
-export const slugify = (s) => (s || 'peer').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'peer';
+export const slugify = s =>
+  (s || 'peer')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || 'peer';
 
 /**
  * Exactly what a utility user does, and nothing else. These are non-admin accounts, so an
@@ -18,12 +22,28 @@ export const slugify = (s) => (s || 'peer').toLowerCase().replace(/[^a-z0-9]+/g,
  * exercises: own the stubs, curate the mirror album, mirror comments, carry an avatar.
  */
 const UTILITY_PERMISSIONS = [
-  'asset.upload', 'asset.read', 'asset.update', 'asset.delete', 'asset.download',
-  'album.create', 'album.read', 'album.update', 'album.delete',
-  'albumAsset.create', 'albumAsset.delete',
-  'albumUser.create', 'albumUser.update', 'albumUser.delete',
-  'activity.create', 'activity.read', 'activity.delete', 'activity.statistics',
-  'user.read', 'user.update', 'userProfileImage.create', 'userProfileImage.update',
+  'asset.upload',
+  'asset.read',
+  'asset.update',
+  'asset.delete',
+  'asset.download',
+  'album.create',
+  'album.read',
+  'album.update',
+  'album.delete',
+  'albumAsset.create',
+  'albumAsset.delete',
+  'albumUser.create',
+  'albumUser.update',
+  'albumUser.delete',
+  'activity.create',
+  'activity.read',
+  'activity.delete',
+  'activity.statistics',
+  'user.read',
+  'user.update',
+  'userProfileImage.create',
+  'userProfileImage.update',
 ];
 /**
  * Provision (or heal) a utility user.
@@ -38,18 +58,26 @@ const UTILITY_PERMISSIONS = [
  * one another. An earlier attempt to reuse contributors as invite targets turned every
  * link-shared album into a bogus invitation and corrupted sync.
  */
-export async function ensureUtilityUser(displayName, opts: {
-  peerPub?: string; peerUserId?: string; stateKey?: string; email?: string; fullName?: string;
-} | string = {}) {
-  if (typeof opts === 'string') opts = { peerPub: opts };   // legacy positional peerPub
+export async function ensureUtilityUser(
+  displayName,
+  opts: {
+    peerPub?: string;
+    peerUserId?: string;
+    stateKey?: string;
+    email?: string;
+    fullName?: string;
+  } = {}
+) {
   const { peerPub, peerUserId } = opts;
-  state.contributors = state.contributors || {};
   const slug = opts.stateKey || slugify(displayName);
   let c = state.contributors[slug];
   const wantedName = opts.fullName || `${displayName}${UTILITY_SUFFIX}`;
-  if (c && c.key) {                       // already fully provisioned — heal a stale display name
+  if (c && c.key) {
+    // already fully provisioned — heal a stale display name
     if ((peerPub && c.peer !== peerPub) || (peerUserId && c.peerUserId !== peerUserId)) {
-      c.peer = peerPub ?? c.peer; c.peerUserId = peerUserId ?? c.peerUserId; save();
+      c.peer = peerPub ?? c.peer;
+      c.peerUserId = peerUserId ?? c.peerUserId;
+      save();
     }
     const current = (await usersById(10000))[c.userId]?.name;
     if (current && current !== wantedName) {
@@ -57,7 +85,9 @@ export async function ensureUtilityUser(displayName, opts: {
         await immichJson(`/admin/users/${c.userId}`, { ...jsonBody({ name: wantedName }), method: 'PUT' });
         if (USERS[c.userId]) USERS[c.userId].name = wantedName;
         log(`healed utility user name: "${current}" -> "${wantedName}"`);
-      } catch { /* cosmetic — retry next time */ }
+      } catch {
+        /* cosmetic — retry next time */
+      }
     }
     return c;
   }
@@ -71,9 +101,15 @@ export async function ensureUtilityUser(displayName, opts: {
     const all = await immichJson('/admin/users?withDeleted=true');
     user = all.find(u => u.email === email);
     if (!user) throw new Error(`cannot create or find contributor user ${email}`);
-    if (user.deletedAt) { await immichJson(`/admin/users/${user.id}/restore`, { method: 'POST' }); log(`restored soft-deleted utility user ${email}`); }
+    if (user.deletedAt) {
+      await immichJson(`/admin/users/${user.id}/restore`, { method: 'POST' });
+      log(`restored soft-deleted utility user ${email}`);
+    }
     // admin reset: also clear shouldChangePassword so programmatic login works
-    await immichJson(`/admin/users/${user.id}`, { ...jsonBody({ password, shouldChangePassword: false, name: wantedName }), method: 'PUT' });
+    await immichJson(`/admin/users/${user.id}`, {
+      ...jsonBody({ password, shouldChangePassword: false, name: wantedName }),
+      method: 'PUT',
+    });
   }
   // Instances with OAuth-only login (passwordLogin disabled) need a brief toggle to mint the key.
   let restorePasswordLoginOff = false;
@@ -84,67 +120,131 @@ export async function ensureUtilityUser(displayName, opts: {
       await immichJson('/system-config', { ...jsonBody(sysCfg), method: 'PUT' });
       restorePasswordLoginOff = true;
     }
-  } catch { /* config not readable — proceed and let login speak */ }
+  } catch {
+    /* config not readable — proceed and let login speak */
+  }
   let login;
   try {
-    login = await (await fetch(`${CFG.immichUrl}/api/auth/login`,
-      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, password }) })).json();
+    login = await (
+      await fetch(`${CFG.immichUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      })
+    ).json();
   } finally {
     if (restorePasswordLoginOff) {
       try {
         const sysCfg = await immichJson('/system-config');
         sysCfg.passwordLogin.enabled = false;
         await immichJson('/system-config', { ...jsonBody(sysCfg), method: 'PUT' });
-      } catch (e) { log(`WARNING: could not restore passwordLogin=disabled: ${e.message}`); }
+      } catch (e) {
+        log(`WARNING: could not restore passwordLogin=disabled: ${e.message}`);
+      }
     }
   }
   if (!login.accessToken) throw new Error(`login failed for ${email} — will retry`);
-  const keyRes = await (await fetch(`${CFG.immichUrl}/api/api-keys`,
-    { method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${login.accessToken}` },
-      body: JSON.stringify({ name: 'sidecar', permissions: UTILITY_PERMISSIONS }) })).json();
-  if (!keyRes.secret) throw new Error(`api-key mint failed for ${email} (${JSON.stringify(keyRes).slice(0,120)}) — will retry`);
+  const keyRes = await (
+    await fetch(`${CFG.immichUrl}/api/api-keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${login.accessToken}` },
+      body: JSON.stringify({ name: 'sidecar', permissions: UTILITY_PERMISSIONS }),
+    })
+  ).json();
+  if (!keyRes.secret)
+    throw new Error(
+      `api-key mint failed for ${email} (${JSON.stringify(keyRes).slice(0, 120)}) — will retry`
+    );
   // The password existed only to mint that key. Roll it to a value we never keep, so these
   // accounts stop being sign-in-able at all: from here the sidecar holds a scoped API key
   // and nothing that can open an interactive session. A stored password would otherwise be
   // a standing login to your server, sitting in state.db, for a bot that never needs one.
   let passwordRetired = false;
   try {
-    await immichJson(`/admin/users/${user.id}`,
-      { ...jsonBody({ password: crypto.randomBytes(24).toString('base64url'), shouldChangePassword: false }), method: 'PUT' });
+    await immichJson(`/admin/users/${user.id}`, {
+      ...jsonBody({ password: crypto.randomBytes(24).toString('base64url'), shouldChangePassword: false }),
+      method: 'PUT',
+    });
     passwordRetired = true;
-  } catch (e) { log(`WARNING: could not retire the login password for ${email}: ${e.message}`); }
+  } catch (e) {
+    log(`WARNING: could not retire the login password for ${email}: ${e.message}`);
+  }
   if (CFG.utilityQuotaMb > 0) {
     try {
-      await immichJson(`/admin/users/${user.id}`,
-        { ...jsonBody({ quotaSizeInBytes: CFG.utilityQuotaMb * 1024 * 1024 }), method: 'PUT' });
-    } catch (e) { log(`could not set utility quota for ${email}: ${e.message}`); }
+      await immichJson(`/admin/users/${user.id}`, {
+        ...jsonBody({ quotaSizeInBytes: CFG.utilityQuotaMb * 1024 * 1024 }),
+        method: 'PUT',
+      });
+    } catch (e) {
+      log(`could not set utility quota for ${email}: ${e.message}`);
+    }
   }
-  c = { ...(c || {}), userId: user.id, key: keyRes.secret, peer: peerPub ?? c?.peer, peerUserId: peerUserId ?? c?.peerUserId };
-  if (!passwordRetired) c.password = password; // keep it only if the roll failed, so a retry can resume
+  c = {
+    ...(c || {}),
+    userId: user.id,
+    key: keyRes.secret,
+    peer: peerPub ?? c?.peer,
+    peerUserId: peerUserId ?? c?.peerUserId,
+  };
+  if (!passwordRetired)
+    c.password = password; // keep it only if the roll failed, so a retry can resume
   else delete c.password;
-  state.contributors[slug] = c; save();
-  log(`provisioned utility user "${displayName} (via shared albums)" (scoped key${passwordRetired ? ', no login' : ''})`);
+  state.contributors[slug] = c;
+  save();
+  log(
+    `provisioned utility user "${displayName} (via shared albums)" (scoped key${passwordRetired ? ', no login' : ''})`
+  );
   return c;
 }
 export async function syncAvatar(c, peerUrl, originUserId) {
   if (!peerUrl || !originUserId || c.avatarDone) return;
   try {
-    const av = await fetch(`${peerUrl}${ROUTE_PREFIX}/api/v1/users/${originUserId}/avatar`,
-      { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(originUserId) }, signal: AbortSignal.timeout(30000) });
+    const av = await fetch(`${peerUrl}${ROUTE_PREFIX}/api/v1/users/${originUserId}/avatar`, {
+      headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(originUserId) },
+      signal: AbortSignal.timeout(30000),
+    });
     if (av.ok) {
       const fd = new FormData();
-      fd.set('file', new Blob([Buffer.from(await av.arrayBuffer())], { type: av.headers.get('content-type') || 'image/jpeg' }), 'avatar.jpg');
-      const put = await fetch(`${CFG.immichUrl}/api/users/profile-image`, { method: 'POST', headers: { 'x-api-key': c.key }, body: fd });
-      if (put.ok) { c.avatarDone = true; save(); }  // only stop retrying once an avatar actually landed
+      fd.set(
+        'file',
+        new Blob([Buffer.from(await av.arrayBuffer())], {
+          type: av.headers.get('content-type') || 'image/jpeg',
+        }),
+        'avatar.jpg'
+      );
+      const put = await fetch(`${CFG.immichUrl}/api/users/profile-image`, {
+        method: 'POST',
+        headers: { 'x-api-key': c.key },
+        body: fd,
+      });
+      if (put.ok) {
+        c.avatarDone = true;
+        save();
+      } // only stop retrying once an avatar actually landed
     }
-  } catch { /* avatars are garnish */ }
+  } catch {
+    /* avatars are garnish */
+  }
 }
-export async function ensureContributor(displayName, albumId, adminKey, peerUrl, originUserId, peerPub?: string) {
+export async function ensureContributor(
+  displayName,
+  albumId,
+  adminKey,
+  peerUrl,
+  originUserId,
+  peerPub?: string
+) {
   const c = await ensureUtilityUser(displayName, { peerPub });
   if (!c.key) throw new Error(`contributor "${displayName}" has no API key yet — will retry`);
   await syncAvatar(c, peerUrl, originUserId);
   try {
-    await immichJson(`/albums/${albumId}/users`, { ...jsonBody({ albumUsers: [{ userId: c.userId, role: 'editor' }] }), method: 'PUT' }, adminKey);
-  } catch { /* already a member */ }
+    await immichJson(
+      `/albums/${albumId}/users`,
+      { ...jsonBody({ albumUsers: [{ userId: c.userId, role: 'editor' }] }), method: 'PUT' },
+      adminKey
+    );
+  } catch {
+    /* already a member */
+  }
   return c;
 }

--- a/src/immich/materialise.ts
+++ b/src/immich/materialise.ts
@@ -14,7 +14,7 @@ import { ensureContributor } from './contributors.ts';
 // false (without marking seen) on failure so reconciliation can retry later.
 export async function materialiseRef(mapping, peerUrl, fallbackName, ref) {
   if (seenHas(mapping.id, ref.checksum)) return true;
-  const sigHeaders = (v) => ({ headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(v) } });
+  const sigHeaders = v => ({ headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(v) } });
   // Hotlink model: nothing of the photo is stored here. The mirror asset is a ~2KB
   // unique stub that exists so the stock app has a row to render; every actual pixel
   // (thumbnails, previews, playback, originals) streams live from the owner's server
@@ -22,15 +22,28 @@ export async function materialiseRef(mapping, peerUrl, fallbackName, ref) {
   // the owner's rendition so the tile carries a real poster and duration.
   let bytes: Buffer;
   if (ref.kind === 'video') {
-    const pr = await fetch(`${peerUrl}${ROUTE_PREFIX}/api/v1/assets/${ref.originAsset}/playback`,
-      { ...sigHeaders(ref.originAsset), headers: { ...sigHeaders(ref.originAsset).headers, Range: 'bytes=0-2097151' }, signal: AbortSignal.timeout(120000) });
-    if (!pr.ok) { log(`playback stub fetch failed for ${ref.originAsset}: ${pr.status}`); return false; }
+    const pr = await fetch(`${peerUrl}${ROUTE_PREFIX}/api/v1/assets/${ref.originAsset}/playback`, {
+      ...sigHeaders(ref.originAsset),
+      headers: { ...sigHeaders(ref.originAsset).headers, Range: 'bytes=0-2097151' },
+      signal: AbortSignal.timeout(120000),
+    });
+    if (!pr.ok) {
+      log(`playback stub fetch failed for ${ref.originAsset}: ${pr.status}`);
+      return false;
+    }
     bytes = Buffer.concat([Buffer.from(await pr.arrayBuffer()), crypto.randomBytes(8)]);
   } else {
     bytes = Buffer.concat([STUB_JPEG, crypto.randomBytes(8)]);
   }
   const adminKey = mapping.adminSlug ? state.contributors[mapping.adminSlug]?.key : undefined;
-  const c = await ensureContributor(ref.contributor?.displayName || fallbackName, mapping.albumId, adminKey, peerUrl, ref.contributor?.originUserId, mapping.peer);
+  const c = await ensureContributor(
+    ref.contributor?.displayName || fallbackName,
+    mapping.albumId,
+    adminKey,
+    peerUrl,
+    ref.contributor?.originUserId,
+    mapping.peer
+  );
   const ext = ref.kind === 'video' ? 'mp4' : 'jpg';
   // base64 checksums contain / and + — never let them into filenames
   const slug = ref.checksum.replace(/[^a-zA-Z0-9]/g, '').slice(0, 12);
@@ -46,11 +59,25 @@ export async function materialiseRef(mapping, peerUrl, fallbackName, ref) {
 export async function deleteProxyAsset(assetId: string): Promise<boolean> {
   try {
     let asset;
-    try { asset = await immichJson(`/assets/${assetId}`); }
-    catch (e) { if (/-> 404/.test(e.message)) return true; throw e; } // already gone
+    try {
+      asset = await immichJson(`/assets/${assetId}`);
+    } catch (e) {
+      if (/-> 404/.test(e.message)) return true;
+      throw e;
+    } // already gone
     const owner = Object.values(state.contributors).find(c => c.userId === asset.ownerId);
-    if (!owner) { log(`proxy delete refused for ${assetId}: owner ${asset.ownerId} is not a utility user`); return false; }
-    await immichJson('/assets', { ...jsonBody({ ids: [assetId], force: true }), method: 'DELETE' }, owner.key);
+    if (!owner) {
+      log(`proxy delete refused for ${assetId}: owner ${asset.ownerId} is not a utility user`);
+      return false;
+    }
+    await immichJson(
+      '/assets',
+      { ...jsonBody({ ids: [assetId], force: true }), method: 'DELETE' },
+      owner.key
+    );
     return true;
-  } catch (e) { log(`proxy delete failed for ${assetId}: ${e.message}`); return false; }
+  } catch (e) {
+    log(`proxy delete failed for ${assetId}: ${e.message}`);
+    return false;
+  }
 }

--- a/src/immich/refs.ts
+++ b/src/immich/refs.ts
@@ -12,15 +12,24 @@ import { wireChecksum, ledgerByAsset, seenHas } from '../state.ts';
 // append locally is stripped so downstream hops don't stack "Shared by" twice.
 export async function assetToRef(a) {
   const u = (await usersById())[a.ownerId];
-  const displayName = u?.utility ? u.name.replace(UTILITY_SUFFIX, '')
-                                 : (a.owner?.name || u?.name || CFG.name);
+  const displayName = u?.utility ? u.name.replace(UTILITY_SUFFIX, '') : a.owner?.name || u?.name || CFG.name;
   const description = (a.exifInfo?.description || '').replace(/(?:\n\n)?Shared by [^\n]*$/, '') || undefined;
-  return { originAsset: a.id, checksum: wireChecksum(a), kind: a.type === 'VIDEO' ? 'video' : 'image',
+  return {
+    originAsset: a.id,
+    checksum: wireChecksum(a),
+    kind: a.type === 'VIDEO' ? 'video' : 'image',
     fileName: a.originalFileName,
     takenAt: a.exifInfo?.dateTimeOriginal || a.fileCreatedAt,
-    exif: a.exifInfo ? { latitude: a.exifInfo.latitude, longitude: a.exifInfo.longitude,
-      description, rating: a.exifInfo.rating } : undefined,
-    contributor: { displayName, originUserId: a.ownerId } };
+    exif: a.exifInfo
+      ? {
+          latitude: a.exifInfo.latitude,
+          longitude: a.exifInfo.longitude,
+          description,
+          rating: a.exifInfo.rating,
+        }
+      : undefined,
+    contributor: { displayName, originUserId: a.ownerId },
+  };
 }
 
 // What may be offered to the peer behind `mappingId`: photos/videos they haven't seen,
@@ -33,8 +42,9 @@ export async function assetToRef(a) {
 // so it must NOT exclude already-synced assets.
 export async function offerableAssets(assets) {
   const users = await usersById();
-  return assets.filter(a => (a.type === 'IMAGE' || a.type === 'VIDEO')
-    && (!users[a.ownerId]?.utility || !!ledgerByAsset(a.id)));
+  return assets.filter(
+    a => (a.type === 'IMAGE' || a.type === 'VIDEO') && (!users[a.ownerId]?.utility || !!ledgerByAsset(a.id))
+  );
 }
 // The push queue: offerable minus what this mapping has already sent.
 export async function shareableAssets(assets, mappingId) {

--- a/src/invariants.test.ts
+++ b/src/invariants.test.ts
@@ -1,0 +1,87 @@
+/**
+ * invariants.test.ts — the fast lane. `npm test`, no containers, no network, milliseconds.
+ *
+ * This deliberately covers ONLY pure logic and the invariants that have actually broken. It is
+ * not a second e2e suite: the mock rig in demo/ owns anything involving Immich, and duplicating
+ * that here would be maintenance for no gain. If a test needs a container, it belongs there.
+ *
+ * Every case below is a bug that shipped or nearly shipped, kept as a guard rather than a wish.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { BOT_PREFIX, markerName, isUtilityEmail, UTILITY_EMAIL_DOMAIN, UTILITY_SUFFIX } from './config.ts';
+import { permissionFor } from './sync/invites.ts';
+import { diffInvitees } from './sync/invitees.ts';
+
+test('bot namespaces are disjoint — no prefix may prefix another', () => {
+  // The mirror/withdraw ping-pong came from one bot serving two roles. Detection reads "this bot
+  // is an album member" as human intent, which is only sound for bots the sidecar never adds
+  // itself. If one prefix were a prefix of another, a startsWith() check would match both.
+  const prefixes = Object.values(BOT_PREFIX);
+  for (const a of prefixes) {
+    for (const b of prefixes) {
+      if (a === b) continue;
+      assert.ok(!a.startsWith(b), `${a} starts with ${b} — namespaces would overlap`);
+    }
+  }
+});
+
+test('a marker name never collides with an attribution contributor name', () => {
+  // Two identically-named users are unpickable in Immich's album picker. A marker and a
+  // contributor can exist for the SAME remote person on the same server.
+  const person = 'Nan',
+    peer = 'The Smiths';
+  const marker = markerName.person(person, peer);
+  const contributor = `${person}${UTILITY_SUFFIX}`;
+  assert.notEqual(marker, contributor);
+  assert.ok(!marker.includes(UTILITY_SUFFIX), 'markers must not wear the contributor suffix');
+});
+
+test('isUtilityEmail accepts only the project domain', () => {
+  assert.ok(isUtilityEmail(`shared-x@${UTILITY_EMAIL_DOMAIN}`));
+  assert.ok(isUtilityEmail(`invite-person-a-b@${UTILITY_EMAIL_DOMAIN}`));
+  assert.ok(!isUtilityEmail('someone@sidecar.local'), 'v1 dropped the legacy domain');
+  assert.ok(!isUtilityEmail('real.person@example.com'));
+  assert.ok(!isUtilityEmail(undefined));
+  // a lookalike domain must not pass
+  assert.ok(!isUtilityEmail(`x@evil-${UTILITY_EMAIL_DOMAIN}.example.com`));
+});
+
+test('album roles map to share permissions', () => {
+  assert.equal(permissionFor('editor'), 'contribute');
+  assert.equal(permissionFor('viewer'), 'view');
+  assert.equal(permissionFor(undefined), 'view', 'unknown roles must fail closed');
+});
+
+test('diffInvitees adds and removes, and never touches non-local users', () => {
+  // Removal is the half that matters: dropping one person while others remain is a revocation.
+  // Without it the sender's action appears to work and silently does nothing.
+  const local = ['nan', 'second'];
+  assert.deepEqual(diffInvitees({ wanted: ['nan', 'second'], current: ['nan'], local }), {
+    add: ['second'],
+    remove: [],
+  });
+  assert.deepEqual(diffInvitees({ wanted: ['second'], current: ['nan', 'second'], local }), {
+    add: [],
+    remove: ['nan'],
+  });
+  // a utility user holding the mirror is not in `local` and must never be removed
+  assert.deepEqual(diffInvitees({ wanted: ['nan'], current: ['nan', 'bot-owner'], local }), {
+    add: [],
+    remove: [],
+  });
+  // an invitee we have no local account for is simply skipped
+  assert.deepEqual(diffInvitees({ wanted: ['ghost'], current: [], local }), {
+    add: [],
+    remove: [],
+  });
+});
+
+test('an empty invitee list is never treated as "remove everyone"', () => {
+  // "Nobody named" means a withdrawal, handled by tearing the mirror down as a whole. If it were
+  // treated as a diff, a failed or empty poll would silently strip every member instead.
+  assert.deepEqual(diffInvitees({ wanted: [], current: ['nan'], local: ['nan'] }), {
+    add: [],
+    remove: [],
+  });
+});

--- a/src/media/cache.ts
+++ b/src/media/cache.ts
@@ -15,11 +15,14 @@ export function cacheRead(originAsset: string): Buffer | null {
   if (!CFG.cacheMaxMb) return null;
   const key = cacheKey(originAsset);
   if (!store.cacheTouch(key)) return null;
-  try { return fs.readFileSync(`${CACHE_DIR}/${key}`); }
-  catch { return null; } // index said yes, disk said no — self-heals on next put
+  try {
+    return fs.readFileSync(`${CACHE_DIR}/${key}`);
+  } catch {
+    return null;
+  } // index said yes, disk said no — self-heals on next put
 }
 export function cacheWrite(originAsset: string, bytes: Buffer) {
-  if (!CFG.cacheMaxMb || bytes.length > CFG.cacheMaxMb * 1024 * 1024 / 10) return; // no single item >10% of cap
+  if (!CFG.cacheMaxMb || bytes.length > (CFG.cacheMaxMb * 1024 * 1024) / 10) return; // no single item >10% of cap
   const key = cacheKey(originAsset);
   try {
     fs.writeFileSync(`${CACHE_DIR}/${key}`, bytes);
@@ -27,7 +30,13 @@ export function cacheWrite(originAsset: string, bytes: Buffer) {
     while (store.cacheTotal() > CFG.cacheMaxMb * 1024 * 1024) {
       const evicted = store.cacheEvictOldest();
       if (!evicted) break;
-      try { fs.unlinkSync(`${CACHE_DIR}/${evicted.key}`); } catch { /* already gone */ }
+      try {
+        fs.unlinkSync(`${CACHE_DIR}/${evicted.key}`);
+      } catch {
+        /* already gone */
+      }
     }
-  } catch (e) { log(`cache write skipped: ${e.message}`); }
+  } catch (e) {
+    log(`cache write skipped: ${e.message}`);
+  }
 }

--- a/src/media/interceptor.ts
+++ b/src/media/interceptor.ts
@@ -14,41 +14,72 @@ import { fetchTrueBytes } from './proxy.ts';
 import { cacheRead, cacheWrite } from './cache.ts';
 
 export async function serveInterceptedBytes(req, res, assetId: string, rawKind: string): Promise<boolean> {
-  const kind = rawKind === 'thumbnail' ? 'preview' : (rawKind === 'original' ? 'original' : 'playback');
+  const kind = rawKind === 'thumbnail' ? 'preview' : rawKind === 'original' ? 'original' : 'playback';
   const entry = store.ledgerWithOrigin(assetId);
   if (!entry) return false; // not a proxy asset -> Immich serves it
   // authorise with the caller's OWN credentials: they must be able to see the asset
   const authHeaders: Record<string, string> = {};
-  for (const h of ['cookie', 'x-api-key', 'authorization']) if (req.headers[h]) authHeaders[h] = req.headers[h] as string;
+  for (const h of ['cookie', 'x-api-key', 'authorization'])
+    if (req.headers[h]) authHeaders[h] = req.headers[h] as string;
   const probe = await fetch(`${CFG.immichUrl}/api/assets/${assetId}`, { headers: authHeaders });
-  if (!probe.ok) { res.writeHead(probe.status); res.end(); return true; }
+  if (!probe.ok) {
+    res.writeHead(probe.status);
+    res.end();
+    return true;
+  }
   // previews ride the bounded LRU cache: household-wide repeat views skip the
   // cross-server fetch, and recently viewed photos survive owner downtime.
   // Only bytes that truly came FROM THE PEER are ever cached (a local stub
   // fallback must not poison the cache), and hits refresh their LRU slot.
   if (kind === 'preview') {
     const cached = cacheRead(entry.o);
-    const baseHeaders = { 'Content-Type': 'image/jpeg', 'Cache-Control': 'private, max-age=604800, immutable' };
-    if (cached) { res.writeHead(200, { ...baseHeaders, 'X-Cache': 'HIT', 'Content-Length': String(cached.length) }); res.end(cached); return true; }
+    const baseHeaders = {
+      'Content-Type': 'image/jpeg',
+      'Cache-Control': 'private, max-age=604800, immutable',
+    };
+    if (cached) {
+      res.writeHead(200, { ...baseHeaders, 'X-Cache': 'HIT', 'Content-Length': String(cached.length) });
+      res.end(cached);
+      return true;
+    }
     const mapping2 = state.mappings.find(mp => mp.id === entry.m);
     const peer2 = mapping2 && state.peers.find(pe => pe.pub === mapping2.peer);
     if (peer2) {
       try {
-        const up = await fetch(`${peer2.url}${ROUTE_PREFIX}/api/v1/assets/${entry.o}/preview`,
-          { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) },
-            signal: AbortSignal.timeout(30000) });
+        const up = await fetch(`${peer2.url}${ROUTE_PREFIX}/api/v1/assets/${entry.o}/preview`, {
+          headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) },
+          signal: AbortSignal.timeout(30000),
+        });
         if (up.ok) {
           const buf = Buffer.from(await up.arrayBuffer());
           cacheWrite(entry.o, buf);
-          res.writeHead(200, { ...baseHeaders, 'Content-Type': up.headers.get('content-type') || 'image/jpeg', 'X-Cache': 'MISS', 'Content-Length': String(buf.length) });
-          res.end(buf); return true;
+          res.writeHead(200, {
+            ...baseHeaders,
+            'Content-Type': up.headers.get('content-type') || 'image/jpeg',
+            'X-Cache': 'MISS',
+            'Content-Length': String(buf.length),
+          });
+          res.end(buf);
+          return true;
         }
-      } catch (e) { log(`preview fetch failed, serving stub: ${e.message}`); }
+      } catch (e) {
+        log(`preview fetch failed, serving stub: ${e.message}`);
+      }
     }
     // owner unreachable and nothing cached -> the local stub thumbnail (uncached)
     const stub = await immich(`/assets/${assetId}/thumbnail?size=preview`).catch(() => null);
-    if (stub) { res.writeHead(200, { ...baseHeaders, 'Content-Type': stub.headers.get('content-type') || 'image/jpeg', 'X-Cache': 'BYPASS' }); res.end(Buffer.from(await stub.arrayBuffer())); return true; }
-    res.writeHead(503); res.end(); return true;
+    if (stub) {
+      res.writeHead(200, {
+        ...baseHeaders,
+        'Content-Type': stub.headers.get('content-type') || 'image/jpeg',
+        'X-Cache': 'BYPASS',
+      });
+      res.end(Buffer.from(await stub.arrayBuffer()));
+      return true;
+    }
+    res.writeHead(503);
+    res.end();
+    return true;
   }
   try {
     const out = await fetchTrueBytes(assetId, kind, req.headers.range as string | undefined);
@@ -59,12 +90,15 @@ export async function serveInterceptedBytes(req, res, assetId: string, rawKind: 
         'Cache-Control': 'private, max-age=604800, immutable',
       };
       for (const h of ['content-length', 'content-range', 'accept-ranges']) {
-        const v = out.headers.get(h); if (v) headers[h] = v;
+        const v = out.headers.get(h);
+        if (v) headers[h] = v;
       }
       res.writeHead(out.status || 200, headers);
       Readable.fromWeb(out.body).pipe(res);
       return true;
     }
-  } catch (e) { log(`byte interceptor fell through (${kind}): ${e.message}`); }
+  } catch (e) {
+    log(`byte interceptor fell through (${kind}): ${e.message}`);
+  }
   return false; // entry existed but we fell through -> Immich serves what it has
 }

--- a/src/media/proxy.ts
+++ b/src/media/proxy.ts
@@ -24,13 +24,19 @@ async function fetchWithHeaderTimeout(url: string, init: RequestInit, ms = 30000
   const timer = setTimeout(() => ac.abort(), ms);
   try {
     return await fetch(url, { ...init, signal: ac.signal });
-  } finally { clearTimeout(timer); }
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // Resolve true bytes for any local asset: local file for our own photos; for a proxy
 // (ledger entry with `o`), chain the fetch to the owner's server — how a relayed
 // photo's pixels stream D <- origin <- contributor. Range passes through for players.
-export async function fetchTrueBytes(assetId: string, kind: 'preview' | 'original' | 'playback', range?: string) {
+export async function fetchTrueBytes(
+  assetId: string,
+  kind: 'preview' | 'original' | 'playback',
+  range?: string
+) {
   const entry = store.ledgerWithOrigin(assetId);
   if (entry) {
     const mapping = state.mappings.find(mp => mp.id === entry.m);
@@ -39,15 +45,23 @@ export async function fetchTrueBytes(assetId: string, kind: 'preview' | 'origina
       const headers: Record<string, string> = { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) };
       if (range) headers.Range = range;
       try {
-        const up = await fetchWithHeaderTimeout(`${peer.url}${ROUTE_PREFIX}/api/v1/assets/${entry.o}/${kind}`, { headers });
+        const up = await fetchWithHeaderTimeout(
+          `${peer.url}${ROUTE_PREFIX}/api/v1/assets/${entry.o}/${kind}`,
+          { headers }
+        );
         if (up.ok) return up;
         log(`chained ${kind} fetch failed (${up.status}) — serving local stub`);
-      } catch (e) { log(`chained ${kind} fetch error (${e.message}) — serving local stub`); }
+      } catch (e) {
+        log(`chained ${kind} fetch error (${e.message}) — serving local stub`);
+      }
     }
   }
-  const local = kind === 'original' ? `/assets/${assetId}/original`
-    : kind === 'playback' ? `/assets/${assetId}/video/playback`
-    : `/assets/${assetId}/thumbnail?size=preview`;
+  const local =
+    kind === 'original'
+      ? `/assets/${assetId}/original`
+      : kind === 'playback'
+        ? `/assets/${assetId}/video/playback`
+        : `/assets/${assetId}/thumbnail?size=preview`;
   return immich(local, range ? { headers: { Range: range } } : {});
 }
 

--- a/src/p2p/entitlement.ts
+++ b/src/p2p/entitlement.ts
@@ -23,8 +23,7 @@ const lastBackfill = new Map<string, number>();
 
 /** Live mappings that face this peer, either role — a member relays its own
  *  contributions back to the origin, so member mappings grant reads too. */
-const mappingsFacing = (peerPub: string) =>
-  state.mappings.filter(m => m.peer === peerPub && !m.dead);
+const mappingsFacing = (peerPub: string) => state.mappings.filter(m => m.peer === peerPub && !m.dead);
 
 /** Record assets we have advertised to a mapping's peer. Safe to call repeatedly. */
 export function recordOffered(mappingId: string, assetIds: (string | undefined)[]) {
@@ -34,7 +33,10 @@ export function recordOffered(mappingId: string, assetIds: (string | undefined)[
 
 /** Record a manifest's worth of refs (each carries the ORIGIN asset id). */
 export function recordOfferedRefs(mappingId: string, manifest: { originAsset?: string }[]) {
-  recordOffered(mappingId, manifest.map(r => r.originAsset));
+  recordOffered(
+    mappingId,
+    manifest.map(r => r.originAsset)
+  );
 }
 
 /**
@@ -56,7 +58,10 @@ export async function peerMayRead(peerPub: string, assetId: string): Promise<boo
     lastBackfill.set(m.id, now);
     try {
       const assets = await getAlbumAssets(m.albumId);
-      recordOffered(m.id, assets.map((a: { id: string }) => a.id));
+      recordOffered(
+        m.id,
+        assets.map((a: { id: string }) => a.id)
+      );
       refreshed = true;
     } catch (e) {
       log(`entitlement backfill failed for "${m.albumName}": ${e.message}`);

--- a/src/p2p/join.ts
+++ b/src/p2p/join.ts
@@ -4,17 +4,25 @@
  * kicks off the first reconcile. Idempotent: re-joining just adds the user to the mirror.
  */
 import { CFG, SIDECAR_VERSION, log, ROUTE_PREFIX } from '../config.ts';
-import { state, save } from '../state.ts';
+import { PROTOCOL_VERSION } from '../types.ts';
+import { state } from '../state.ts';
 import { signedFetch, assertPeerUrlAllowed } from '../peers.ts';
 import { ensureMirror, fillMirrorInBackground } from './mirror.ts';
 
 export async function join(shareUrl, forUserId, password?: string) {
-  const m = String(shareUrl ?? '').trim().match(/^(https?:\/\/[^/]+)\/share\/([A-Za-z0-9_-]+)/);
+  const m = String(shareUrl ?? '')
+    .trim()
+    .match(/^(https?:\/\/[^/]+)\/share\/([A-Za-z0-9_-]+)/);
   if (!m) throw new Error('that does not look like an Immich share link');
   const [, origin, shareKey] = m;
   await assertPeerUrlAllowed(origin);
-  const body = JSON.stringify({ shareKey, protocol: 1, version: SIDECAR_VERSION, password,
-    household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name } });
+  const body = JSON.stringify({
+    shareKey,
+    protocol: PROTOCOL_VERSION,
+    version: SIDECAR_VERSION,
+    password,
+    household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name },
+  });
   const r = await signedFetch(`${origin}${ROUTE_PREFIX}/api/v1/invites/redeem`, body);
   if (!r.ok) {
     // Surface the other sidecar's own message (an expired link, a wrong password) but
@@ -27,9 +35,17 @@ export async function join(shareUrl, forUserId, password?: string) {
     throw err;
   }
   const res = await r.json();
-  if (res.protocol && res.protocol > 1) log(`origin "${res.household?.name}" speaks protocol ${res.protocol} > ours (1) — update the immich-shared-albums sidecar on this server`);
+  if (res.protocol && res.protocol > PROTOCOL_VERSION)
+    log(
+      `origin "${res.household?.name}" speaks protocol ${res.protocol} > ours (${PROTOCOL_VERSION}) — update the immich-shared-albums sidecar on this server`
+    );
   if (!state.peers.some(p => p.pub === res.household.publicKey)) {
-    state.peers.push({ pub: res.household.publicKey, url: res.household.url, name: res.household.name, version: res.version });
+    state.peers.push({
+      pub: res.household.publicKey,
+      url: res.household.url,
+      name: res.household.name,
+      version: res.version,
+    });
   }
   const { mapping, created } = await ensureMirror({
     peer: state.peers.find(pe => pe.pub === res.household.publicKey),
@@ -41,11 +57,19 @@ export async function join(shareUrl, forUserId, password?: string) {
     // A link join is for one account when the panel/accept page names one, else the household.
     forUserIds: forUserId ? [forUserId] : undefined,
   });
-  log(created
-    ? `joined "${res.album.name}" from "${res.household.name}" (${res.manifest.length} photos)`
-    : `re-join: "${mapping.albumName}" already mirrored from "${res.household.name}"`);
+  log(
+    created
+      ? `joined "${res.album.name}" from "${res.household.name}" (${res.manifest.length} photos)`
+      : `re-join: "${mapping.albumName}" already mirrored from "${res.household.name}"`
+  );
   const peerRec = state.peers.find(pe => pe.pub === res.household.publicKey);
   if (created && peerRec) fillMirrorInBackground(mapping, peerRec);
-  return { album: mapping.albumName, albumId: mapping.albumId, photos: res.manifest.length,
-           from: res.household.name, permissions: res.album.permissions, mappingId: mapping.id };
+  return {
+    album: mapping.albumName,
+    albumId: mapping.albumId,
+    photos: res.manifest.length,
+    from: res.household.name,
+    permissions: res.album.permissions,
+    mappingId: mapping.id,
+  };
 }

--- a/src/p2p/mirror.ts
+++ b/src/p2p/mirror.ts
@@ -45,18 +45,23 @@ export async function ensureMirror(req: MirrorRequest): Promise<{ mapping: Mappi
   await syncAvatar(host, peer.url, req.albumOwnerId);
 
   const addMembers = async (albumId: string) => {
-    let members = (await immichJson('/admin/users')).filter((u) => !isUtilityEmail(u.email));
-    if (forUserIds?.length) members = members.filter((u) => forUserIds.includes(u.id));
+    let members = (await immichJson('/admin/users')).filter(u => !isUtilityEmail(u.email));
+    if (forUserIds?.length) members = members.filter(u => forUserIds.includes(u.id));
     const alb = await immichJson(`/albums/${albumId}`, {}, host.key);
-    const already = new Set((alb.albumUsers || []).map((au) => au.user?.id));
-    members = members.filter((u) => !already.has(u.id));
-    if (members.length) await immichJson(`/albums/${albumId}/users`,
-      { ...jsonBody({ albumUsers: members.map((u) => ({ userId: u.id, role: 'editor' })) }), method: 'PUT' }, host.key);
+    const already = new Set((alb.albumUsers || []).map(au => au.user?.id));
+    members = members.filter(u => !already.has(u.id));
+    if (members.length)
+      await immichJson(
+        `/albums/${albumId}/users`,
+        { ...jsonBody({ albumUsers: members.map(u => ({ userId: u.id, role: 'editor' })) }), method: 'PUT' },
+        host.key
+      );
     return members.length;
   };
 
-  const existing = state.mappings.find(mp => mp.role === 'member' && mp.peer === peer.pub
-    && mp.remoteAlbumId === album.id && !mp.dead);
+  const existing = state.mappings.find(
+    mp => mp.role === 'member' && mp.peer === peer.pub && mp.remoteAlbumId === album.id && !mp.dead
+  );
   if (existing) {
     const n = await addMembers(existing.albumId);
     if (n) log(`added ${n} member(s) to existing mirror "${existing.albumName}"`);
@@ -67,8 +72,14 @@ export async function ensureMirror(req: MirrorRequest): Promise<{ mapping: Mappi
   // with backoff and log each attempt so failures are diagnosable from CI logs
   let mirror;
   for (let attempt = 1; ; attempt++) {
-    try { mirror = await immichJson('/albums', jsonBody({ albumName: CFG.template.replace('{name}', album.name) }), host.key); break; }
-    catch (e) {
+    try {
+      mirror = await immichJson(
+        '/albums',
+        jsonBody({ albumName: CFG.template.replace('{name}', album.name) }),
+        host.key
+      );
+      break;
+    } catch (e) {
       log(`mirror album create attempt ${attempt} failed: ${e.message}`);
       if (attempt >= 6) throw e;
       await new Promise(r => setTimeout(r, attempt * 2000));
@@ -76,13 +87,25 @@ export async function ensureMirror(req: MirrorRequest): Promise<{ mapping: Mappi
   }
   try {
     const n = await addMembers(mirror.id);
-    log(`mirror shared with ${forUserIds?.length ? forUserIds.length + ' named user(s)' : n + ' household member(s)'}`);
-  } catch (e) { log(`could not add local members to mirror: ${e.message}`); }
+    log(
+      `mirror shared with ${forUserIds?.length ? forUserIds.length + ' named user(s)' : n + ' household member(s)'}`
+    );
+  } catch (e) {
+    log(`could not add local members to mirror: ${e.message}`);
+  }
 
-  const mapping: Mapping = { id: crypto.randomUUID(), role: 'member', albumId: mirror.id,
-    albumName: mirror.albumName, peer: peer.pub, remoteAlbumId: album.id,
-    remoteMappingId: req.remoteMappingId, permissions, adminSlug: slugify(ownerName),
-    via: req.via ?? 'link' };
+  const mapping: Mapping = {
+    id: crypto.randomUUID(),
+    role: 'member',
+    albumId: mirror.id,
+    albumName: mirror.albumName,
+    peer: peer.pub,
+    remoteAlbumId: album.id,
+    remoteMappingId: req.remoteMappingId,
+    permissions,
+    adminSlug: slugify(ownerName),
+    via: req.via ?? 'link',
+  };
   state.mappings.push(mapping);
   save();
   return { mapping, created: true };
@@ -93,8 +116,13 @@ export async function ensureMirror(req: MirrorRequest): Promise<{ mapping: Mappi
  * album or a video transcode must not hold the accept page (or a poll cycle) hostage.
  */
 export function fillMirrorInBackground(mapping: Mapping, peer: Peer) {
-  (async () => {
-    try { await reconcileMapping(mapping, peer); await pullCanonicalComments(mapping, peer); }
-    catch (e) { log(`post-join sync error: ${e.message} — the loops will retry`); }
+  // `void`: deliberately not awaited — a large album or a transcode must not block the caller.
+  void (async () => {
+    try {
+      await reconcileMapping(mapping, peer);
+      await pullCanonicalComments(mapping, peer);
+    } catch (e) {
+      log(`post-join sync error: ${e.message} — the loops will retry`);
+    }
   })();
 }

--- a/src/p2p/protocol.ts
+++ b/src/p2p/protocol.ts
@@ -12,6 +12,7 @@
  */
 import crypto from 'node:crypto';
 import { CFG, SIDECAR_VERSION, log } from '../config.ts';
+import { PROTOCOL_VERSION } from '../types.ts';
 import { state, save } from '../state.ts';
 import { verify, nudgePeers, callingPeer, mappingFor } from '../peers.ts';
 import { getSharedLinkByKey, getAlbum, getAlbumAssets, ownerName, immichJson } from '../immich/client.ts';
@@ -25,7 +26,10 @@ import { recordOfferedRefs } from './entitlement.ts';
 function secretEquals(a: string, b: string): boolean {
   const ba = Buffer.from(String(a ?? ''));
   const bb = Buffer.from(String(b ?? ''));
-  if (ba.length !== bb.length) { crypto.timingSafeEqual(ba, ba); return false; }
+  if (ba.length !== bb.length) {
+    crypto.timingSafeEqual(ba, ba);
+    return false;
+  }
   return crypto.timingSafeEqual(ba, bb);
 }
 
@@ -35,10 +39,13 @@ export async function handleRedeem(req, body) {
   // Bind the request to the key being enrolled. This is trust-on-first-use: it proves the
   // caller holds the private half of the key it is asking us to trust, so the enrolled
   // identity cannot be forged or substituted later.
-  if (!verify(body, req.headers['x-isa-sig'] as string || '', household.publicKey)) {
+  if (!verify(body, (req.headers['x-isa-sig'] as string) || '', household.publicKey)) {
     return [403, { error: 'redeem signature does not match the household key' }];
   }
-  if (protocol && protocol > 1) log(`peer "${household?.name}" speaks protocol ${protocol} > ours (1) — update the immich-shared-albums sidecar on this server`);
+  if (protocol && protocol > PROTOCOL_VERSION)
+    log(
+      `peer "${household?.name}" speaks protocol ${protocol} > ours (${PROTOCOL_VERSION}) — update the immich-shared-albums sidecar on this server`
+    );
   const link = await getSharedLinkByKey(shareKey);
   if (!link || link.type !== 'ALBUM') return [404, { error: 'unknown share key' }];
   // A share link's own rules are the owner's stated intent — honour them here exactly as
@@ -63,17 +70,29 @@ export async function handleRedeem(req, body) {
     state.peers.push({ pub: household.publicKey, url: household.url, name: household.name, version });
   } else {
     const pe = state.peers.find(p => p.pub === household.publicKey);
-    if (pe) { pe.url = household.url; pe.name = household.name; if (version) pe.version = version; }
+    if (pe) {
+      pe.url = household.url;
+      pe.name = household.name;
+      if (version) pe.version = version;
+    }
   }
   // Idempotent: re-redeeming the same link must reuse the mapping, not mint another.
   // Otherwise a valid link is an unbounded state-growth lever.
-  let mapping = state.mappings.find(mp => mp.role === 'owner'
-    && mp.peer === household.publicKey && mp.albumId === album.id && !mp.dead);
+  let mapping = state.mappings.find(
+    mp => mp.role === 'owner' && mp.peer === household.publicKey && mp.albumId === album.id && !mp.dead
+  );
   if (mapping) {
     mapping.permissions = link.allowUpload ? 'contribute' : 'view';
   } else {
-    mapping = { id: crypto.randomUUID(), role: 'owner', albumId: album.id, albumName: album.albumName,
-      peer: household.publicKey, permissions: link.allowUpload ? 'contribute' : 'view', via: 'link' };
+    mapping = {
+      id: crypto.randomUUID(),
+      role: 'owner',
+      albumId: album.id,
+      albumName: album.albumName,
+      peer: household.publicKey,
+      permissions: link.allowUpload ? 'contribute' : 'view',
+      via: 'link',
+    };
     state.mappings.push(mapping);
     log(`peer joined: "${household.name}" -> album "${album.albumName}"`);
   }
@@ -84,14 +103,23 @@ export async function handleRedeem(req, body) {
   // exactly "the person who shared this"; majority asset owner is the empty-proof fallback
   const ownerCounts = {};
   for (const a of album.assets) ownerCounts[a.ownerId] = (ownerCounts[a.ownerId] || 0) + 1;
-  const albumOwnerId = link.userId || album.ownerId || Object.keys(ownerCounts).sort((x, y) => ownerCounts[y] - ownerCounts[x])[0];
-  const albumOwner = { displayName: await ownerName(albumOwnerId) || CFG.name, originUserId: albumOwnerId };
-  return [200, {
-    protocol: 1, version: SIDECAR_VERSION,
-    household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name },
-    album: { id: album.id, name: album.albumName, permissions: link.allowUpload ? 'contribute' : 'view' },
-    albumOwner, manifest, mappingId: mapping.id,
-  }];
+  const albumOwnerId =
+    link.userId ||
+    album.ownerId ||
+    Object.keys(ownerCounts).sort((x, y) => ownerCounts[y] - ownerCounts[x])[0];
+  const albumOwner = { displayName: (await ownerName(albumOwnerId)) || CFG.name, originUserId: albumOwnerId };
+  return [
+    200,
+    {
+      protocol: PROTOCOL_VERSION,
+      version: SIDECAR_VERSION,
+      household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name },
+      album: { id: album.id, name: album.albumName, permissions: link.allowUpload ? 'contribute' : 'view' },
+      albumOwner,
+      manifest,
+      mappingId: mapping.id,
+    },
+  ];
 }
 export async function handleRefs(req, body, albumMappingId) {
   const peer = callingPeer(req, body);
@@ -103,8 +131,12 @@ export async function handleRefs(req, body, albumMappingId) {
   const { add = [] } = JSON.parse(body);
   const failed = [];
   for (const ref of add) {
-    try { if (!(await materialiseRef(mapping, peer.url, peer.name, ref))) failed.push(ref.checksum); }
-    catch (e) { log(`ref materialise failed (${ref.checksum?.slice(0,10)}): ${e.message}`); failed.push(ref.checksum); }
+    try {
+      if (!(await materialiseRef(mapping, peer.url, peer.name, ref))) failed.push(ref.checksum);
+    } catch (e) {
+      log(`ref materialise failed (${ref.checksum?.slice(0, 10)}): ${e.message}`);
+      failed.push(ref.checksum);
+    }
   }
   if (add.length > failed.length) nudgePeers(mapping.albumId, peer.pub); // relay moved — tell the others
   // partial success: sender re-offers only the failed refs next cycle
@@ -121,7 +153,10 @@ export async function handleVersion(req, albumMappingId) {
   const album = await getAlbum(mapping.albumId);
   // updatedAt alone misses cascade deletions (removing an asset from the library skips
   // the album's timestamp) — fold the asset count in so deletions move the version too
-  return [200, { version: `${album.updatedAt}|${album.assetCount ?? ''}`, comments: stats?.comments ?? null }];
+  return [
+    200,
+    { version: `${album.updatedAt}|${album.assetCount ?? ''}`, comments: stats?.comments ?? null },
+  ];
 }
 export async function handleNudge(req, body, albumMappingId) {
   const caller = callingPeer(req, body);
@@ -136,14 +171,16 @@ export async function handleNudge(req, body, albumMappingId) {
   // household's album at a server of its choosing and materialise whatever it served.
   const origin = state.peers.find(p => p.pub === mapping.peer);
   if (!origin) return [404, { error: 'unknown album mapping' }];
-  // answer fast; do the pull in the background
-  (async () => {
+  // answer fast; do the pull in the background. `void` marks that as intended, not forgotten.
+  void (async () => {
     try {
       if (mapping.role === 'member') {
         await reconcileMapping(mapping, origin);
         await pullCanonicalComments(mapping, origin);
       }
-    } catch (e) { log(`nudge pull error on "${mapping.albumName}": ${e.message}`); }
+    } catch (e) {
+      log(`nudge pull error on "${mapping.albumName}": ${e.message}`);
+    }
   })();
   return [200, { ok: true }];
 }

--- a/src/p2p/unlink.ts
+++ b/src/p2p/unlink.ts
@@ -32,18 +32,27 @@ export async function unlinkPeer(pub: string): Promise<UnlinkResult> {
   const peer = state.peers.find(p => p.pub === pub);
   if (!peer) throw new Error('unknown household');
   const household = peer.name;
-  let mirrorsRemoved = 0, sharesRevoked = 0, markersRemoved = 0;
+  let mirrorsRemoved = 0,
+    sharesRevoked = 0,
+    markersRemoved = 0;
 
   // Copy first: leaveAlbum splices state.mappings, so iterating it live would skip entries.
   for (const mp of [...state.mappings].filter(m => m.peer === pub)) {
     if (mp.role === 'member') {
-      try { await leaveAlbum(mp.id); mirrorsRemoved++; }
-      catch (e) { log(`unlink: could not remove mirror "${mp.albumName}": ${e.message}`); }
+      try {
+        await leaveAlbum(mp.id);
+        mirrorsRemoved++;
+      } catch (e) {
+        log(`unlink: could not remove mirror "${mp.albumName}": ${e.message}`);
+      }
       continue;
     }
     forgetOffered(mp.id);
     const at = state.mappings.findIndex(x => x.id === mp.id);
-    if (at >= 0) { state.mappings.splice(at, 1); sharesRevoked++; }
+    if (at >= 0) {
+      state.mappings.splice(at, 1);
+      sharesRevoked++;
+    }
   }
 
   // Their invite markers exist only so our people could pick them. Once unlinked they are noise
@@ -52,11 +61,15 @@ export async function unlinkPeer(pub: string): Promise<UnlinkResult> {
     if (!slug.startsWith(BOT_PREFIX.invitePerson) || c.peer !== pub) continue;
     if (c.userId) {
       try {
-        await immichJson(`/admin/users/${c.userId}`,
-          { method: 'DELETE', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ force: true }) });
+        await immichJson(`/admin/users/${c.userId}`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ force: true }),
+        });
         markersRemoved++;
-      } catch (e) { log(`unlink: could not delete marker ${slug}: ${e.message}`); }
+      } catch (e) {
+        log(`unlink: could not delete marker ${slug}: ${e.message}`);
+      }
     }
     delete state.contributors[slug];
   }
@@ -64,21 +77,25 @@ export async function unlinkPeer(pub: string): Promise<UnlinkResult> {
   const pi = state.peers.findIndex(p => p.pub === pub);
   if (pi >= 0) state.peers.splice(pi, 1);
   save();
-  log(`unlinked "${household}" — ${mirrorsRemoved} mirror(s) removed, ${sharesRevoked} share(s) revoked, ${markersRemoved} marker(s) deleted`);
+  log(
+    `unlinked "${household}" — ${mirrorsRemoved} mirror(s) removed, ${sharesRevoked} share(s) revoked, ${markersRemoved} marker(s) deleted`
+  );
   return { household, mirrorsRemoved, sharesRevoked, markersRemoved };
 }
 
 /** What the panel shows: one row per linked server, with what the link is currently carrying. */
-export const linkedPeers = () => state.peers.map(p => ({
-  pub: p.pub,
-  name: p.name,
-  url: p.url,
-  version: p.version,
-  sharedToThem: state.mappings.filter(m => m.peer === p.pub && m.role === 'owner' && !m.dead).length,
-  sharedToUs: state.mappings.filter(m => m.peer === p.pub && m.role === 'member' && !m.dead).length,
-  people: Object.entries(state.contributors || {})
-    .filter(([k, c]) => k.startsWith(BOT_PREFIX.invitePerson) && c.peer === p.pub).length,
-}));
+export const linkedPeers = () =>
+  state.peers.map(p => ({
+    pub: p.pub,
+    name: p.name,
+    url: p.url,
+    version: p.version,
+    sharedToThem: state.mappings.filter(m => m.peer === p.pub && m.role === 'owner' && !m.dead).length,
+    sharedToUs: state.mappings.filter(m => m.peer === p.pub && m.role === 'member' && !m.dead).length,
+    people: Object.entries(state.contributors || {}).filter(
+      ([k, c]) => k.startsWith(BOT_PREFIX.invitePerson) && c.peer === p.pub
+    ).length,
+  }));
 
 /** Our own household identity, for the panel header. */
 export const localHousehold = () => ({ name: CFG.name, url: CFG.publicUrl });

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -8,13 +8,20 @@ import { state } from './state.ts';
 import { CFG, ROUTE_PREFIX } from './config.ts';
 
 const PRIVATE_V4 = [
-  /^127\./, /^10\./, /^192\.168\./, /^169\.254\./, /^0\./,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^0\./,
   /^172\.(1[6-9]|2\d|3[01])\./,
   /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./, // CGNAT, which is also the tailnet range
 ];
 const isPrivateAddress = (ip: string) =>
   PRIVATE_V4.some(re => re.test(ip)) ||
-  ip === '::1' || ip === '::' || /^f[cd]/i.test(ip) || /^fe80:/i.test(ip);
+  ip === '::1' ||
+  ip === '::' ||
+  /^f[cd]/i.test(ip) ||
+  /^fe80:/i.test(ip);
 
 /**
  * Guard a peer-supplied URL before we fetch it. Private destinations are normal for LAN
@@ -25,21 +32,48 @@ const isPrivateAddress = (ip: string) =>
 export async function assertPeerUrlAllowed(rawUrl: string) {
   if (CFG.allowPrivatePeers) return;
   let u: URL;
-  try { u = new URL(rawUrl); } catch { throw new Error('that does not look like a valid server address'); }
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    throw new Error('that does not look like a valid server address');
+  }
   if (u.protocol !== 'https:') throw new Error('peer servers must be reached over https');
   let address: string;
-  try { ({ address } = await dns.lookup(u.hostname)); }
-  catch { throw new Error(`cannot resolve ${u.hostname}`); }
+  try {
+    ({ address } = await dns.lookup(u.hostname));
+  } catch {
+    throw new Error(`cannot resolve ${u.hostname}`);
+  }
   if (isPrivateAddress(address)) throw new Error(`${u.hostname} resolves to a private address`);
 }
 
-export const sign = (body) => crypto.sign(null, Buffer.from(body),
-  crypto.createPrivateKey({ key: Buffer.from(state.keys.priv, 'base64url'), format: 'der', type: 'pkcs8' })).toString('base64url');
+export const sign = body =>
+  crypto
+    .sign(
+      null,
+      Buffer.from(body),
+      crypto.createPrivateKey({
+        key: Buffer.from(state.keys.priv, 'base64url'),
+        format: 'der',
+        type: 'pkcs8',
+      })
+    )
+    .toString('base64url');
 export const verify = (body, sig, pub) => {
   try {
-    return crypto.verify(null, Buffer.from(body), crypto.createPublicKey({
-      key: Buffer.from(pub, 'base64url'), format: 'der', type: 'spki' }), Buffer.from(sig, 'base64url'));
-  } catch { return false; }
+    return crypto.verify(
+      null,
+      Buffer.from(body),
+      crypto.createPublicKey({
+        key: Buffer.from(pub, 'base64url'),
+        format: 'der',
+        type: 'spki',
+      }),
+      Buffer.from(sig, 'base64url')
+    );
+  } catch {
+    return false;
+  }
 };
 /**
  * The peer behind an inbound request, or null. A key names a peer; only the signature
@@ -51,7 +85,7 @@ export function callingPeer(req, signedValue: string) {
   if (!peerKey) return null;
   const peer = state.peers.find(p => p.pub === peerKey);
   if (!peer) return null;
-  return verify(signedValue, req.headers['x-isa-sig'] as string || '', peerKey) ? peer : null;
+  return verify(signedValue, (req.headers['x-isa-sig'] as string) || '', peerKey) ? peer : null;
 }
 /**
  * Find one of THIS peer's mappings. The `m.peer === peerPub` term is the whole point:
@@ -59,22 +93,27 @@ export function callingPeer(req, signedValue: string) {
  * relationship that belongs to a different household.
  */
 export function mappingFor(peerPub: string, ref: string, role?: 'owner' | 'member') {
-  return state.mappings.find(m => m.peer === peerPub
-    && (!role || m.role === role)
-    && (m.id === ref || m.albumId === ref || m.remoteAlbumId === ref));
+  return state.mappings.find(
+    m =>
+      m.peer === peerPub &&
+      (!role || m.role === role) &&
+      (m.id === ref || m.albumId === ref || m.remoteAlbumId === ref)
+  );
 }
 /** GET with a detached signature over `signedValue` — the read-side counterpart of signedFetch. */
-export const signedGet = (url: string, signedValue: string, init: RequestInit = {}) => fetch(url, {
-  ...init,
-  signal: init.signal ?? AbortSignal.timeout(20000),
-  headers: { ...(init.headers || {}), 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(signedValue) },
-});
-export const signedFetch = (url, body) => fetch(url, {
-  signal: AbortSignal.timeout(30000),
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json', 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(body) },
-  body,
-});
+export const signedGet = (url: string, signedValue: string, init: RequestInit = {}) =>
+  fetch(url, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(20000),
+    headers: { ...(init.headers || {}), 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(signedValue) },
+  });
+export const signedFetch = (url, body) =>
+  fetch(url, {
+    signal: AbortSignal.timeout(30000),
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(body) },
+    body,
+  });
 // Nudge: tell every OTHER household mapped to this album that it moved, so they pull
 // now instead of at their next tick. Fire-and-forget — a lost nudge costs nothing,
 // the scheduled handshake still catches everything (fail-open by design).
@@ -83,7 +122,11 @@ export function nudgePeers(albumId: string, exceptPeerPub?: string) {
     if (mp.albumId !== albumId || mp.dead || mp.role !== 'owner' || mp.peer === exceptPeerPub) continue;
     const peer = state.peers.find(p => p.pub === mp.peer);
     if (!peer) continue;
-    signedFetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${albumId}/nudge`, JSON.stringify({ album: albumId }))
-      .catch(() => { /* fail-open */ });
+    signedFetch(
+      `${peer.url}${ROUTE_PREFIX}/api/v1/albums/${albumId}/nudge`,
+      JSON.stringify({ album: albumId })
+    ).catch(() => {
+      /* fail-open */
+    });
   }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,7 +5,7 @@
 import fs from 'node:fs';
 import crypto from 'node:crypto';
 import { Store } from './store.ts';
-import { CFG, log } from './config.ts';
+import { CFG } from './config.ts';
 
 fs.mkdirSync(CFG.dataDir, { recursive: true });
 export const store = new Store(CFG.dataDir);

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,9 +16,15 @@ import path from 'node:path';
 export type SeenEntry = { m: string; c: string; l: string; o?: string };
 
 export type Mapping = {
-  id: string; role: 'owner' | 'member'; albumId: string; albumName: string;
-  peer: string; remoteAlbumId?: string; remoteMappingId?: string;
-  permissions?: 'view' | 'contribute'; adminSlug?: string;
+  id: string;
+  role: 'owner' | 'member';
+  albumId: string;
+  albumName: string;
+  peer: string;
+  remoteAlbumId?: string;
+  remoteMappingId?: string;
+  permissions?: 'view' | 'contribute';
+  adminSlug?: string;
   /** How this share came about. Absent means 'link' (every mapping predating invitations).
    *  Load-bearing: only 'invite' mappings may be retired by sync/invites when a peer's
    *  stand-in disappears from an album — a link-redeemed mapping never had a stand-in added
@@ -33,16 +39,22 @@ export type Mapping = {
    *  learn this from the redeem response instead; without it a mirror would be named after
    *  the household rather than the person who shared it. */
   albumOwnerName?: string;
-  dead?: boolean; failCount?: number;
-  localVersion?: string; remoteVersion?: string;
-  commentCount?: number; remoteCommentCount?: number;
+  dead?: boolean;
+  failCount?: number;
+  localVersion?: string;
+  remoteVersion?: string;
+  commentCount?: number;
+  remoteCommentCount?: number;
 };
 
 export type Peer = { pub: string; url: string; name: string; version?: string };
 // `password` is transient: it exists only while the account is being provisioned, and is
 // rolled to an unheld value once the API key is minted (see immich/contributors.ts).
 export type Contributor = {
-  userId: string; key: string; password?: string; avatarDone?: boolean;
+  userId: string;
+  key: string;
+  password?: string;
+  avatarDone?: boolean;
   /** Public key of the peer household this person belongs to. */
   peer?: string;
   /** That person's user id ON THE PEER, for invite targets — what lets an invitation be routed
@@ -94,7 +106,8 @@ export class Store {
   }
 
   private kvGet(name: string) {
-    const row = this.db.prepare('SELECT value FROM kv WHERE name = ?').get(name) as { value: string } | undefined;
+    const row = this.db.prepare('SELECT value FROM kv WHERE name = ?').get(name) as
+      { value: string } | undefined;
     return row ? JSON.parse(row.value) : null;
   }
 
@@ -119,7 +132,10 @@ export class Store {
       throw e;
     }
     fs.renameSync(legacy, `${legacy}.migrated`);
-    console.log(new Date().toISOString(), `migrated state.json -> state.db (${(old.seen ?? []).length} ledger entries)`);
+    console.log(
+      new Date().toISOString(),
+      `migrated state.json -> state.db (${(old.seen ?? []).length} ledger entries)`
+    );
   }
 
   /** Persist the in-memory collections (small; one transaction). */
@@ -142,22 +158,23 @@ export class Store {
     return !!this.db.prepare('SELECT 1 FROM seen WHERE m = ? AND c = ?').get(mappingId, checksum);
   }
   seenAdd(mappingId: string, checksum: string, localAssetId: string, originAsset?: string) {
-    this.db.prepare('INSERT OR IGNORE INTO seen (m, c, l, o) VALUES (?, ?, ?, ?)')
+    this.db
+      .prepare('INSERT OR IGNORE INTO seen (m, c, l, o) VALUES (?, ?, ?, ?)')
       .run(mappingId, checksum, localAssetId, originAsset ?? null);
   }
   /** The authoritative ledger entry for a local asset. A deduped proxy can carry rows
    *  from several mappings/eras; materialisation rows (with an origin asset) hold the
    *  TRUE wire identity, so they always win over watcher-push bookkeeping rows. */
   ledgerByAsset(assetId: string): SeenEntry | undefined {
-    return this.db.prepare(
-      'SELECT m, c, l, o FROM seen WHERE l = ? ORDER BY (o IS NOT NULL) DESC, rowid DESC LIMIT 1'
-    ).get(assetId) as SeenEntry | undefined;
+    return this.db
+      .prepare('SELECT m, c, l, o FROM seen WHERE l = ? ORDER BY (o IS NOT NULL) DESC, rowid DESC LIMIT 1')
+      .get(assetId) as SeenEntry | undefined;
   }
   /** Ledger entry that can chain to the owner (has an origin asset id). */
   ledgerWithOrigin(assetId: string): SeenEntry | undefined {
-    return this.db.prepare(
-      'SELECT m, c, l, o FROM seen WHERE l = ? AND o IS NOT NULL ORDER BY rowid DESC LIMIT 1'
-    ).get(assetId) as SeenEntry | undefined;
+    return this.db
+      .prepare('SELECT m, c, l, o FROM seen WHERE l = ? AND o IS NOT NULL ORDER BY rowid DESC LIMIT 1')
+      .get(assetId) as SeenEntry | undefined;
   }
   seenRemoveMapping(mappingId: string) {
     this.db.prepare('DELETE FROM seen WHERE m = ?').run(mappingId);
@@ -186,7 +203,8 @@ export class Store {
   offeredAllows(mappingIds: string[], assetId: string): boolean {
     if (!mappingIds.length) return false;
     const holes = mappingIds.map(() => '?').join(',');
-    return !!this.db.prepare(`SELECT 1 FROM offered WHERE a = ? AND m IN (${holes})`)
+    return !!this.db
+      .prepare(`SELECT 1 FROM offered WHERE a = ? AND m IN (${holes})`)
       .get(assetId, ...mappingIds);
   }
   offeredRemoveMapping(mappingId: string) {
@@ -207,13 +225,16 @@ export class Store {
     return !!hit;
   }
   cachePut(key: string, size: number) {
-    this.db.prepare('INSERT OR REPLACE INTO cache (key, size, lastUsed) VALUES (?, ?, ?)').run(key, size, Date.now());
+    this.db
+      .prepare('INSERT OR REPLACE INTO cache (key, size, lastUsed) VALUES (?, ?, ?)')
+      .run(key, size, Date.now());
   }
   cacheTotal(): number {
     return (this.db.prepare('SELECT COALESCE(SUM(size),0) AS n FROM cache').get() as { n: number }).n;
   }
   cacheEvictOldest(): { key: string; size: number } | undefined {
-    const row = this.db.prepare('SELECT key, size FROM cache ORDER BY lastUsed ASC LIMIT 1').get() as { key: string; size: number } | undefined;
+    const row = this.db.prepare('SELECT key, size FROM cache ORDER BY lastUsed ASC LIMIT 1').get() as
+      { key: string; size: number } | undefined;
     if (row) this.db.prepare('DELETE FROM cache WHERE key = ?').run(row.key);
     return row;
   }

--- a/src/sync/comments.ts
+++ b/src/sync/comments.ts
@@ -20,31 +20,43 @@ export const getComments = (albumId, key?: string) =>
  * `400 Not found or no album.read access` on every poll. The mirror-owning stand-in always has
  * access because it owns the album. Owner mappings keep the admin key (undefined => default).
  */
-const albumReaderKey = (mapping) =>
-  mapping.role === 'member' && mapping.adminSlug
-    ? state.contributors?.[mapping.adminSlug]?.key
-    : undefined;
-export const postComment = (albumId, comment, key) => immichJson('/activities', jsonBody({ albumId, type: 'comment', comment }), key);
+const albumReaderKey = mapping =>
+  mapping.role === 'member' && mapping.adminSlug ? state.contributors?.[mapping.adminSlug]?.key : undefined;
+export const postComment = (albumId, comment, key) =>
+  immichJson('/activities', jsonBody({ albumId, type: 'comment', comment }), key);
 // Materialise foreign comments locally via the author's utility user. Skips ids already
 // seen AND (author, text) pairs already present locally — the latter guards legacy comments
 // synced before canonical ids existed.
 export async function materialiseComments(mapping, peerUrl, peerName, comments) {
   const users = await usersById();
   const local = await getComments(mapping.albumId, albumReaderKey(mapping));
-  const localPairs = new Set(local.map(a => {
-    const n = (users[a.user?.id]?.name || a.user?.name || '').replace(UTILITY_SUFFIX, '');
-    return `${n}\u0000${a.comment}`;
-  }));
+  const localPairs = new Set(
+    local.map(a => {
+      const n = (users[a.user?.id]?.name || a.user?.name || '').replace(UTILITY_SUFFIX, '');
+      return `${n}\u0000${a.comment}`;
+    })
+  );
   const ids = {};
   for (const cm of comments) {
     const tag = `remote:${cm.id}`;
     if (seenActHas(tag)) continue;
-    if (localPairs.has(`${cm.author}\u0000${cm.comment}`)) { seenActAdd(tag); continue; }
+    if (localPairs.has(`${cm.author}\u0000${cm.comment}`)) {
+      seenActAdd(tag);
+      continue;
+    }
     const adminKey = mapping.adminSlug ? state.contributors[mapping.adminSlug]?.key : undefined;
-    const c = await ensureContributor(cm.author || peerName, mapping.albumId, adminKey, peerUrl, cm.authorUserId, mapping.peer);
+    const c = await ensureContributor(
+      cm.author || peerName,
+      mapping.albumId,
+      adminKey,
+      peerUrl,
+      cm.authorUserId,
+      mapping.peer
+    );
     const posted = await postComment(mapping.albumId, cm.comment, c.key);
     ids[cm.id] = posted.id;
-    seenActAdd(tag); seenActAdd(`local:${posted.id}`); // don't echo it back
+    seenActAdd(tag);
+    seenActAdd(`local:${posted.id}`); // don't echo it back
     log(`synced comment from "${cm.author}" into "${mapping.albumName}"`);
   }
   return ids;
@@ -67,11 +79,15 @@ export async function handleComments(req, albumMappingId) {
   const mapping = mappingFor(peer.pub, albumMappingId, 'owner');
   if (!mapping) return [404, { error: 'unknown album mapping' }];
   const users = await usersById();
-  const comments = (await getComments(mapping.albumId)).filter(a => a.comment).map(a => ({
-    id: a.id, comment: a.comment, createdAt: a.createdAt,
-    author: (users[a.user?.id]?.name || a.user?.name || CFG.name).replace(UTILITY_SUFFIX, ''),
-    authorUserId: a.user?.id,
-  }));
+  const comments = (await getComments(mapping.albumId))
+    .filter(a => a.comment)
+    .map(a => ({
+      id: a.id,
+      comment: a.comment,
+      createdAt: a.createdAt,
+      author: (users[a.user?.id]?.name || a.user?.name || CFG.name).replace(UTILITY_SUFFIX, ''),
+      authorUserId: a.user?.id,
+    }));
   return [200, { comments }];
 }
 // push locally-authored comments (not ones we materialised) to the peer.
@@ -81,7 +97,11 @@ export let COMMENTS_RUNNING = false;
 export async function syncComments() {
   if (COMMENTS_RUNNING) return;
   COMMENTS_RUNNING = true;
-  try { await syncCommentsOnce(); } finally { COMMENTS_RUNNING = false; }
+  try {
+    await syncCommentsOnce();
+  } finally {
+    COMMENTS_RUNNING = false;
+  }
 }
 export async function syncCommentsOnce() {
   for (const mapping of state.mappings) {
@@ -90,26 +110,54 @@ export async function syncCommentsOnce() {
       const peer = state.peers.find(p => p.pub === mapping.peer);
       if (!peer) continue;
       if (mapping.role === 'member') await pullCanonicalComments(mapping, peer);
-      const stats = await immichJson(`/activities/statistics?albumId=${mapping.albumId}`, {},
-                                     albumReaderKey(mapping)).catch(() => null);
+      const stats = await immichJson(
+        `/activities/statistics?albumId=${mapping.albumId}`,
+        {},
+        albumReaderKey(mapping)
+      ).catch(() => null);
       if (stats && stats.comments === mapping.commentCount) continue;
       const utilityIds = new Set(Object.values(state.contributors || {}).map(c => c.userId));
-      const comments = (await getComments(mapping.albumId, albumReaderKey(mapping)))
-        .filter(a => a.comment && !seenActHas(`local:${a.id}`) && !seenActHas(`remote:${a.id}`) && !utilityIds.has(a.user?.id));
-      if (!comments.length) { if (stats) { mapping.commentCount = stats.comments; save(); } continue; }
-      const targetMapping = mapping.role === 'member' ? (mapping.remoteMappingId || mapping.remoteAlbumId) : mapping.albumId;
-      const payload = comments.map(a => ({ id: a.id, comment: a.comment, author: a.user?.name || CFG.name, authorUserId: a.user?.id }));
-      const r = await signedFetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${targetMapping}/activity`, JSON.stringify({ comments: payload }));
+      const comments = (await getComments(mapping.albumId, albumReaderKey(mapping))).filter(
+        a =>
+          a.comment &&
+          !seenActHas(`local:${a.id}`) &&
+          !seenActHas(`remote:${a.id}`) &&
+          !utilityIds.has(a.user?.id)
+      );
+      if (!comments.length) {
+        if (stats) {
+          mapping.commentCount = stats.comments;
+          save();
+        }
+        continue;
+      }
+      const targetMapping =
+        mapping.role === 'member' ? mapping.remoteMappingId || mapping.remoteAlbumId : mapping.albumId;
+      const payload = comments.map(a => ({
+        id: a.id,
+        comment: a.comment,
+        author: a.user?.name || CFG.name,
+        authorUserId: a.user?.id,
+      }));
+      const r = await signedFetch(
+        `${peer.url}${ROUTE_PREFIX}/api/v1/albums/${targetMapping}/activity`,
+        JSON.stringify({ comments: payload })
+      );
       if (r.ok) {
         comments.forEach(a => seenActAdd(`local:${a.id}`));
         // the origin answers with canonical ids for our comments — remember them so the
         // canonical pull can never hand us our own comments back
         const { ids = {} } = await r.json().catch(() => ({}));
         for (const originId of Object.values(ids)) seenActAdd(`remote:${originId}`);
-        if (stats) { mapping.commentCount = stats.comments; save(); }
+        if (stats) {
+          mapping.commentCount = stats.comments;
+          save();
+        }
         log(`pushed ${comments.length} comment(s) to "${peer.name}"`);
       }
-    } catch (e) { log(`comment sync error on "${mapping.albumName}": ${e.message}`); }
+    } catch (e) {
+      log(`comment sync error on "${mapping.albumName}": ${e.message}`);
+    }
   }
 }
 // The origin is the source of truth for messages: members pull its canonical comment set
@@ -118,19 +166,29 @@ export async function syncCommentsOnce() {
 export async function pullCanonicalComments(mapping, peer) {
   const target = mapping.remoteMappingId || mapping.remoteAlbumId;
   const sig = { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(target) } };
-  const vr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/version`, { ...sig, signal: AbortSignal.timeout(15000) });
+  const vr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/version`, {
+    ...sig,
+    signal: AbortSignal.timeout(15000),
+  });
   if (!vr.ok) return;
   const v = await vr.json().catch(() => ({}));
   if (v.comments == null || v.comments === mapping.remoteCommentCount) return;
-  const cr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/comments`, { ...sig, signal: AbortSignal.timeout(20000) });
+  const cr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/comments`, {
+    ...sig,
+    signal: AbortSignal.timeout(20000),
+  });
   if (!cr.ok) return;
   const { comments = [] } = await cr.json().catch(() => ({}));
   await materialiseComments(mapping, peer.url, peer.name, comments);
-  mapping.remoteCommentCount = v.comments; save();
+  mapping.remoteCommentCount = v.comments;
+  save();
 }
 
 // comments ride a fast lane: the count statistic is one indexed query, so seconds-level
 // cadence stays cheap even on low-power hosts; the full activity fetch only runs on change
 export function startCommentLoop() {
-  setInterval(() => syncComments().catch(e => log('comment loop:', e.message)), Number(process.env.COMMENT_POLL_MS || 5000));
+  setInterval(
+    () => syncComments().catch(e => log('comment loop:', e.message)),
+    Number(process.env.COMMENT_POLL_MS || 5000)
+  );
 }

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -8,7 +8,7 @@ import { CFG, log, ROUTE_PREFIX } from '../config.ts';
 import type { Mapping, Peer } from '../store.ts';
 import { state, store, save, seenHas, seenAdd, wireChecksum } from '../state.ts';
 import { sign, signedFetch } from '../peers.ts';
-import { getAlbum, getAlbumAssets, usersById, immichJson } from '../immich/client.ts';
+import { getAlbum, getAlbumAssets, usersById } from '../immich/client.ts';
 import { shareableAssets, assetToRef } from '../immich/refs.ts';
 import { materialiseRef, deleteProxyAsset } from '../immich/materialise.ts';
 import { recordOffered } from '../p2p/entitlement.ts';
@@ -28,18 +28,27 @@ export async function watchOnce() {
       // created — stubs, mirror, mapping, ledger. No custom UI involved.
       if (mapping.role === 'member') {
         const users = await usersById();
-        const humans = (album.albumUsers || []).filter((au) => {
-          const u = users[au.user?.id]; return u && !u.utility;
+        const humans = (album.albumUsers || []).filter(au => {
+          const u = users[au.user?.id];
+          return u && !u.utility;
         });
-        if (humans.length === 0) { await leaveAlbum(mapping.id); continue; }
+        if (humans.length === 0) {
+          await leaveAlbum(mapping.id);
+          continue;
+        }
       }
       if (mapping.role === 'member' && mapping.permissions === 'view') continue; // view-only: nothing to push
       const assets = await getAlbumAssets(mapping.albumId);
       mapping.failCount = 0;
       const fresh = await shareableAssets(assets, mapping.id);
-      if (!fresh.length) { mapping.localVersion = album.updatedAt; save(); continue; }
+      if (!fresh.length) {
+        mapping.localVersion = album.updatedAt;
+        save();
+        continue;
+      }
       const peer = state.peers.find(p => p.pub === mapping.peer);
-      const targetMapping = mapping.role === 'member' ? (mapping.remoteMappingId || mapping.remoteAlbumId) : mapping.albumId;
+      const targetMapping =
+        mapping.role === 'member' ? mapping.remoteMappingId || mapping.remoteAlbumId : mapping.albumId;
       const add = [];
       for (const a of fresh) add.push(await assetToRef(a));
       const body = JSON.stringify({ add });
@@ -49,15 +58,26 @@ export async function watchOnce() {
         const landed = fresh.filter(a => !failed.has(wireChecksum(a)));
         landed.forEach(a => seenAdd(mapping.id, wireChecksum(a), a.id));
         // pushed to this peer => this peer may read their bytes (see p2p/entitlement)
-        recordOffered(mapping.id, landed.map(a => a.id));
-        if (!failed.size) { mapping.localVersion = album.updatedAt; save(); }
-        log(`pushed ${landed.length}/${fresh.length} ref(s) to "${peer.name}"${failed.size ? ` (${failed.size} deferred)` : ''}`);
+        recordOffered(
+          mapping.id,
+          landed.map(a => a.id)
+        );
+        if (!failed.size) {
+          mapping.localVersion = album.updatedAt;
+          save();
+        }
+        log(
+          `pushed ${landed.length}/${fresh.length} ref(s) to "${peer.name}"${failed.size ? ` (${failed.size} deferred)` : ''}`
+        );
       } else log(`ref push failed: ${r.status}`);
     } catch (e) {
       mapping.failCount = (mapping.failCount || 0) + 1;
       if (/album.read access|Not found/i.test(e.message) && mapping.failCount >= 5) {
-        mapping.dead = true; save();
-        log(`mapping "${mapping.albumName}" marked dead after ${mapping.failCount} failures (album deleted?) — no longer polled`);
+        mapping.dead = true;
+        save();
+        log(
+          `mapping "${mapping.albumName}" marked dead after ${mapping.failCount} failures (album deleted?) — no longer polled`
+        );
       } else log(`watcher error on "${mapping.albumName}": ${e.message}`);
     }
   }
@@ -71,7 +91,9 @@ export async function reconcileOnce() {
       const peer = state.peers.find(p => p.pub === mapping.peer);
       if (!peer) continue;
       await reconcileMapping(mapping, peer);
-    } catch (e) { log(`reconcile error on "${mapping.albumName}": ${e.message}`); }
+    } catch (e) {
+      log(`reconcile error on "${mapping.albumName}": ${e.message}`);
+    }
   }
 }
 // per-mapping mutex: the join-time reconcile is fired unawaited and can race the
@@ -82,47 +104,68 @@ export async function reconcileMapping(mapping: Mapping, peer: Peer) {
   if (RECONCILING.has(mapping.id)) return;
   RECONCILING.add(mapping.id);
   try {
-      const target = mapping.remoteMappingId || mapping.remoteAlbumId;
-      const sig = { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(target) } };
-      // handshake first: only pull the full manifest when the origin's version moved.
-      // remoteVersion is only stored after a CLEAN pass so failures keep retrying.
-      let version = null;
-      const vr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/version`, { ...sig, signal: AbortSignal.timeout(15000) });
-      if (vr.ok) {
-        version = (await vr.json().catch(() => ({}))).version || null;
-        if (version && version === mapping.remoteVersion) return;
+    const target = mapping.remoteMappingId || mapping.remoteAlbumId;
+    const sig = { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(target) } };
+    // handshake first: only pull the full manifest when the origin's version moved.
+    // remoteVersion is only stored after a CLEAN pass so failures keep retrying.
+    let version = null;
+    const vr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/version`, {
+      ...sig,
+      signal: AbortSignal.timeout(15000),
+    });
+    if (vr.ok) {
+      version = (await vr.json().catch(() => ({}))).version || null;
+      if (version && version === mapping.remoteVersion) return;
+    }
+    const r = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/manifest`, {
+      ...sig,
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!r.ok) return;
+    const { manifest = [] } = await r.json();
+    // The version's asset count comes from the album table (instant); the manifest
+    // comes from the search index (which lags behind deletes). Only trust a read
+    // where the two agree — dirty reads retry next cycle instead of poisoning the cursor.
+    const expectedCount = version ? Number(String(version).split('|')[1]) : NaN;
+    const consistent = !Number.isFinite(expectedCount) || manifest.length === expectedCount;
+    if (process.env.RECONCILE_DEBUG)
+      log(
+        `DBG reconcile "${mapping.albumName}": version=${version} cursor=${mapping.remoteVersion} manifest=${manifest.length} expected=${expectedCount} consistent=${consistent} ledger=${store.seenForMapping(mapping.id).length}`
+      );
+    // deletion propagation: refs we materialised that the owner no longer offers are
+    // gone at the source — remove our stubs too (utility-owner-guarded).
+    let propagated = true;
+    if (version && consistent) {
+      const offered = new Set(manifest.map(x => x.checksum));
+      for (const entry of store.seenForMapping(mapping.id)) {
+        if (process.env.RECONCILE_DEBUG)
+          log(`DBG entry c=${entry.c.slice(0, 8)} o=${!!entry.o} offered=${offered.has(entry.c)}`);
+        if (!entry.o || offered.has(entry.c)) continue;
+        if (await deleteProxyAsset(entry.l)) {
+          store.seenRemoveEntry(mapping.id, entry.c);
+          log(`removed stub for a photo its owner deleted ("${mapping.albumName}")`);
+        } else propagated = false; // keep the cursor back so the removal retries next cycle
       }
-      const r = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/manifest`, { ...sig, signal: AbortSignal.timeout(30000) });
-      if (!r.ok) return;
-      const { manifest = [] } = await r.json();
-      // The version's asset count comes from the album table (instant); the manifest
-      // comes from the search index (which lags behind deletes). Only trust a read
-      // where the two agree — dirty reads retry next cycle instead of poisoning the cursor.
-      const expectedCount = version ? Number(String(version).split('|')[1]) : NaN;
-      const consistent = !Number.isFinite(expectedCount) || manifest.length === expectedCount;
-      if (process.env.RECONCILE_DEBUG) log(`DBG reconcile "${mapping.albumName}": version=${version} cursor=${mapping.remoteVersion} manifest=${manifest.length} expected=${expectedCount} consistent=${consistent} ledger=${store.seenForMapping(mapping.id).length}`);
-      // deletion propagation: refs we materialised that the owner no longer offers are
-      // gone at the source — remove our stubs too (utility-owner-guarded).
-      let propagated = true;
-      if (version && consistent) {
-        const offered = new Set(manifest.map((x) => x.checksum));
-        for (const entry of store.seenForMapping(mapping.id)) {
-          if (process.env.RECONCILE_DEBUG) log(`DBG entry c=${entry.c.slice(0,8)} o=${!!entry.o} offered=${offered.has(entry.c)}`);
-          if (!entry.o || offered.has(entry.c)) continue;
-          if (await deleteProxyAsset(entry.l)) {
-            store.seenRemoveEntry(mapping.id, entry.c);
-            log(`removed stub for a photo its owner deleted ("${mapping.albumName}")`);
-          } else propagated = false; // keep the cursor back so the removal retries next cycle
-        }
+    }
+    const missing = manifest.filter(ref => !seenHas(mapping.id, ref.checksum));
+    let allOk = true;
+    for (const ref of missing) {
+      try {
+        if (await materialiseRef(mapping, peer.url, peer.name, ref))
+          log(`reconciled missed ref into "${mapping.albumName}"`);
+        else allOk = false;
+      } catch (e) {
+        allOk = false;
+        log(`reconcile materialise failed (${ref.checksum?.slice(0, 10)}): ${e.message}`);
       }
-      const missing = manifest.filter(ref => !seenHas(mapping.id, ref.checksum));
-      let allOk = true;
-      for (const ref of missing) {
-        try { if (await materialiseRef(mapping, peer.url, peer.name, ref)) log(`reconciled missed ref into "${mapping.albumName}"`); else allOk = false; }
-        catch (e) { allOk = false; log(`reconcile materialise failed (${ref.checksum?.slice(0,10)}): ${e.message}`); }
-      }
-      if (allOk && propagated && version && consistent) { mapping.remoteVersion = version; save(); }
-  } finally { RECONCILING.delete(mapping.id); }
+    }
+    if (allOk && propagated && version && consistent) {
+      mapping.remoteVersion = version;
+      save();
+    }
+  } finally {
+    RECONCILING.delete(mapping.id);
+  }
 }
 
 // overlap guard: a slow cycle (large albums, slow peers) must not stack concurrent
@@ -132,6 +175,10 @@ export function startWatchLoop() {
   setInterval(() => {
     if (WATCH_RUNNING) return;
     WATCH_RUNNING = true;
-    watchOnce().catch(e => log('watch loop:', e.message)).finally(() => { WATCH_RUNNING = false; });
+    watchOnce()
+      .catch(e => log('watch loop:', e.message))
+      .finally(() => {
+        WATCH_RUNNING = false;
+      });
   }, CFG.pollMs);
 }

--- a/src/sync/invitees.ts
+++ b/src/sync/invitees.ts
@@ -1,0 +1,42 @@
+/**
+ * sync/invitees.ts — who should be on a mirror, as pure set arithmetic.
+ *
+ * Extracted from syncMirrorMembers so it can be tested without a container. This is the only
+ * code path that removes a real person from a real album, so it is worth being able to check in
+ * milliseconds rather than in a seven-minute e2e run.
+ */
+
+export type InviteeDiff = { add: string[]; remove: string[] };
+
+/**
+ * Reconcile an album's local membership against the people an invitation names.
+ *
+ * `wanted`  — user ids the sender currently names (local ids, echoed back from our own directory)
+ * `current` — ids already on the album, owner excluded
+ * `local`   — our own human user ids; anything outside this is a utility user
+ *
+ * Two rules carry the safety here:
+ *  - An EMPTY `wanted` is not "remove everyone". Nobody-named means the invitation is gone, which
+ *    is a withdrawal and tears the whole mirror down elsewhere. Diffing it instead would let a
+ *    failed or empty poll silently strip every member of a live album.
+ *  - Only ids in `local` are ever removed. Utility users own the mirror and its stubs; removing
+ *    one would strand the content it holds.
+ */
+export function diffInvitees({
+  wanted,
+  current,
+  local,
+}: {
+  wanted: string[];
+  current: string[];
+  local: string[];
+}): InviteeDiff {
+  if (!wanted.length) return { add: [], remove: [] };
+  const want = new Set(wanted);
+  const have = new Set(current);
+  const mine = new Set(local);
+  return {
+    add: local.filter(id => want.has(id) && !have.has(id)),
+    remove: current.filter(id => mine.has(id) && !want.has(id)),
+  };
+}

--- a/src/sync/invites.ts
+++ b/src/sync/invites.ts
@@ -32,6 +32,7 @@ import { signedGet } from '../peers.ts';
 import { ROUTE_PREFIX } from '../config.ts';
 import { ensureMirror, fillMirrorInBackground } from '../p2p/mirror.ts';
 import { leaveAlbum } from './leave.ts';
+import { diffInvitees } from './invitees.ts';
 import crypto from 'node:crypto';
 
 /**
@@ -44,8 +45,8 @@ export async function localDirectory() {
   if (!CFG.shareUserDirectory) return [];
   const users = await immichJson('/admin/users');
   return (users || [])
-    .filter((u) => !isUtilityEmail(u.email) && !u.deletedAt)
-    .map((u) => ({ id: u.id, name: u.name }));
+    .filter(u => !isUtilityEmail(u.email) && !u.deletedAt)
+    .map(u => ({ id: u.id, name: u.name }));
 }
 
 /**
@@ -58,9 +59,11 @@ async function syncPeerDirectory(peer: Peer) {
   let people;
   try {
     const r = await signedGet(`${peer.url}${ROUTE_PREFIX}/api/v1/directory`, 'directory');
-    if (!r.ok) return;                                  // peer too old, or sharing disabled
+    if (!r.ok) return; // peer too old, or sharing disabled
     people = (await r.json()).users || [];
-  } catch { return; }                                    // unreachable: next cycle
+  } catch {
+    return;
+  } // unreachable: next cycle
   for (const person of people) {
     if (!person?.id || !person?.name) continue;
     try {
@@ -71,7 +74,9 @@ async function syncPeerDirectory(peer: Peer) {
         email: `${BOT_PREFIX.invitePerson}${slugify(peer.name)}-${slugify(person.name)}@${UTILITY_EMAIL_DOMAIN}`,
         fullName: markerName.person(person.name, peer.name),
       });
-    } catch (e) { log(`could not create an invite target for "${person.name}": ${e.message}`); }
+    } catch (e) {
+      log(`could not create an invite target for "${person.name}": ${e.message}`);
+    }
   }
 }
 
@@ -84,7 +89,7 @@ function inviteTargetsFor(peerPub: string) {
 
 /** Immich album roles map onto the permission a share link would have carried. */
 export const permissionFor = (role?: string): 'view' | 'contribute' =>
-  (role === 'editor' ? 'contribute' : 'view');
+  role === 'editor' ? 'contribute' : 'view';
 
 /**
  * Sharing is PER PERSON. There is deliberately no household-wide stand-in: a server link is not
@@ -109,13 +114,16 @@ async function albumsAsMarker(markerKey: string, markerUserId: string): Promise<
   const visible = new Set<string>();
   for (const a of albums || []) {
     visible.add(a.id);
-    const mine = (a.albumUsers || []).find((au) => au.user?.id === markerUserId);
+    const mine = (a.albumUsers || []).find(au => au.user?.id === markerUserId);
     // 'owner' means this is a mirror we created for inbound content, not an invitation
     if (!mine || mine.role === 'owner') continue;
     // v3 album responses carry no ownerId — the owner is only discoverable inside albumUsers
-    const owner = (a.albumUsers || []).find((au) => au.role === 'owner');
-    invited.set(a.id, { name: a.albumName, permissions: permissionFor(mine.role),
-                        ownerName: owner?.user?.name });
+    const owner = (a.albumUsers || []).find(au => au.role === 'owner');
+    invited.set(a.id, {
+      name: a.albumName,
+      permissions: permissionFor(mine.role),
+      ownerName: owner?.user?.name,
+    });
   }
   return { invited, visible };
 }
@@ -132,7 +140,7 @@ export async function detectInvitesOnce() {
     // given album: inviting two people from the same household to one album must mirror for both.
     // Abort the peer on ANY read failure — a partial view is indistinguishable from a withdrawal.
     const targets = inviteTargetsFor(peer.pub);
-    if (!targets.length) continue;               // directory not shared yet, or SHARE_USER_DIRECTORY=false
+    if (!targets.length) continue; // directory not shared yet, or SHARE_USER_DIRECTORY=false
     const seen: Seen = { invited: new Map(), visible: new Set() };
     const invitees = new Map<string, Set<string>>();
     let readFailed = false;
@@ -147,36 +155,58 @@ export async function detectInvitesOnce() {
           }
         }
         for (const id of part.visible) seen.visible.add(id);
-      } catch (e) { log(`could not read invitations for "${peer.name}": ${e.message}`); readFailed = true; break; }
+      } catch (e) {
+        log(`could not read invitations for "${peer.name}": ${e.message}`);
+        readFailed = true;
+        break;
+      }
     }
     if (readFailed) continue;
 
     for (const [albumId, a] of seen.invited) {
       const forPeerUserIds = [...(invitees.get(albumId) || [])];
-      if (!forPeerUserIds.length) continue;      // invited nobody we can name — nothing to offer
-      const existing = state.mappings.find(mp => mp.role === 'owner' && mp.peer === peer.pub && mp.albumId === albumId);
+      if (!forPeerUserIds.length) continue; // invited nobody we can name — nothing to offer
+      const existing = state.mappings.find(
+        mp => mp.role === 'owner' && mp.peer === peer.pub && mp.albumId === albumId
+      );
       if (!existing) {
-        state.mappings.push({ id: crypto.randomUUID(), role: 'owner', albumId, albumName: a.name,
-          peer: peer.pub, permissions: a.permissions, via: 'invite', albumOwnerName: a.ownerName,
-          forPeerUserIds });
+        state.mappings.push({
+          id: crypto.randomUUID(),
+          role: 'owner',
+          albumId,
+          albumName: a.name,
+          peer: peer.pub,
+          permissions: a.permissions,
+          via: 'invite',
+          albumOwnerName: a.ownerName,
+          forPeerUserIds,
+        });
         save();
         // A silent persistence failure here would mean invitations are re-detected on every
         // restart and withdrawals forgotten, so verify rather than assume.
         const persisted = (store.state.mappings || []).some(x => x.albumId === albumId && x.via === 'invite');
-        log(`invited ${forPeerUserIds.length} person(s) at "${peer.name}" to "${a.name}" (${a.permissions}) — shared natively, no link needed`
-            + (persisted ? '' : ' [WARNING: mapping did not persist]'));
+        log(
+          `invited ${forPeerUserIds.length} person(s) at "${peer.name}" to "${a.name}" (${a.permissions}) — shared natively, no link needed` +
+            (persisted ? '' : ' [WARNING: mapping did not persist]')
+        );
         continue;
       }
       let changed = false;
-      if (existing.dead) { existing.dead = false; changed = true; log(`invitation re-added: "${peer.name}" -> "${a.name}"`); }
+      if (existing.dead) {
+        existing.dead = false;
+        changed = true;
+        log(`invitation re-added: "${peer.name}" -> "${a.name}"`);
+      }
       // people added to / removed from the invite while the album stays shared
       const before = (existing.forPeerUserIds || []).slice().sort().join(',');
       if (before !== forPeerUserIds.slice().sort().join(',')) {
-        existing.forPeerUserIds = forPeerUserIds; changed = true;
+        existing.forPeerUserIds = forPeerUserIds;
+        changed = true;
         log(`invitation for "${a.name}" now names ${forPeerUserIds.length} person(s) at "${peer.name}"`);
       }
       if (existing.permissions !== a.permissions) {
-        existing.permissions = a.permissions; changed = true;
+        existing.permissions = a.permissions;
+        changed = true;
         log(`invitation for "${peer.name}" on "${a.name}" is now ${a.permissions}`);
       }
       if (changed) save();
@@ -197,7 +227,8 @@ export async function detectInvitesOnce() {
       if (seen.invited.has(mp.albumId)) continue;
       // still visible but not invited => the stand-in owns it, or was demoted oddly; leave it
       if (seen.visible.has(mp.albumId)) continue;
-      mp.dead = true; save();
+      mp.dead = true;
+      save();
       log(`invitation withdrawn: "${peer.name}" removed from "${mp.albumName}" — no longer syncing it`);
     }
   }
@@ -230,33 +261,43 @@ export const invitationsFor = (peerPub: string) =>
  * the album forever — the sender's action would appear to work and quietly do nothing.
  */
 async function syncMirrorMembers(mapping: Mapping, forUserIds: string[]) {
-  if (!forUserIds.length) return;                 // "nobody named" is handled as a withdrawal
   const host = mapping.adminSlug ? state.contributors[mapping.adminSlug] : undefined;
   if (!host?.key) return;
   let alb;
-  try { alb = await immichJson(`/albums/${mapping.albumId}`, {}, host.key); }
-  catch { return; }                               // album gone: the withdrawal path will clean up
-  const wanted = new Set(forUserIds);
-  const current = (alb.albumUsers || []).filter((au) => au.role !== 'owner' && au.user?.id);
-  const humans = (await immichJson('/admin/users')).filter((u) => !isUtilityEmail(u.email));
-  const localIds = new Set(humans.map((u) => u.id));
-
-  const toAdd = humans.filter((u) => wanted.has(u.id) && !current.some((au) => au.user.id === u.id));
-  if (toAdd.length) {
+  try {
+    alb = await immichJson(`/albums/${mapping.albumId}`, {}, host.key);
+  } catch {
+    return;
+  } // album gone: the withdrawal path will clean up
+  const humans = (await immichJson('/admin/users')).filter(u => !isUtilityEmail(u.email));
+  // The set arithmetic lives in invitees.ts so it can be tested without a container — this is
+  // the only path that removes a real person from a real album.
+  const { add, remove } = diffInvitees({
+    wanted: forUserIds,
+    current: (alb.albumUsers || []).filter(au => au.role !== 'owner' && au.user?.id).map(au => au.user.id),
+    local: humans.map(u => u.id),
+  });
+  if (add.length) {
     try {
-      await immichJson(`/albums/${mapping.albumId}/users`,
-        { ...jsonBody({ albumUsers: toAdd.map((u) => ({ userId: u.id, role: 'editor' })) }), method: 'PUT' }, host.key);
-      log(`invitation for "${mapping.albumName}" now includes ${toAdd.length} more of us`);
-    } catch (e) { log(`could not widen mirror "${mapping.albumName}": ${e.message}`); }
+      await immichJson(
+        `/albums/${mapping.albumId}/users`,
+        { ...jsonBody({ albumUsers: add.map(id => ({ userId: id, role: 'editor' })) }), method: 'PUT' },
+        host.key
+      );
+      log(`invitation for "${mapping.albumName}" now includes ${add.length} more of us`);
+    } catch (e) {
+      log(`could not widen mirror "${mapping.albumName}": ${e.message}`);
+    }
   }
-  // Only ever remove OUR OWN humans. Utility users own the mirror and its stubs; removing one
-  // would strand the content it holds.
-  for (const au of current) {
-    if (!localIds.has(au.user.id) || wanted.has(au.user.id)) continue;
+  for (const id of remove) {
     try {
-      await immichJson(`/albums/${mapping.albumId}/user/${au.user.id}`, { method: 'DELETE' }, host.key);
-      log(`"${au.user.name}" was dropped from the invitation to "${mapping.albumName}" — removed locally`);
-    } catch (e) { log(`could not narrow mirror "${mapping.albumName}": ${e.message}`); }
+      await immichJson(`/albums/${mapping.albumId}/user/${id}`, { method: 'DELETE' }, host.key);
+      log(
+        `"${humans.find(u => u.id === id)?.name || id}" was dropped from the invitation to "${mapping.albumName}" — removed locally`
+      );
+    } catch (e) {
+      log(`could not narrow mirror "${mapping.albumName}": ${e.message}`);
+    }
   }
 }
 
@@ -272,9 +313,11 @@ export async function pullInvitationsOnce() {
     let invitations;
     try {
       const r = await signedGet(`${peer.url}${ROUTE_PREFIX}/api/v1/invitations`, 'invitations');
-      if (!r.ok) continue;                       // old peer, or not sharing anything with us
+      if (!r.ok) continue; // old peer, or not sharing anything with us
       invitations = (await r.json()).invitations || [];
-    } catch { continue; }                        // unreachable: try again next cycle
+    } catch {
+      continue;
+    } // unreachable: try again next cycle
 
     const offered = new Set<string>();
     for (const inv of invitations) {
@@ -282,8 +325,9 @@ export async function pullInvitationsOnce() {
       const albumId = inv?.album?.id;
       if (!albumId) continue;
       // already mirrored, or we are the origin of this album ourselves
-      const known = state.mappings.find(mp => mp.peer === peer.pub && !mp.dead
-        && (mp.remoteAlbumId === albumId || mp.albumId === albumId));
+      const known = state.mappings.find(
+        mp => mp.peer === peer.pub && !mp.dead && (mp.remoteAlbumId === albumId || mp.albumId === albumId)
+      );
       if (known) {
         // The sender can add or drop individual people without withdrawing the album. Follow it,
         // or a de-invited person keeps the mirror forever and revocation silently does nothing.
@@ -293,8 +337,11 @@ export async function pullInvitationsOnce() {
         // authoritative over it — narrowing one would evict people who joined by link. A throw
         // here must not abandon the rest of this peer's invitations either.
         if (known.role === 'member' && known.via === 'invite') {
-          try { await syncMirrorMembers(known, inv.forUserIds || []); }
-          catch (e) { log(`could not follow the invitee list for "${known.albumName}": ${e.message}`); }
+          try {
+            await syncMirrorMembers(known, inv.forUserIds || []);
+          } catch (e) {
+            log(`could not follow the invitee list for "${known.albumName}": ${e.message}`);
+          }
         }
         continue;
       }
@@ -311,10 +358,14 @@ export async function pullInvitationsOnce() {
           forUserIds: inv.forUserIds || [],
         });
         if (created) {
-          log(`"${peer.name}" invited ${(inv.forUserIds || []).length} of us to "${inv.album.name}" — mirrored it (${inv.permissions})`);
+          log(
+            `"${peer.name}" invited ${(inv.forUserIds || []).length} of us to "${inv.album.name}" — mirrored it (${inv.permissions})`
+          );
           fillMirrorInBackground(mapping, peer);
         }
-      } catch (e) { log(`could not mirror invitation "${inv.album?.name}": ${e.message}`); }
+      } catch (e) {
+        log(`could not mirror invitation "${inv.album?.name}": ${e.message}`);
+      }
     }
 
     // Withdrawn upstream: tear the mirror down rather than leaving a stale album of
@@ -327,7 +378,9 @@ export async function pullInvitationsOnce() {
       try {
         await leaveAlbum(mp.id);
         log(`"${peer.name}" withdrew "${mp.albumName}" — removed the mirror it created`);
-      } catch (e) { log(`could not remove withdrawn mirror "${mp.albumName}": ${e.message}`); }
+      } catch (e) {
+        log(`could not remove withdrawn mirror "${mp.albumName}": ${e.message}`);
+      }
     }
   }
 }
@@ -343,9 +396,20 @@ export function startInviteLoop() {
   setInterval(() => {
     if (INVITES_RUNNING) return;
     INVITES_RUNNING = true;
-    (async () => {
-      try { await detectInvitesOnce(); } catch (e) { log(`invite detection error: ${e.message}`); }
-      try { await pullInvitationsOnce(); } catch (e) { log(`invitation pull error: ${e.message}`); }
-    })().finally(() => { INVITES_RUNNING = false; });
+    // `void`: the tick owns its errors and clears the guard in .finally — do not await it.
+    void (async () => {
+      try {
+        await detectInvitesOnce();
+      } catch (e) {
+        log(`invite detection error: ${e.message}`);
+      }
+      try {
+        await pullInvitationsOnce();
+      } catch (e) {
+        log(`invitation pull error: ${e.message}`);
+      }
+    })().finally(() => {
+      INVITES_RUNNING = false;
+    });
   }, CFG.pollMs);
 }

--- a/src/sync/leave.ts
+++ b/src/sync/leave.ts
@@ -17,15 +17,19 @@ import { forgetOffered } from '../p2p/entitlement.ts';
 // fully reversible and reclaims all space it ever took.
 export async function leaveAlbum(mappingId: string) {
   const mapping = state.mappings.find(mp => mp.id === mappingId);
-  if (!mapping || mapping.role !== 'member') throw new Error('unknown mapping (only joined albums can be left)');
+  if (!mapping || mapping.role !== 'member')
+    throw new Error('unknown mapping (only joined albums can be left)');
   let removed = 0;
   for (const entry of store.seenForMapping(mapping.id)) {
-    if (entry.o && await deleteProxyAsset(entry.l)) removed++;
+    if (entry.o && (await deleteProxyAsset(entry.l))) removed++;
   }
   const host = mapping.adminSlug ? state.contributors[mapping.adminSlug] : undefined;
   if (host?.key) {
-    try { await immichJson(`/albums/${mapping.albumId}`, { method: 'DELETE' }, host.key); }
-    catch (e) { log(`mirror album delete failed: ${e.message}`); }
+    try {
+      await immichJson(`/albums/${mapping.albumId}`, { method: 'DELETE' }, host.key);
+    } catch (e) {
+      log(`mirror album delete failed: ${e.message}`);
+    }
   }
   store.seenRemoveMapping(mapping.id);
   forgetOffered(mapping.id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,15 +18,17 @@ export type Household = {
 
 /** One photo living on its owner's server, referenced into a shared album. */
 export type AssetRef = {
-  originAsset: string;      // asset id on the origin server
-  checksum: string;         // sha1 of the original bytes (Immich native)
-  contributor: {            // person, not server — provenance survives mirroring
+  originAsset: string; // asset id on the origin server
+  checksum: string; // sha1 of the original bytes (Immich native)
+  contributor: {
+    // person, not server — provenance survives mirroring
     displayName: string;
     originUserId: string;
   };
   kind: 'image' | 'video';
   takenAt?: string;
-  exif?: {                  // re-applied to the materialised proxy
+  exif?: {
+    // re-applied to the materialised proxy
     latitude?: number;
     longitude?: number;
     description?: string;
@@ -36,15 +38,15 @@ export type AssetRef = {
 
 /** POST /immich-shared-albums/api/v1/invites/redeem — consume a share link as a household. */
 export type RedeemRequest = {
-  shareKey: string;         // the Immich share-link key IS the capability
-  household: Household;     // joiner introduces itself; key pinned on success
+  shareKey: string; // the Immich share-link key IS the capability
+  household: Household; // joiner introduces itself; key pinned on success
 };
 export type RedeemResponse = {
-  household: Household;     // owner's identity, pinned by the joiner
+  household: Household; // owner's identity, pinned by the joiner
   album: { id: string; name: string; permissions: 'view' | 'contribute' };
   albumOwner: { displayName: string; originUserId: string };
-  manifest: AssetRef[];     // current human-owned photos; previews fetched separately
-  mappingId: string;        // quote this in refs/activity/manifest calls
+  manifest: AssetRef[]; // current human-owned photos; previews fetched separately
+  mappingId: string; // quote this in refs/activity/manifest calls
 };
 
 /** POST /immich-shared-albums/api/v1/albums/:mappingId/refs — offer new refs to a peer. */

--- a/src/web/auth.ts
+++ b/src/web/auth.ts
@@ -30,7 +30,9 @@ export async function callerIdentity(req): Promise<Caller | null> {
     if (!r.ok) return null;
     const u = await r.json();
     return u?.id ? { id: u.id, name: u.name, isAdmin: !!u.isAdmin } : null;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
 
 /** 401 body that tells a browser where to go to fix it. */

--- a/src/web/banner.ts
+++ b/src/web/banner.ts
@@ -10,7 +10,9 @@ export let BANNER_JS = '';
 try {
   // banner.js hardcodes the default prefix so it stays valid standalone (see banner/preview.html);
   // rewriting it here keeps config.ROUTE_PREFIX the single source of truth.
-  BANNER_JS = fs.readFileSync(new URL('./banner/banner.js', import.meta.url), 'utf8')
+  BANNER_JS = fs
+    .readFileSync(new URL('./banner/banner.js', import.meta.url), 'utf8')
     .replaceAll('/immich-shared-albums/', `${ROUTE_PREFIX}/`);
+} catch {
+  log('banner.js not bundled — share pages will be served un-injected');
 }
-catch { log('banner.js not bundled — share pages will be served un-injected'); }

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -11,7 +11,8 @@ import { CFG, ROUTE_PREFIX } from '../config.ts';
 import { linkedPeers } from '../p2p/unlink.ts';
 import { state } from '../state.ts';
 
-export const PANEL = () => `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+export const PANEL =
+  () => `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>${CFG.name} — shared albums</title>
 <style>
  body{margin:0;font-family:Inter,-apple-system,sans-serif;background:#101216;color:#e5e7eb;display:grid;place-items:start center;min-height:100vh}
@@ -40,11 +41,17 @@ export const PANEL = () => `<!doctype html><meta charset="utf-8"><meta name="vie
   <p class="muted" style="font-size:13px">Once a server is connected, its people appear in Immich's
    own “share album” picker. Unlinking removes them from the picker, tears down the albums they
    shared with you, and stops serving the albums you shared with them.</p>
-  ${linkedPeers().map(p => `<div class="item">
+  ${
+    linkedPeers()
+      .map(
+        p => `<div class="item">
     <span>${p.name}<br><span class="muted" style="font-size:12px">${p.url}${p.version ? ` · v${p.version}` : ''}</span></span>
     <span style="text-align:right"><span class="muted" style="font-size:12px">${p.people} ${p.people === 1 ? 'person' : 'people'} · ${p.sharedToThem} out · ${p.sharedToUs} in</span><br>
-     <button class="danger" onclick="unlink('${p.pub}','${p.name.replace(/'/g, "\\'")}')">Unlink</button></span></div>`).join('')
-   || '<p class="muted" style="font-size:13px">None yet — join a shared album above to connect one.</p>'}
+     <button class="danger" onclick="unlink('${p.pub}','${p.name.replace(/'/g, "\\'")}')">Unlink</button></span></div>`
+      )
+      .join('') ||
+    '<p class="muted" style="font-size:13px">None yet — join a shared album above to connect one.</p>'
+  }
   <div id="umsg"></div></div>
 </main>
 <script>async function j(e){e.preventDefault();
@@ -66,7 +73,8 @@ async function unlink(pub,name){
  const d=await r.json().catch(()=>({error:'failed'}));
  el.textContent=r.ok?('Unlinked '+d.household+' — '+d.mirrorsRemoved+' album(s) removed, '+d.sharesRevoked+' share(s) revoked.'):('Error: '+(d.error||r.status));
  if(r.ok)setTimeout(()=>location.reload(),1800)}</script>`;
-export const ACCEPT_PAGE = () => `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+export const ACCEPT_PAGE =
+  () => `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Join shared album — ${CFG.name}</title>
 <style>
  body{margin:0;font-family:Overpass,Inter,Roboto,-apple-system,sans-serif;background:#f8f9fa;color:#202124;display:grid;place-items:center;min-height:100vh}

--- a/src/web/passthrough.ts
+++ b/src/web/passthrough.ts
@@ -18,7 +18,8 @@ import { BANNER_JS } from './banner.ts';
 export async function proxyToImmich(req, res, pathname: string): Promise<void> {
   const headers: Record<string, string> = {};
   for (const [k, v] of Object.entries(req.headers)) {
-    if (typeof v === 'string') headers[k] = v; else if (Array.isArray(v)) headers[k] = v.join(', ');
+    if (typeof v === 'string') headers[k] = v;
+    else if (Array.isArray(v)) headers[k] = v.join(', ');
   }
   delete headers.host;
   const hasBody = !['GET', 'HEAD'].includes(req.method);
@@ -31,17 +32,24 @@ export async function proxyToImmich(req, res, pathname: string): Promise<void> {
     redirect: 'manual',
   } as RequestInit);
   const outHeaders = {};
-  for (const [k, v] of up.headers) if (!['content-encoding', 'transfer-encoding', 'content-length'].includes(k)) outHeaders[k] = v;
+  for (const [k, v] of up.headers)
+    if (!['content-encoding', 'transfer-encoding', 'content-length'].includes(k)) outHeaders[k] = v;
   const setCookie = up.headers.getSetCookie?.() || [];
   if (setCookie.length) outHeaders['set-cookie'] = setCookie;
   const ct = up.headers.get('content-type') || '';
   if (req.method === 'GET' && pathname.startsWith('/share/') && ct.includes('text/html') && BANNER_JS) {
     let html = Buffer.from(await up.arrayBuffer()).toString();
-    html = html.includes('</body>') ? html.replace('</body>', `<script src="${ROUTE_PREFIX}/banner.js" defer></script></body>`)
-                                    : html + `<script src="${ROUTE_PREFIX}/banner.js" defer></script>`;
-    res.writeHead(up.status, outHeaders); res.end(html); return;
+    html = html.includes('</body>')
+      ? html.replace('</body>', `<script src="${ROUTE_PREFIX}/banner.js" defer></script></body>`)
+      : html + `<script src="${ROUTE_PREFIX}/banner.js" defer></script>`;
+    res.writeHead(up.status, outHeaders);
+    res.end(html);
+    return;
   }
   res.writeHead(up.status, outHeaders);
-  if (!up.body) { res.end(); return; }
+  if (!up.body) {
+    res.end();
+    return;
+  }
   Readable.fromWeb(up.body).pipe(res);
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -42,19 +42,28 @@ import { invitationsFor, localDirectory } from '../sync/invites.ts';
  */
 async function readCappedBody(req): Promise<string | null> {
   const max = CFG.maxBodyKb * 1024;
-  if (Number(req.headers['content-length'] || 0) > max) { req.resume(); return null; }
+  if (Number(req.headers['content-length'] || 0) > max) {
+    req.resume();
+    return null;
+  }
   const chunks = [];
   let size = 0;
   for await (const c of req) {
     size += c.length;
-    if (size > max) { req.resume(); return null; }
+    if (size > max) {
+      req.resume();
+      return null;
+    }
     chunks.push(c);
   }
   return Buffer.concat(chunks).toString();
 }
 
 export const server = http.createServer(async (req, res) => {
-  const send = (code, obj) => { res.writeHead(code, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(obj)); };
+  const send = (code, obj) => {
+    res.writeHead(code, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(obj));
+  };
   try {
     const u = new URL(req.url, 'http://x');
     const path = u.pathname;
@@ -66,25 +75,30 @@ export const server = http.createServer(async (req, res) => {
       const peerKey = req.headers['x-isa-key'] as string;
       const peer = state.peers.find(pp => pp.pub === peerKey);
       const related = peer && state.mappings.some(mp => mp.peer === peerKey && !mp.dead);
-      if (!peer || !related || !verify(m[1], req.headers['x-isa-sig'] as string || '', peerKey)) {
+      if (!peer || !related || !verify(m[1], (req.headers['x-isa-sig'] as string) || '', peerKey)) {
         return send(403, { error: 'unknown or unverified peer' });
       }
       try {
         const av = await immich(`/users/${m[1]}/profile-image`);
         res.writeHead(200, { 'Content-Type': av.headers.get('content-type') || 'image/jpeg' });
         return res.end(Buffer.from(await av.arrayBuffer()));
-      } catch { return send(404, { error: 'no avatar' }); }
+      } catch {
+        return send(404, { error: 'no avatar' });
+      }
     }
     if (path === `${ROUTE_PREFIX}/banner.js`) {
-      res.writeHead(200, { 'Content-Type': 'application/javascript' }); return res.end(BANNER_JS);
+      res.writeHead(200, { 'Content-Type': 'application/javascript' });
+      return res.end(BANNER_JS);
     }
     if (path === `${ROUTE_PREFIX}/accept`) {
-      res.writeHead(200, { 'Content-Type': 'text/html' }); return res.end(ACCEPT_PAGE());
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      return res.end(ACCEPT_PAGE());
     }
     // Byte interceptors (hotlink model): the app's own asset URLs are served with true
     // bytes streamed live from the owner's server for proxy assets. See media/interceptor.
     const assetHit = u.pathname.match(/^\/api\/assets\/([^/]+)\/(thumbnail|original|video\/playback)$/);
-    if (assetHit && req.method === 'GET' && await serveInterceptedBytes(req, res, assetHit[1], assetHit[2])) return;
+    if (assetHit && req.method === 'GET' && (await serveInterceptedBytes(req, res, assetHit[1], assetHit[2])))
+      return;
     // Everything that isn't a sidecar route -> transparent proxy to Immich (banner-injected
     // on /share pages). Streams both ways: uploads must not be buffered here.
     if (!path.startsWith(ROUTE_PREFIX)) return proxyToImmich(req, res, u.pathname);
@@ -99,7 +113,8 @@ export const server = http.createServer(async (req, res) => {
         res.writeHead(caller ? 403 : 401, { 'Content-Type': 'text/html' });
         return res.end(SIGN_IN_PAGE('manage shared albums'));
       }
-      res.writeHead(200, { 'Content-Type': 'text/html' }); return res.end(PANEL());
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      return res.end(PANEL());
     }
     if (path === `${ROUTE_PREFIX}/join` && req.method === 'POST') {
       // The account being joined is the SIGNED-IN one. The request body may name a
@@ -114,16 +129,22 @@ export const server = http.createServer(async (req, res) => {
         }
         return send(200, await join(b.url, forUserId, b.password));
       } catch (e) {
-        return send(e.passwordRequired ? 401 : 400,
-          e.passwordRequired ? { error: e.message, passwordRequired: true } : { error: e.message });
+        return send(
+          e.passwordRequired ? 401 : 400,
+          e.passwordRequired ? { error: e.message, passwordRequired: true } : { error: e.message }
+        );
       }
     }
     if (path === `${ROUTE_PREFIX}/leave` && req.method === 'POST') {
       const caller = await callerIdentity(req);
       if (!caller) return send(401, signInRequired('leave a shared album'));
       if (!caller.isAdmin) return send(403, { error: 'only an admin can remove a shared album' });
-      try { const b = JSON.parse(body); return send(200, await leaveAlbum(b.mappingId)); }
-      catch (e) { return send(400, { error: e.message }); }
+      try {
+        const b = JSON.parse(body);
+        return send(200, await leaveAlbum(b.mappingId));
+      } catch (e) {
+        return send(400, { error: e.message });
+      }
     }
     // Server links are admin-owned, so managing them is an admin route — not something expressed
     // by removing a bot from an album. See p2p/unlink.ts.
@@ -137,26 +158,51 @@ export const server = http.createServer(async (req, res) => {
       const caller = await callerIdentity(req);
       if (!caller) return send(401, signInRequired('unlink a server'));
       if (!caller.isAdmin) return send(403, { error: 'only an admin can unlink a server' });
-      try { const b = JSON.parse(body); return send(200, await unlinkPeer(b.pub)); }
-      catch (e) { return send(400, { error: e.message }); }
+      try {
+        const b = JSON.parse(body);
+        return send(200, await unlinkPeer(b.pub));
+      } catch (e) {
+        return send(400, { error: e.message });
+      }
     }
     if (path === `${ROUTE_PREFIX}/api/v1/invites/redeem` && req.method === 'POST') {
-      const [code, obj] = await handleRedeem(req, body); return send(code, obj);
+      const [code, obj] = await handleRedeem(req, body);
+      return send(code, obj);
     }
-    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/activity$/)) && req.method === 'POST') {
-      const [code, obj] = await handleActivity(req, body, m[1]); return send(code, obj);
+    if (
+      (m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/activity$/)) &&
+      req.method === 'POST'
+    ) {
+      const [code, obj] = await handleActivity(req, body, m[1]);
+      return send(code, obj);
     }
-    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/refs$/)) && req.method === 'POST') {
-      const [code, obj] = await handleRefs(req, body, m[1]); return send(code, obj);
+    if (
+      (m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/refs$/)) &&
+      req.method === 'POST'
+    ) {
+      const [code, obj] = await handleRefs(req, body, m[1]);
+      return send(code, obj);
     }
-    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/version$/)) && req.method === 'GET') {
-      const [code, obj] = await handleVersion(req, m[1]); return send(code, obj);
+    if (
+      (m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/version$/)) &&
+      req.method === 'GET'
+    ) {
+      const [code, obj] = await handleVersion(req, m[1]);
+      return send(code, obj);
     }
-    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/manifest$/)) && req.method === 'GET') {
-      const [code, obj] = await handleManifest(req, m[1]); return send(code, obj);
+    if (
+      (m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/manifest$/)) &&
+      req.method === 'GET'
+    ) {
+      const [code, obj] = await handleManifest(req, m[1]);
+      return send(code, obj);
     }
-    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/comments$/)) && req.method === 'GET') {
-      const [code, obj] = await handleComments(req, m[1]); return send(code, obj);
+    if (
+      (m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/comments$/)) &&
+      req.method === 'GET'
+    ) {
+      const [code, obj] = await handleComments(req, m[1]);
+      return send(code, obj);
     }
     // Our people, so a paired household can invite one of us specifically. Names only.
     if (path === `${ROUTE_PREFIX}/api/v1/directory` && req.method === 'GET') {
@@ -170,14 +216,22 @@ export const server = http.createServer(async (req, res) => {
       if (!peer) return send(403, { error: 'unknown or unverified peer' });
       return send(200, { invitations: invitationsFor(peer.pub) });
     }
-    if ((m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/nudge$/)) && req.method === 'POST') {
-      const [code, obj] = await handleNudge(req, body, m[1]); return send(code, obj);
+    if (
+      (m = path.match(/^\/immich-shared-albums\/api\/v1\/albums\/([^/]+)\/nudge$/)) &&
+      req.method === 'POST'
+    ) {
+      const [code, obj] = await handleNudge(req, body, m[1]);
+      return send(code, obj);
     }
-    const streamOut = (out) => { // stream byte responses through — never buffer (Pi-friendly)
+    const streamOut = out => {
+      // stream byte responses through — never buffer (Pi-friendly)
       if (Array.isArray(out)) return send(out[0], out[1]);
-      const headers: Record<string, string> = { 'Content-Type': out.headers.get('content-type') || 'application/octet-stream' };
+      const headers: Record<string, string> = {
+        'Content-Type': out.headers.get('content-type') || 'application/octet-stream',
+      };
       for (const h of ['content-length', 'content-range', 'accept-ranges']) {
-        const v = out.headers.get(h); if (v) headers[h] = v;
+        const v = out.headers.get(h);
+        if (v) headers[h] = v;
       }
       res.writeHead(out.status || 200, headers);
       Readable.fromWeb(out.body).pipe(res);
@@ -201,5 +255,8 @@ export const server = http.createServer(async (req, res) => {
       return res.end(JSON.stringify({ ok: true }));
     }
     send(404, { error: 'not found' });
-  } catch (e) { log('http error:', e.message); send(500, { error: e.message }); }
+  } catch (e) {
+    log('http error:', e.message);
+    send(500, { error: e.message });
+  }
 });

--- a/src/web/upgrade.ts
+++ b/src/web/upgrade.ts
@@ -25,9 +25,17 @@ import { CFG, log, ROUTE_PREFIX } from '../config.ts';
  */
 export function proxyUpgrade(req, socket, head: Buffer): void {
   // nothing under our own prefix speaks a websocket — refuse rather than open a socket
-  if ((req.url || '').startsWith(ROUTE_PREFIX)) { socket.destroy(); return; }
+  if ((req.url || '').startsWith(ROUTE_PREFIX)) {
+    socket.destroy();
+    return;
+  }
   let target: URL;
-  try { target = new URL(CFG.immichUrl); } catch { socket.destroy(); return; }
+  try {
+    target = new URL(CFG.immichUrl);
+  } catch {
+    socket.destroy();
+    return;
+  }
 
   const upstream = net.connect({
     host: target.hostname,
@@ -35,14 +43,16 @@ export function proxyUpgrade(req, socket, head: Buffer): void {
   });
   const bail = (why: string) => (e?: Error) => {
     if (e) log(`websocket proxy ${why}: ${e.message}`);
-    upstream.destroy(); socket.destroy();
+    upstream.destroy();
+    socket.destroy();
   };
   socket.setNoDelay(true);
   upstream.setNoDelay(true);
 
   upstream.on('connect', () => {
     const lines = [`${req.method} ${req.url} HTTP/1.1`];
-    for (let i = 0; i < req.rawHeaders.length; i += 2) lines.push(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}`);
+    for (let i = 0; i < req.rawHeaders.length; i += 2)
+      lines.push(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}`);
     upstream.write(`${lines.join('\r\n')}\r\n\r\n`);
     if (head?.length) upstream.write(head);
     socket.pipe(upstream);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,14 @@
     "noEmit": true,
     "strict": false,
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
> **Stacked on #13** — based on `feat/invite-followups`, so review that first. GitHub will
> retarget this to `main` automatically once #13 merges.

Every bug fixed in #13 had its invariant written down in a comment, and none were enforced by anything. This adds the cheap enforcement, sized so it stays useful rather than becoming something to switch off.

## Fast lane (~200ms)

`npm test` — `node:test` over **pure logic only**, no containers. Each case is a bug that shipped or nearly shipped: bot namespaces staying disjoint, marker names never colliding with contributor names, and the invitee diff. That set arithmetic moved into `sync/invitees.ts` so the one code path that removes a real person from a real album can be checked in milliseconds instead of a seven-minute e2e run.

It runs on `node:24-alpine` — the image the app ships on — because the host Node is older, which also stops local and CI drifting apart.

## ESLint: five rules, zero style rules

No `recommended`/`stylistic` preset. That is where Prettier clashes come from, so its absence is documented in the config as a property to preserve. Three rules catch async bugs in a codebase that is entirely concurrent loops over shared state; `no-restricted-syntax` encodes two invariants that previously lived only in comments:

- never reassign `state.mappings`/`peers`/`contributors` — a reassignment discards a concurrent loop's writes, which is a bug that shipped
- never inline the bot email domain or the protocol number — the last naming bug was one predicate inlined in eleven places that drifted

Verified non-clashing in both directions: `prettier → eslint --fix → prettier --check` and `eslint --fix → prettier → eslint` both settle at the same fixed point.

## It found real things

Three dead imports, a dead defensive init (the store already initialises `contributors`), a dead legacy positional-argument overload, and three fire-and-forget calls now marked `void` so they read as deliberate rather than as a forgotten `await`. `PROTOCOL_VERSION` is now the single source of truth it was always meant to be — it was exported, unused, with the literal inlined in four places.

## Prettier

`printWidth: 110`, chosen because the existing p95 line length is 108, so the house style survives. `demo/` is deliberately excluded — reformatting the 880-line e2e harness would make the history of every future test change unreadable.

## TypeScript, measured rather than guessed

Enabled the **seven strict-family flags that were already clean**, which locks that property in, plus `noUnusedLocals` after clearing the four dead imports it found.

Deliberately left off: `strictNullChecks` (28 errors — worth its own PR with the e2e as a safety net) and `useUnknownInCatchVariables` (41 errors, firing on every idiomatic `catch (e) { e.message }` for almost no benefit).

## Other gates

- **Import cycles** are now checked rather than merely documented, after one was introduced in #13 and verified by hand. Tested both ways: clean here, and it does catch a deliberately reintroduced cycle.
- **CI gains a `checks` job** in parallel with `e2e`, so a lint failure reports as `checks` in ~1 minute instead of as a confusing `e2e` failure after four Immich stacks boot. Worth making a required check alongside `e2e`.
- **`.vscode`** formats and fixes on save; **`.githooks/pre-commit`** runs the fast gate (`git config core.hooksPath .githooks`). The e2e suite is deliberately *not* in the hook — a seven-minute hook is one people bypass.

## AGENTS.md

Now carries the test-first rule and the invariants. TDD is split honestly: strict test-first for pure logic, but **discover → pin → implement** for Immich-facing behaviour, because a test written against a guessed API only pins the guess — and guessing about Immich caused real bugs here (`GET /albums` is per-user scoped; adding an existing owner returns 200 and is silently ignored).

**e2e: 123 checks green** after the reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)