### PR TITLE
chore!: clear the v1 housekeeping while the clean-break window is open

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ Every method needs Docker, an admin API key, and **a reverse proxy in front of I
 - **Guided script.** No agent? Clone next to your Immich and run `bash deploy/install.sh`. It auto-detects your Immich network, builds and starts the sidecar, health-checks it, and prints the proxy routes for you to add.
 - **Manual.** Build the container and add the three routes yourself. See [deploy/](./deploy/).
 
+### Configuration
+
+Only two are required. The rest have working defaults, so set them only if you need to.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `IMMICH_API_KEY` | — | **Required.** Admin API key. The addon refuses to start without one. |
+| `PUBLIC_URL` | — | **Required in practice.** How the *other* server reaches yours. Peers use it to pull photos. |
+| `HOUSEHOLD_NAME` | `Unnamed household` | The name peers see, and the name mirrored albums are attributed to. |
+| `IMMICH_URL` | `http://immich-server:2283` | Your Immich, from inside the container. |
+| `PORT` | `8300` | Port the addon listens on. |
+| `DATA_DIR` | `/data` | Where `state.db` lives. Back this up; it holds your signing key. |
+| `REQUIRE_SHARE_PASSWORD` | `false` | Refuse to link with a server whose share link has no password. **Recommended if you are publicly reachable** — otherwise possession of a link is the whole credential. A link's own password and expiry are always enforced regardless. |
+| `SHARE_USER_DIRECTORY` | `true` | Share your users' **names** (never emails) with linked servers, so they can invite a specific person. Set `false` to keep your user list private — that disables native invitations with that server, leaving share links. |
+| `ALLOW_PRIVATE_PEERS` | `true` | Allow peer URLs on private ranges (normal for LAN and tailnet). Set `false` on a public host so a peer URL cannot be aimed at your internal services. |
+| `ALBUM_TEMPLATE` | `{name}` | Naming for mirrored albums, e.g. `{name} (shared)`. |
+| `CACHE_MAX_MB` | `512` | Bounded cache for viewed photos. `0` disables. Delete the folder any time — it is a cache, not storage. |
+| `UTILITY_QUOTA_MB` | `0` (none) | Storage cap on the addon's bot accounts. Bounds what a stolen key could write, but too low and syncing silently fails. |
+| `MAX_BODY_KB` | `1024` | Hard cap on any request body the addon buffers. |
+| `POLL_MS` | `20000` | How often it checks peers for changes. |
+
 ## Permissions & security
 
 - **You choose how exposed your server is.** This addon doesn't open your server to the internet or change how sharing works; it only handles the server-to-server handshake. Each server just needs to reach the other's sidecar. A peer only ever touches `/immich-shared-albums/*` and `/share/*`, so the rest of Immich (all of `/api`, your library, admin) can stay private whichever way you set it up:

