### PR TITLE
fix: enable strictNullChecks, and fix the two real bugs it found

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,17 @@
  */
 
 export const SIDECAR_VERSION = '0.5.0'; // x-release-please-version
+// Read and check this first: the process cannot run without it, so proving that here once
+// means `CFG.apiKey` is a plain `string` everywhere instead of `string | undefined`.
+const apiKey = process.env.IMMICH_API_KEY;
+if (!apiKey) {
+  console.error('IMMICH_API_KEY required');
+  process.exit(1);
+}
+
 export const CFG = {
   immichUrl: process.env.IMMICH_URL || 'http://immich-server:2283',
-  apiKey: process.env.IMMICH_API_KEY,
+  apiKey,
   publicUrl: (process.env.PUBLIC_URL || '').replace(/\/$/, ''),
   name: process.env.HOUSEHOLD_NAME || 'Unnamed household',
   port: Number(process.env.PORT || 8300),
@@ -38,10 +46,6 @@ export const CFG = {
   // at internal services.
   allowPrivatePeers: process.env.ALLOW_PRIVATE_PEERS !== 'false',
 };
-if (!CFG.apiKey) {
-  console.error('IMMICH_API_KEY required');
-  process.exit(1);
-}
 export const log = (...a) => console.log(new Date().toISOString(), ...a);
 export const UTILITY_SUFFIX = ' (via shared albums)';
 

--- a/src/immich/client.ts
+++ b/src/immich/client.ts
@@ -55,7 +55,7 @@ export const getSharedLinkByKey = async key => (await immichJson('/shared-links'
 export const getAlbum = id => immichJson(`/albums/${id}?withoutAssets=true`);
 // Immich v3 removed embedded assets from the album endpoint; search/metadata is the stable enumerator.
 export const getAlbumAssets = async albumId => {
-  const out = [];
+  const out: any[] = [];
   let page = 1;
   while (page) {
     const res = await immichJson(

--- a/src/immich/contributors.ts
+++ b/src/immich/contributors.ts
@@ -5,7 +5,7 @@
  */
 import crypto from 'node:crypto';
 import { CFG, log, UTILITY_SUFFIX, ROUTE_PREFIX, UTILITY_EMAIL_DOMAIN, BOT_PREFIX } from '../config.ts';
-import { state, save } from '../state.ts';
+import { state, save, keys } from '../state.ts';
 import { immichJson, jsonBody, usersById, USERS } from './client.ts';
 import { sign } from '../peers.ts';
 
@@ -200,7 +200,7 @@ export async function syncAvatar(c, peerUrl, originUserId) {
   if (!peerUrl || !originUserId || c.avatarDone) return;
   try {
     const av = await fetch(`${peerUrl}${ROUTE_PREFIX}/api/v1/users/${originUserId}/avatar`, {
-      headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(originUserId) },
+      headers: { 'x-isa-key': keys.pub, 'x-isa-sig': sign(originUserId) },
       signal: AbortSignal.timeout(30000),
     });
     if (av.ok) {

--- a/src/immich/materialise.ts
+++ b/src/immich/materialise.ts
@@ -5,7 +5,7 @@
  */
 import crypto from 'node:crypto';
 import { log, ROUTE_PREFIX } from '../config.ts';
-import { state, seenHas, seenAdd } from '../state.ts';
+import { state, seenHas, seenAdd, keys } from '../state.ts';
 import { sign } from '../peers.ts';
 import { STUB_JPEG, immichJson, jsonBody, uploadAsset, addToAlbum, applyRefMetadata } from './client.ts';
 import { ensureContributor } from './contributors.ts';
@@ -14,7 +14,7 @@ import { ensureContributor } from './contributors.ts';
 // false (without marking seen) on failure so reconciliation can retry later.
 export async function materialiseRef(mapping, peerUrl, fallbackName, ref) {
   if (seenHas(mapping.id, ref.checksum)) return true;
-  const sigHeaders = v => ({ headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(v) } });
+  const sigHeaders = v => ({ headers: { 'x-isa-key': keys.pub, 'x-isa-sig': sign(v) } });
   // Hotlink model: nothing of the photo is stored here. The mirror asset is a ~2KB
   // unique stub that exists so the stock app has a row to render; every actual pixel
   // (thumbnails, previews, playback, originals) streams live from the owner's server

--- a/src/immich/refs.ts
+++ b/src/immich/refs.ts
@@ -3,6 +3,7 @@
  * assets to AssetRefs, decides what an album may offer a peer (offer set vs push queue),
  * and builds the manifest a member diffs against.
  */
+import type { AssetRef } from '../types.ts';
 import { CFG, UTILITY_SUFFIX } from '../config.ts';
 import { usersById } from './client.ts';
 import { wireChecksum, ledgerByAsset, seenHas } from '../state.ts';
@@ -10,7 +11,7 @@ import { wireChecksum, ledgerByAsset, seenHas } from '../state.ts';
 // A shared photo, described for a peer. For utility-owned proxies (relayed photos)
 // the true contributor is recovered from the utility user's name; the credit line we
 // append locally is stripped so downstream hops don't stack "Shared by" twice.
-export async function assetToRef(a) {
+export async function assetToRef(a): Promise<AssetRef> {
   const u = (await usersById())[a.ownerId];
   const displayName = u?.utility ? u.name.replace(UTILITY_SUFFIX, '') : a.owner?.name || u?.name || CFG.name;
   const description = (a.exifInfo?.description || '').replace(/(?:\n\n)?Shared by [^\n]*$/, '') || undefined;
@@ -18,7 +19,6 @@ export async function assetToRef(a) {
     originAsset: a.id,
     checksum: wireChecksum(a),
     kind: a.type === 'VIDEO' ? 'video' : 'image',
-    fileName: a.originalFileName,
     takenAt: a.exifInfo?.dateTimeOriginal || a.fileCreatedAt,
     exif: a.exifInfo
       ? {
@@ -52,7 +52,7 @@ export async function shareableAssets(assets, mappingId) {
 }
 // Everything shareable with the peer behind mappingId (see shareableAssets for the rules).
 export async function buildManifest(assets) {
-  const out = [];
+  const out: AssetRef[] = [];
   for (const a of await offerableAssets(assets)) out.push(await assetToRef(a));
   return out;
 }

--- a/src/media/interceptor.ts
+++ b/src/media/interceptor.ts
@@ -7,7 +7,7 @@
  */
 import { Readable } from 'node:stream';
 import { CFG, log, ROUTE_PREFIX } from '../config.ts';
-import { state, store } from '../state.ts';
+import { state, store, keys } from '../state.ts';
 import { sign } from '../peers.ts';
 import { immich } from '../immich/client.ts';
 import { fetchTrueBytes } from './proxy.ts';
@@ -47,7 +47,7 @@ export async function serveInterceptedBytes(req, res, assetId: string, rawKind: 
     if (peer2) {
       try {
         const up = await fetch(`${peer2.url}${ROUTE_PREFIX}/api/v1/assets/${entry.o}/preview`, {
-          headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) },
+          headers: { 'x-isa-key': keys.pub, 'x-isa-sig': sign(entry.o) },
           signal: AbortSignal.timeout(30000),
         });
         if (up.ok) {
@@ -94,7 +94,7 @@ export async function serveInterceptedBytes(req, res, assetId: string, rawKind: 
         if (v) headers[h] = v;
       }
       res.writeHead(out.status || 200, headers);
-      Readable.fromWeb(out.body).pipe(res);
+      Readable.fromWeb(out.body as Parameters<typeof Readable.fromWeb>[0]).pipe(res);
       return true;
     }
   } catch (e) {

--- a/src/media/proxy.ts
+++ b/src/media/proxy.ts
@@ -9,7 +9,7 @@
  * that, "a valid peer" would mean "any asset in the library that it can name".
  */
 import { log, ROUTE_PREFIX } from '../config.ts';
-import { state, store } from '../state.ts';
+import { state, store, keys } from '../state.ts';
 import { sign, callingPeer } from '../peers.ts';
 import { peerMayRead } from '../p2p/entitlement.ts';
 import { immich } from '../immich/client.ts';
@@ -42,7 +42,7 @@ export async function fetchTrueBytes(
     const mapping = state.mappings.find(mp => mp.id === entry.m);
     const peer = mapping && state.peers.find(p => p.pub === mapping.peer);
     if (peer) {
-      const headers: Record<string, string> = { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(entry.o) };
+      const headers: Record<string, string> = { 'x-isa-key': keys.pub, 'x-isa-sig': sign(entry.o) };
       if (range) headers.Range = range;
       try {
         const up = await fetchWithHeaderTimeout(

--- a/src/p2p/join.ts
+++ b/src/p2p/join.ts
@@ -5,7 +5,7 @@
  */
 import { CFG, SIDECAR_VERSION, log, ROUTE_PREFIX } from '../config.ts';
 import { PROTOCOL_VERSION } from '../types.ts';
-import { state } from '../state.ts';
+import { state, keys } from '../state.ts';
 import { signedFetch, assertPeerUrlAllowed } from '../peers.ts';
 import { ensureMirror, fillMirrorInBackground } from './mirror.ts';
 
@@ -21,7 +21,7 @@ export async function join(shareUrl, forUserId, password?: string) {
     protocol: PROTOCOL_VERSION,
     version: SIDECAR_VERSION,
     password,
-    household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name },
+    household: { publicKey: keys.pub, url: CFG.publicUrl, name: CFG.name },
   });
   const r = await signedFetch(`${origin}${ROUTE_PREFIX}/api/v1/invites/redeem`, body);
   if (!r.ok) {
@@ -47,8 +47,12 @@ export async function join(shareUrl, forUserId, password?: string) {
       version: res.version,
     });
   }
+  // Pinned just above if it was missing, so this cannot be undefined — but find it once and
+  // say so, rather than looking it up twice and pretending each result might be absent.
+  const peer = state.peers.find(pe => pe.pub === res.household.publicKey);
+  if (!peer) throw new Error('peer record vanished during join — retry');
   const { mapping, created } = await ensureMirror({
-    peer: state.peers.find(pe => pe.pub === res.household.publicKey),
+    peer,
     album: { id: res.album.id, name: res.album.name },
     permissions: res.album.permissions,
     albumOwnerName: res.albumOwner?.displayName,

--- a/src/p2p/protocol.ts
+++ b/src/p2p/protocol.ts
@@ -13,7 +13,7 @@
 import crypto from 'node:crypto';
 import { CFG, SIDECAR_VERSION, log } from '../config.ts';
 import { PROTOCOL_VERSION } from '../types.ts';
-import { state, save } from '../state.ts';
+import { state, save, keys } from '../state.ts';
 import { verify, nudgePeers, callingPeer, mappingFor } from '../peers.ts';
 import { getSharedLinkByKey, getAlbum, getAlbumAssets, ownerName, immichJson } from '../immich/client.ts';
 import { buildManifest } from '../immich/refs.ts';
@@ -113,7 +113,7 @@ export async function handleRedeem(req, body) {
     {
       protocol: PROTOCOL_VERSION,
       version: SIDECAR_VERSION,
-      household: { publicKey: state.keys.pub, url: CFG.publicUrl, name: CFG.name },
+      household: { publicKey: keys.pub, url: CFG.publicUrl, name: CFG.name },
       album: { id: album.id, name: album.albumName, permissions: link.allowUpload ? 'contribute' : 'view' },
       albumOwner,
       manifest,
@@ -129,7 +129,7 @@ export async function handleRefs(req, body, albumMappingId) {
   // the share link's "allow public user to upload" switch, honoured cross-server
   if (mapping.permissions === 'view') return [403, { error: 'view-only album — uploads not allowed' }];
   const { add = [] } = JSON.parse(body);
-  const failed = [];
+  const failed: string[] = [];
   for (const ref of add) {
     try {
       if (!(await materialiseRef(mapping, peer.url, peer.name, ref))) failed.push(ref.checksum);

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -4,7 +4,7 @@
  */
 import crypto from 'node:crypto';
 import dns from 'node:dns/promises';
-import { state } from './state.ts';
+import { state, keys } from './state.ts';
 import { CFG, ROUTE_PREFIX } from './config.ts';
 
 const PRIVATE_V4 = [
@@ -53,7 +53,7 @@ export const sign = body =>
       null,
       Buffer.from(body),
       crypto.createPrivateKey({
-        key: Buffer.from(state.keys.priv, 'base64url'),
+        key: Buffer.from(keys.priv, 'base64url'),
         format: 'der',
         type: 'pkcs8',
       })
@@ -105,13 +105,13 @@ export const signedGet = (url: string, signedValue: string, init: RequestInit = 
   fetch(url, {
     ...init,
     signal: init.signal ?? AbortSignal.timeout(20000),
-    headers: { ...(init.headers || {}), 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(signedValue) },
+    headers: { ...(init.headers || {}), 'x-isa-key': keys.pub, 'x-isa-sig': sign(signedValue) },
   });
 export const signedFetch = (url, body) =>
   fetch(url, {
     signal: AbortSignal.timeout(30000),
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(body) },
+    headers: { 'Content-Type': 'application/json', 'x-isa-key': keys.pub, 'x-isa-sig': sign(body) },
     body,
   });
 // Nudge: tell every OTHER household mapped to this album that it moved, so they pull

--- a/src/state.ts
+++ b/src/state.ts
@@ -10,13 +10,24 @@ import { CFG } from './config.ts';
 fs.mkdirSync(CFG.dataDir, { recursive: true });
 export const store = new Store(CFG.dataDir);
 export const state = store.state;
-if (!state.keys) {
+/**
+ * This household's signing keypair — the sidecar's whole identity on the wire.
+ *
+ * Exported non-null on purpose. `Store.state.keys` is legitimately nullable (nothing exists
+ * before first boot), but it is generated here the moment this module loads and then persisted,
+ * so every consumer downstream can rely on it. Reading `keys` rather than `state.keys` is what
+ * keeps eleven call sites free of null checks that could never fire.
+ */
+function ensureKeys(): { pub: string; priv: string } {
+  if (state.keys) return state.keys;
   const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
   state.keys = {
     pub: publicKey.export({ type: 'spki', format: 'der' }).toString('base64url'),
     priv: privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64url'),
   };
+  return state.keys;
 }
+export const keys = ensureKeys();
 export const save = () => store.save();
 save();
 export const seenHas = (mappingId: string, checksum: string) => store.seenHas(mappingId, checksum);

--- a/src/store.ts
+++ b/src/store.ts
@@ -168,13 +168,15 @@ export class Store {
   ledgerByAsset(assetId: string): SeenEntry | undefined {
     return this.db
       .prepare('SELECT m, c, l, o FROM seen WHERE l = ? ORDER BY (o IS NOT NULL) DESC, rowid DESC LIMIT 1')
-      .get(assetId) as SeenEntry | undefined;
+      .get(assetId) as (SeenEntry & { o: string }) | undefined;
   }
   /** Ledger entry that can chain to the owner (has an origin asset id). */
-  ledgerWithOrigin(assetId: string): SeenEntry | undefined {
+  /** A ledger row that definitely has an origin asset: the SQL filters `o IS NOT NULL`,
+   *  so the type says so and callers stop re-checking what the query already guaranteed. */
+  ledgerWithOrigin(assetId: string): (SeenEntry & { o: string }) | undefined {
     return this.db
       .prepare('SELECT m, c, l, o FROM seen WHERE l = ? AND o IS NOT NULL ORDER BY rowid DESC LIMIT 1')
-      .get(assetId) as SeenEntry | undefined;
+      .get(assetId) as (SeenEntry & { o: string }) | undefined;
   }
   seenRemoveMapping(mappingId: string) {
     this.db.prepare('DELETE FROM seen WHERE m = ?').run(mappingId);

--- a/src/sync/comments.ts
+++ b/src/sync/comments.ts
@@ -4,7 +4,7 @@
  * statistic so messages land in seconds without heavy polling. startCommentLoop runs it.
  */
 import { CFG, log, UTILITY_SUFFIX, ROUTE_PREFIX } from '../config.ts';
-import { state, save, seenActHas, seenActAdd } from '../state.ts';
+import { state, save, seenActHas, seenActAdd, keys } from '../state.ts';
 import { sign, signedFetch, nudgePeers, callingPeer, mappingFor } from '../peers.ts';
 import { immichJson, jsonBody, usersById } from '../immich/client.ts';
 import { ensureContributor } from '../immich/contributors.ts';
@@ -165,7 +165,7 @@ export async function syncCommentsOnce() {
 // This is also what relays member comments onward to other member households.
 export async function pullCanonicalComments(mapping, peer) {
   const target = mapping.remoteMappingId || mapping.remoteAlbumId;
-  const sig = { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(target) } };
+  const sig = { headers: { 'x-isa-key': keys.pub, 'x-isa-sig': sign(target) } };
   const vr = await fetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${target}/version`, {
     ...sig,
     signal: AbortSignal.timeout(15000),

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -4,9 +4,10 @@
  * refs, and propagate deletions. leaveAlbum is the full reverse of a join. startWatchLoop
  * runs it all on an overlap-guarded interval.
  */
+import type { AssetRef } from '../types.ts';
 import { CFG, log, ROUTE_PREFIX } from '../config.ts';
 import type { Mapping, Peer } from '../store.ts';
-import { state, store, save, seenHas, seenAdd, wireChecksum } from '../state.ts';
+import { state, store, save, seenHas, seenAdd, wireChecksum, keys } from '../state.ts';
 import { sign, signedFetch } from '../peers.ts';
 import { getAlbum, getAlbumAssets, usersById } from '../immich/client.ts';
 import { shareableAssets, assetToRef } from '../immich/refs.ts';
@@ -47,9 +48,12 @@ export async function watchOnce() {
         continue;
       }
       const peer = state.peers.find(p => p.pub === mapping.peer);
+      // No peer record: nothing to push to. The reconcile loop below already did this;
+      // without it, peer.url below throws instead of skipping.
+      if (!peer) continue;
       const targetMapping =
         mapping.role === 'member' ? mapping.remoteMappingId || mapping.remoteAlbumId : mapping.albumId;
-      const add = [];
+      const add: AssetRef[] = [];
       for (const a of fresh) add.push(await assetToRef(a));
       const body = JSON.stringify({ add });
       const r = await signedFetch(`${peer.url}${ROUTE_PREFIX}/api/v1/albums/${targetMapping}/refs`, body);
@@ -105,7 +109,7 @@ export async function reconcileMapping(mapping: Mapping, peer: Peer) {
   RECONCILING.add(mapping.id);
   try {
     const target = mapping.remoteMappingId || mapping.remoteAlbumId;
-    const sig = { headers: { 'x-isa-key': state.keys.pub, 'x-isa-sig': sign(target) } };
+    const sig = { headers: { 'x-isa-key': keys.pub, 'x-isa-sig': sign(target) } };
     // handshake first: only pull the full manifest when the origin's version moved.
     // remoteVersion is only stored after a CLEAN pass so failures keep retrying.
     let version = null;

--- a/src/sync/invites.ts
+++ b/src/sync/invites.ts
@@ -150,8 +150,9 @@ export async function detectInvitesOnce() {
         for (const [id, v] of part.invited) {
           if (!seen.invited.has(id)) seen.invited.set(id, v);
           if (t.peerUserId) {
-            if (!invitees.has(id)) invitees.set(id, new Set());
-            invitees.get(id).add(t.peerUserId);
+            let people = invitees.get(id);
+            if (!people) invitees.set(id, (people = new Set()));
+            people.add(t.peerUserId);
           }
         }
         for (const id of part.visible) seen.visible.add(id);

--- a/src/web/passthrough.ts
+++ b/src/web/passthrough.ts
@@ -51,5 +51,5 @@ export async function proxyToImmich(req, res, pathname: string): Promise<void> {
     res.end();
     return;
   }
-  Readable.fromWeb(up.body).pipe(res);
+  Readable.fromWeb(up.body as Parameters<typeof Readable.fromWeb>[0]).pipe(res);
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -46,7 +46,7 @@ async function readCappedBody(req): Promise<string | null> {
     req.resume();
     return null;
   }
-  const chunks = [];
+  const chunks: Buffer[] = [];
   let size = 0;
   for await (const c of req) {
     size += c.length;
@@ -65,7 +65,7 @@ export const server = http.createServer(async (req, res) => {
     res.end(JSON.stringify(obj));
   };
   try {
-    const u = new URL(req.url, 'http://x');
+    const u = new URL(req.url ?? '/', 'http://x');
     const path = u.pathname;
     let m;
     // Peer-facing avatar read. Signed like every other peer route — a bare public key is

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "alwaysStrict": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "strictNullChecks": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
28 errors, **no `!` assertions used**. Most weren't 28 separate problems — they were four nullable declarations that didn't say what the code already guaranteed.

## Four declarations, twenty-odd errors

| | |
|---|---|
| **`state.keys`** | 11 of the 28. Non-null by construction — generated at module load if absent, then persisted — but typed `\| null`, so eleven call sites carried a check that could never fire. `state.ts` now exports a narrowed `keys`. |
| **`CFG.apiKey`** | Guarded by `process.exit(1)` *after* `CFG` was built, so nothing could narrow it. Reading the env var and checking it *before* constructing `CFG` makes it a plain `string` everywhere — and drops a module-level exit that fired after the object already existed. |
| **`ledgerWithOrigin`** | Returns rows from a query filtering `o IS NOT NULL`, but its type didn't say so, so callers re-checked what SQL had already guaranteed. |
| **`assetToRef`** | No return type, so `kind` widened from `'image' \| 'video'` to `string` and nothing matched `AssetRef`. |

## Two genuine bugs

**`sync/engine.ts` was missing a guard.** It pushed refs after `state.peers.find(...)` with no check, then dereferenced `peer.url` — while the reconcile loop forty lines below does the *identical* find and guards it with `if (!peer) continue`. A missing peer record threw a `TypeError` mid-push instead of skipping the mapping. Exactly the asymmetry a human reviewer skims past.

**`sync/invites.ts` had an unchecked `invitees.get(id).add(...)`.** Mine, from #13. Written, reviewed, and run through 123 e2e checks without being caught — which is the argument for the flag better than anything I could say.

## Smaller findings

`AssetRef` never declared `fileName`, yet `assetToRef` sent it and **nothing on either side ever read it**. Dead wire payload, so it's removed rather than documented. Not a wire break in either direction: no version has read the field, and receivers ignore unknown keys.

Two `Readable.fromWeb` casts, because `fetch` returns the DOM `ReadableStream` while Node wants `stream/web`'s — structurally identical, nominally different. The only two casts here, both annotated.

## Deliberately not included

`useUnknownInCatchVariables`: 41 errors, all from idiomatic `catch (e) { e.message }`, for no real safety gain. Left off.

**e2e: 123 checks green.** Fast gate green (format, lint, types, cycles, 6 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)