--- a/demo/run-mock-e2e.sh
+++ b/demo/run-mock-e2e.sh
@@ -19,7 +19,6 @@ purge() { # base key statedir : delete all albums, sidecar users, non-admin asse
   # mirror albums are owned by utility users — only their own keys (in the state store) can delete them
   local CONTRIB=""
   [ -f "$STATEDIR/state.db" ] && CONTRIB=$(sqlite3 "$STATEDIR/state.db" "SELECT value FROM kv WHERE name='contributors'" 2>/dev/null)
-  [ -z "$CONTRIB" ] && [ -f "$STATEDIR/state.json" ] && CONTRIB=$(python3 -c "import json;print(json.dumps(json.load(open('$STATEDIR/state.json')).get('contributors',{})))" 2>/dev/null)
   if [ -n "$CONTRIB" ]; then
     for CK in $(echo "$CONTRIB" | python3 -c "import json,sys;print('\n'.join(c.get('key','') for c in json.load(sys.stdin).values() if c.get('key')))" 2>/dev/null); do
       for AL in $(curl -s $BASE/api/albums -H "x-api-key: $CK" | python3 -c "import json,sys;[print(a['id']) for a in json.load(sys.stdin)]" 2>/dev/null); do
@@ -37,11 +36,11 @@ purge() { # base key statedir : delete all albums, sidecar users, non-admin asse
 
 echo "== redeploy + purge B =="
 cd "$DIR/demo" && docker compose up -d --force-recreate sidecar-b >/dev/null 2>&1
-purge http://localhost:2284 "$BKEY" b-sidecar; docker compose exec -T sidecar-b rm -f /data/state.json /data/state.json.migrated /data/state.db /data/state.db-wal /data/state.db-shm 2>/dev/null; docker compose restart sidecar-b >/dev/null 2>&1
+purge http://localhost:2284 "$BKEY" b-sidecar; docker compose exec -T sidecar-b rm -f /data/state.db /data/state.db-wal /data/state.db-shm 2>/dev/null; docker compose restart sidecar-b >/dev/null 2>&1
 
 echo "== redeploy + purge C =="
 cd "$DIR/demo/household-c" && docker compose up -d --force-recreate sidecar-c >/dev/null 2>&1
-purge http://localhost:2285 "$CKEY" c-sidecar; docker compose exec -T sidecar-c rm -f /data/state.json /data/state.json.migrated /data/state.db /data/state.db-wal /data/state.db-shm 2>/dev/null; docker compose restart sidecar-c >/dev/null 2>&1
+purge http://localhost:2285 "$CKEY" c-sidecar; docker compose exec -T sidecar-c rm -f /data/state.db /data/state.db-wal /data/state.db-shm 2>/dev/null; docker compose restart sidecar-c >/dev/null 2>&1
 
 echo "== redeploy + purge D (third household — relay coverage) =="
 cd "$DIR/demo/household-d"
@@ -51,7 +50,7 @@ if [ ! -f .env ]; then
 fi
 DKEY=$(grep -m1 D_API_KEY .env | cut -d= -f2-)
 docker compose up -d --force-recreate sidecar-d >/dev/null 2>&1
-purge http://localhost:2286 "$DKEY" d-sidecar; docker compose exec -T sidecar-d rm -f /data/state.json /data/state.json.migrated /data/state.db /data/state.db-wal /data/state.db-shm 2>/dev/null; docker compose restart sidecar-d >/dev/null 2>&1
+purge http://localhost:2286 "$DKEY" d-sidecar; docker compose exec -T sidecar-d rm -f /data/state.db /data/state.db-wal /data/state.db-shm 2>/dev/null; docker compose restart sidecar-d >/dev/null 2>&1
 sleep 4
 
 echo "== harden C like production (passwordLogin off) =="

--- a/src/immich/client.ts
+++ b/src/immich/client.ts
@@ -67,11 +67,8 @@ export const getAlbumAssets = async albumId => {
   }
   return out;
 };
-export const createAlbum = albumName => immichJson('/albums', jsonBody({ albumName }));
 export const addToAlbum = (albumId, ids, key) =>
   immichJson(`/albums/${albumId}/assets`, { ...jsonBody({ ids }), method: 'PUT' }, key);
-export const previewStream = assetId => immich(`/assets/${assetId}/thumbnail?size=preview`);
-export const originalStream = assetId => immich(`/assets/${assetId}/original`);
 export async function uploadAsset(bytes, filename, key = CFG.apiKey, takenAt) {
   const fd = new FormData();
   const stamp = takenAt || new Date().toISOString();

--- a/src/immich/contributors.ts
+++ b/src/immich/contributors.ts
@@ -148,7 +148,7 @@ export async function ensureUtilityUser(
     await fetch(`${CFG.immichUrl}/api/api-keys`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${login.accessToken}` },
-      body: JSON.stringify({ name: 'sidecar', permissions: UTILITY_PERMISSIONS }),
+      body: JSON.stringify({ name: 'immich-shared-albums', permissions: UTILITY_PERMISSIONS }),
     })
   ).json();
   if (!keyRes.secret)

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,10 +7,8 @@
  * as an in-memory object persisted to a kv table in one transaction — same ergonomics
  * as before, now crash-safe (WAL).
  *
- * A legacy state.json is migrated on first boot and kept as state.json.migrated.
  */
 import { DatabaseSync } from 'node:sqlite';
-import fs from 'node:fs';
 import path from 'node:path';
 
 export type SeenEntry = { m: string; c: string; l: string; o?: string };
@@ -96,7 +94,6 @@ export class Store {
       CREATE UNIQUE INDEX IF NOT EXISTS offered_ma ON offered (m, a);
       CREATE INDEX IF NOT EXISTS offered_a ON offered (a);
     `);
-    this.migrateLegacyJson(dataDir);
     this.state = {
       keys: this.kvGet('keys'),
       peers: this.kvGet('peers') ?? [],
@@ -109,33 +106,6 @@ export class Store {
     const row = this.db.prepare('SELECT value FROM kv WHERE name = ?').get(name) as
       { value: string } | undefined;
     return row ? JSON.parse(row.value) : null;
-  }
-
-  private migrateLegacyJson(dataDir: string) {
-    const legacy = path.join(dataDir, 'state.json');
-    const already = this.db.prepare('SELECT 1 FROM kv LIMIT 1').get();
-    if (already || !fs.existsSync(legacy)) return;
-    const old = JSON.parse(fs.readFileSync(legacy, 'utf8'));
-    const put = this.db.prepare('INSERT OR REPLACE INTO kv (name, value) VALUES (?, ?)');
-    const seenIns = this.db.prepare('INSERT OR IGNORE INTO seen (m, c, l, o) VALUES (?, ?, ?, ?)');
-    const actIns = this.db.prepare('INSERT OR IGNORE INTO seen_activity (tag) VALUES (?)');
-    this.db.exec('BEGIN');
-    try {
-      for (const name of ['keys', 'peers', 'mappings', 'contributors']) {
-        if (old[name] != null) put.run(name, JSON.stringify(old[name]));
-      }
-      for (const s of old.seen ?? []) seenIns.run(s.m, s.c, s.l, s.o ?? null);
-      for (const tag of old.seenActivity ?? []) actIns.run(tag);
-      this.db.exec('COMMIT');
-    } catch (e) {
-      this.db.exec('ROLLBACK');
-      throw e;
-    }
-    fs.renameSync(legacy, `${legacy}.migrated`);
-    console.log(
-      new Date().toISOString(),
-      `migrated state.json -> state.db (${(old.seen ?? []).length} ledger entries)`
-    );
   }
 
   /** Persist the in-memory collections (small; one transaction). */


### PR DESCRIPTION
Four leftovers from the earlier survey, all verified against the code before being touched. Batched now because **1.0.0 hasn't shipped** — release-please's PR is still open, so the no-migrations allowance still applies.

| | |
|---|---|
| **`state.json` importer** | `Store.migrateLegacyJson` existed for installs predating SQLite. Serves nobody. `noUnusedLocals` immediately caught the `fs` import it had been keeping alive — the gate from #14 earning its keep. The e2e runner's purge no longer looks for `state.json` either. |
| **API key name** | The key this addon creates in the user's own Immich was literally named `'sidecar'` — visible in their admin UI, and the last user-facing use of the old name. Nothing looks it up by name. |
| **Dead exports** | `createAlbum`, `previewStream`, `originalStream` — zero callers each. |
| **README config table** | All 14 env vars now documented, **checked programmatically against `config.ts`** rather than by eye. Leads with the two that are actually required, and gives `REQUIRE_SHARE_PASSWORD`, `SHARE_USER_DIRECTORY` and `ALLOW_PRIVATE_PEERS` the context a publicly-reachable operator needs — previously only discoverable in `deploy/` examples. |

**e2e: 123 checks green.** Fast gate green.

### Breaking

An install still holding a pre-SQLite `state.json` will no longer import it — it starts from empty state and must re-join its albums. No released version ever wrote that file, so this affects nobody in practice; flagged because the migration path is genuinely gone rather than deprecated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)