### PR TITLE
feat!: one account per remote person, and stop the sidecar overruling a human

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,34 @@
 This is the contract for changing immich-shared-albums. It applies to everyone, and
 especially to AI coding agents — read it before you make changes.
 
+## The ethos this inherits
+
+Immich exists so people own their photos and host them themselves. Cross-server sharing is the
+easiest place to quietly betray that, so this addon inherits the constraint rather than treating
+it as Immich's problem. Concretely, and these are design rules not sentiments:
+
+- **Originals never leave the owner's server.** A shared photo materialises elsewhere as a stub
+  whose bytes stream from its owner on demand. Nobody accumulates copies of anyone else's
+  library, and the owner can stop serving at any moment.
+- **No third party, ever.** Two servers talk directly, signed with their own ed25519 keys. There
+  is no broker, no account with us, nothing to shut down.
+- **Sharing is per person, and the person is their own server's account.** Not a "household", not
+  an identity this addon invents. Accounts here are keyed by the person's id on *their* server.
+- **Anything shared can be fully withdrawn, and withdrawal reclaims the space.** `leaveAlbum`
+  purges every stub a join created; unlinking deletes a peer's people *and their proxied photos*,
+  because holding someone's content after they have gone is exactly the thing this opposes.
+- **Every sharing ACTION happens in Immich's own UI** (see the product rule below). The addon adds
+  no second way to share, so nobody has to learn our surface to use their own photos.
+- **Minimise the footprint in someone else's instance.** Every user, album, and permission this
+  addon creates is a liability the operator did not ask for.
+
+**Where we currently fall short, honestly:** the sidecar still needs an all-permissions admin API
+key, so its blast radius is the whole instance — the sharpest contradiction of this ethos in the
+codebase, and worth chipping at whenever a change touches key handling. It also creates real user
+accounts in your Immich (one per remote person) that show up in every picker, because Immich has
+no service-account flag. Both are known costs, not oversights; do not make either worse without
+saying so.
+
 ## Golden rules
 
 - **Never touch Immich itself.** This is a sidecar: it only ever adds its own container
@@ -55,6 +83,46 @@ rename; a test pinning one literal name has to be edited whenever behaviour chan
 edited to match new behaviour has stopped being a test. **Print real state on failure** — a
 message showing what was actually found saves a whole debugging cycle, and the e2e suite's
 `check(name, ok, detail)` takes that detail for exactly this reason.
+
+## Store the fact, don't infer it — but only if the fact is safe to hold
+
+Nearly every sync bug in this project came from *deducing* something the code could have
+recorded. Two accounts existed for one person so that "who added this album membership" could be
+inferred from which account it was; a boolean said "we know where this person lives" instead of
+storing *where*; a mapping pointed at an account by a name-derived slug instead of its id, and
+stopped resolving the moment the account was keyed differently. Each inference was correct when
+written and wrong later.
+
+So prefer a column in `state.db` over a rule in someone's head. **With two constraints, because
+a stored fact is also a stored liability:**
+
+- **Only store what is safe to hold.** `state.db` holds this household's ed25519 private key and
+  the bot accounts' API keys, so anything added inherits that blast radius. (The *admin* key is
+  not in there — it comes from `IMMICH_API_KEY` in the environment.) Two rules follow, neither
+  about compliance:
+  - The bot password is rolled to a value nobody keeps (`ensureUtilityUser`), because it existed
+    only to mint one API key and has no purpose afterwards. The concrete gain is small but real:
+    a bot key deliberately lacks `apiKey.create`, so it can do its 22 things and no more, whereas
+    a password logs in interactively and can mint an unrestricted key for that account. Keeping it
+    is pure downside rather than a tradeoff — the bots are non-admin and quota-capped, so this is
+    cheap hygiene, not a critical control. The e2e asserts it.
+  - The user directory sends **names, not emails** — not because storing an email is dangerous,
+    but because an Immich email is a *login identifier*. Sending it gives a linked household, or
+    whoever later compromises it, the first half of a credential for every user here. Names are
+    all a picker needs, so nothing is given up.
+
+  Both scale with exposure: on a single-user LAN-only box they buy little, and on a public domain
+  with several linked households they matter. Default to the cautious side when it is free, and
+  say which it is rather than implying everything is critical.
+- **Order the writes so a crash fails safe.** A stored fact that is missing must lead somewhere
+  harmless. `added` records a membership BEFORE creating it, so a crash in between makes the
+  sidecar *ignore* an invitation rather than treat its own membership as a human's and share an
+  album nobody offered. Work out which way each new record fails before writing it, and say so in
+  a comment.
+
+Corollary: a fact only counts as known if something *proved* it. `Contributor.homePeer` is set
+only by a linked server's directory, never by an incoming photo — a relayed ref names the person
+but not their server, and guessing would route someone's album to the wrong household.
 
 ## Invariants that will bite you
 

--- a/demo/e2e/e2e-test.mjs
+++ b/demo/e2e/e2e-test.mjs
@@ -60,6 +60,24 @@ const readSidecarKv = (stateDir, name) => {
     return out ? JSON.parse(out) : null;
   } catch { return null; }
 };
+// Rows in the `added` ledger — memberships the sidecar created rather than a human. Security
+// property: after unlinking, the memberships left behind must be recorded here.
+const readSidecarAdded = (stateDir, albumId) => {
+  try {
+    const path = new URL(`../${stateDir}/state.db`, import.meta.url).pathname;
+    const sql = albumId
+      ? `SELECT COUNT(*) FROM added WHERE al='${albumId}'`
+      : 'SELECT COUNT(*) FROM added';
+    const out = execFileSync('sqlite3', [path, sql], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return out ? Number(out) : 0;
+  } catch {
+    return null;
+  }
+};
+
 const until = async (fn, timeoutMs = 90000, everyMs = 5000) => {
   const t0 = Date.now();
   while (Date.now() - t0 < timeoutMs) { const v = await fn(); if (v) return v; await sleep(everyMs); }
@@ -143,7 +161,11 @@ if (mAssets) {
         `x-cache: ${thumbRes2.headers.get('x-cache')}`);
 }
 
-const bAdminUtility = `${(await api(B, BKEY, '/users/me')).name} (via shared albums)`;
+const bAdminName = (await api(B, BKEY, '/users/me')).name;
+// One account now represents a remote person for BOTH jobs, so its name depends on what we know:
+// "(via <server> server)" once a directory has placed them, "(via shared albums)" until then.
+// Match the person, not one naming form — the point is that the account represents that human.
+const representsBAdmin = name => !!name && name.startsWith(`${bAdminName} (`);
 console.log(`— stage: B admin contributes 2 photos (old capture dates)`);
 const nIds = [];
 for (let i = 1; i <= 2; i++) {
@@ -158,8 +180,9 @@ const aAfter = await until(async () => { const x = await albumAssets(A, AKEY, AL
 check('A album has 6 assets after contribution', !!aAfter, aAfter ? '' : `still ${(await albumAssets(A, AKEY, ALBUM_ID)).length}`);
 if (aAfter) {
   const aUsers = await api(A, AKEY, '/admin/users');
-  const nanUser = aUsers.find(u => u.name === bAdminUtility);
-  check('contributor utility user exists on A', !!nanUser, bAdminUtility);
+  const nanUser = aUsers.find(u => isBot(u.email) && representsBAdmin(u.name));
+  check('contributor utility user exists on A', !!nanUser,
+        aUsers.filter(u => isBot(u.email)).map(u => u.name).join(', '));
   const ownerId_A = (await api(A, AKEY, '/users/me')).id;
   const contributed = aAfter.filter(a => !aIds.includes(a.id));
   check('contributions NOT owned by origin admin (timeline clean)', contributed.every(a => a.ownerId !== ownerId_A),
@@ -171,16 +194,19 @@ if (aAfter) {
   check('contribution capture dates preserved', JSON.stringify(cDates) === JSON.stringify(['2026-07-01','2026-07-02']), cDates.join(','));
 
   console.log('— stage: stale utility-user display name heals on next sync');
+  if (!nanUser) console.log('  (skipped: no contributor account found on A)');
+  else {
   await api(A, AKEY, `/admin/users/${nanUser.id}`, { ...j({ name: 'Shared · Legacy Name' }), method: 'PUT' });
   const healId = await upload(B, BKEY, 'heal-e2e.jpg', `hl${Date.now() % 1000}`, '2026-07-03T09:00:00.000Z');
   await ensurePreviews(B, BKEY, [healId]);
   await api(B, BKEY, `/albums/${mirror.id}/assets`, { ...j({ ids: [healId] }), method: 'PUT' });
   const healed = await until(async () => {
     const u = (await api(A, AKEY, '/admin/users')).find(x => x.id === nanUser.id);
-    return u && u.name === bAdminUtility ? u : null;
+    return u && representsBAdmin(u.name) ? u : null;
   }, 60000);
   check('stale utility-user name healed (regression: old "Shared ·" naming)', !!healed,
         healed ? healed.name : 'still stale');
+  }
 }
 
 console.log('— stage: A personal timeline must NOT contain B-contributed photos');
@@ -200,7 +226,7 @@ if (aAfter) {
   // albumUsers is what the app renders under album Options → People
   const albumDetail = await api(A, AKEY, `/albums/${ALBUM_ID}`);
   const memberNames = (albumDetail.albumUsers || []).map(u => u.user?.name).filter(Boolean);
-  check('contributor utility user listed as album member on A', memberNames.includes(bAdminUtility), memberNames.join(', ') || '(none)');
+  check('contributor utility user listed as album member on A', memberNames.some(representsBAdmin), memberNames.join(', ') || '(none)');
 }
 
 console.log('— stage: photo ordering matches capture date (newest-first)');
@@ -386,7 +412,7 @@ if (DKEY) {
   check('D mirror receives all 9 photos incl. B contributions (relay)', !!dAssets,
         dAssets ? '' : `at ${(await albumAssets(D, DKEY, dMirror.id)).length}`);
   const dUtility = (await api(D, DKEY, '/admin/users')).filter(u => isBot(u.email));
-  check('relayed photos attributed to the original contributor on D', dUtility.some(u => u.name === bAdminUtility),
+  check('relayed photos attributed to the original contributor on D', dUtility.some(u => representsBAdmin(u.name)),
         dUtility.map(u => u.name).join(', '));
   if (dAssets) {
     const nanProxy = dAssets.find(a => (a.fileCreatedAt || '').startsWith('2026-07-01'));
@@ -506,12 +532,20 @@ console.log('— stage: native album invitations, per person (no share link)');
     check('origin created a per-person invite marker for each person on the linked server', !!nan,
           nan ? nan.email : `no user named "${bAdmin.name} (via ${bPeer.name} server)"`);
     check('the marker lives in the per-person namespace, not the contributors one',
-          !!nan && nan.email.startsWith('invite-person-'), nan?.email);
+          !!nan && nan.email.startsWith('person-'), nan?.email);
     // Sharing is per person. A server link is not a person, so it must not exist as a pickable
     // user at all — managing the link belongs to the panel (see the unlink stage).
     const households = (await api(A, AKEY, '/admin/users')).filter(u => u.email.startsWith('invite-household-'));
     check('no household-wide stand-in exists — a server link is not a person',
           households.length === 0, households.map(u => u.email).join(', '));
+    // ONE account per remote person: it owns their photos AND is what a human picks to share
+    // with them. Two accounts for one human is the clutter this replaced.
+    {
+      const all = await api(A, AKEY, '/admin/users');
+      const forNan = all.filter(u => isBot(u.email) && (u.name || '').startsWith(bAdmin.name));
+      check('one account per remote person, not two', forNan.length === 1,
+            forNan.map(u => `${u.name} <${u.email}>`).join(' | '));
+    }
     // An invite marker and an attribution contributor can exist for the SAME remote person. If
     // they ever share a display name the two are indistinguishable in the picker.
     {
@@ -638,6 +672,102 @@ console.log('— stage: native album invitations, per person (no share link)');
       const bogus = bMappings.filter(m => m.role === 'owner' && m.via === 'invite');
       check('member never mistakes its own mirror for an invitation (no ping-pong)',
             bogus.length === 0, bogus.map(m => `${m.albumName}`).join(', ') || '');
+    }
+  }
+}
+
+// THE RACE the `added` ledger exists to close. One account now serves both jobs, so after a human
+// revokes, the sidecar may still materialise an arriving photo into that album and re-add the
+// person for attribution. If that re-add were mistaken for a fresh invitation, the revocation
+// would silently never happen — the worst failure mode in this project, because it looks like it
+// worked. Recording our own additions is what makes the human's removal win.
+//
+// A 20s poll race cannot be forced deterministically, so this is built to prove the mechanism and
+// never fail falsely: it drives content at the album immediately after revoking, then asserts the
+// withdrawal happened anyway. If the re-add did land it proves the ledger; if it did not, the
+// withdrawal assertion still holds.
+console.log('— stage: a revocation survives content arriving in the same window');
+{
+  const originPeers = readSidecarKv('household-c/c-sidecar', 'peers');
+  const bPeer = (originPeers || []).find(p => (p.name || '').includes('(B)'));
+  const bAdmin2 = await api(B, BKEY, '/users/me');
+  const nan =
+    bPeer &&
+    (await api(A, AKEY, '/admin/users')).find(
+      u => isBot(u.email) && (u.name || '').startsWith(`${bAdmin2.name} (`)
+    );
+  if (!nan) console.log('  (skipped: no account representing B\'s admin on the origin)');
+  else {
+    const raceAlb = (await api(A, AKEY, '/albums', j({ albumName: 'race album' }))).id;
+    const rAsset = await upload(A, AKEY, 'race.jpg', `rc${Date.now() % 10000}`, '2026-03-01T09:00:00.000Z');
+    await ensurePreviews(A, AKEY, [rAsset]);
+    await api(A, AKEY, `/albums/${raceAlb}/assets`, { ...j({ ids: [rAsset] }), method: 'PUT' });
+    await api(A, AKEY, `/albums/${raceAlb}/users`,
+      { ...j({ albumUsers: [{ userId: nan.id, role: 'editor' }] }), method: 'PUT' });
+
+    const standInKeys = () =>
+      Object.values(readSidecarKv('b-sidecar', 'contributors') || {})
+        .map(c => c && c.key)
+        .filter(Boolean);
+    const mirroredRace = await until(async () => {
+      for (const k of standInKeys()) {
+        const al = await api(B, k, '/albums').catch(() => []);
+        const hit = (al || []).find(a => a.albumName === 'race album');
+        if (hit) return { album: hit, key: k };
+      }
+      return null;
+    }, 150000);
+    check('race setup: the invited album mirrored on the member', !!mirroredRace,
+          mirroredRace ? '' : 'timed out');
+
+    if (mirroredRace) {
+      // Revoke, then IMMEDIATELY give the origin something to materialise into that same album.
+      await fetch(`${A}/api/albums/${raceAlb}/user/${nan.id}`, {
+        method: 'DELETE',
+        headers: { 'x-api-key': AKEY },
+      });
+      const pushId = await upload(B, BKEY, 'race-push.jpg', `rp${Date.now() % 10000}`, '2026-03-02T09:00:00.000Z');
+      await ensurePreviews(B, BKEY, [pushId]);
+      await api(B, mirroredRace.key, `/albums/${mirroredRace.album.id}/assets`,
+        { ...j({ ids: [pushId] }), method: 'PUT' }).catch(() => {});
+
+      const invitations = async () => {
+        const bKeys2 = readSidecarKv('b-sidecar', 'keys');
+        const sig = crypto
+          .sign(null, Buffer.from('invitations'),
+            crypto.createPrivateKey({ key: Buffer.from(bKeys2.priv, 'base64url'), format: 'der', type: 'pkcs8' }))
+          .toString('base64url');
+        const r = await fetch(`${ORIGIN_DIRECT}/immich-shared-albums/api/v1/invitations`,
+          { headers: { 'x-isa-key': bKeys2.pub, 'x-isa-sig': sig } });
+        return r.ok ? ((await r.json()).invitations || []) : null;
+      };
+      const withdrawn = await until(async () => {
+        const list = await invitations();
+        return list && !list.some(i => i.album?.name === 'race album') ? true : null;
+      }, 150000);
+      check('the revocation still wins when a photo arrives in the same window', !!withdrawn,
+            withdrawn ? '' : 'still offered — a sidecar re-add was read as a fresh invitation');
+
+      const raceGone = await until(async () => {
+        for (const k of standInKeys()) {
+          const al = await api(B, k, '/albums').catch(() => []);
+          if ((al || []).some(a => a.albumName === 'race album')) return null;
+        }
+        return true;
+      }, 150000);
+      check('the member tears the mirror down despite the arriving content', !!raceGone,
+            raceGone ? '' : 'stale mirror survived the revocation');
+
+      // Mechanism, not timing: if the sidecar did re-add during the window it must be recorded.
+      // The sidecar no longer writes membership on an invitation album at all — an invited
+      // person's membership is the human's, so a missing one is a revocation, not a gap to fill.
+      // Zero rows here is therefore the CORRECT state, not an unexercised race.
+      const rows = readSidecarAdded('household-c/c-sidecar', raceAlb);
+      check(
+        'the sidecar never wrote membership on the invitation album',
+        rows === null || rows === 0,
+        rows === null ? 'state.db unreadable' : `${rows} row(s) — it should never write here`
+      );
     }
   }
 }
@@ -848,7 +978,8 @@ console.log('— stage: panel manages server links (unlink)');
         `${target?.people} marker(s)`);
 
   if (target) {
-    const before = (await api(B, BKEY, '/admin/users')).filter(u => u.email.startsWith('invite-person-')).length;
+    const beforeUsers = (await api(B, BKEY, '/admin/users')).filter(u => u.email.startsWith('person-'));
+    const before = beforeUsers.length;
     const res = await fetch(`${BS}/immich-shared-albums/unlink`,
       { method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': BKEY },
         body: JSON.stringify({ pub: target.pub }) });
@@ -864,13 +995,26 @@ console.log('— stage: panel manages server links (unlink)');
     check('the server is gone from the panel after unlinking', !!gone, gone ? '' : 'still listed');
 
     // Its people must leave Immich's picker — that is the visible half of unlinking.
-    const after = (await api(B, BKEY, '/admin/users')).filter(u => u.email.startsWith('invite-person-')).length;
-    check('unlink deletes that server\'s invite markers so they leave the picker',
-          after < before, `${before} -> ${after}`);
-    // Attribution contributors OWN real photos; deleting them would be a data-loss event.
-    const attrib = (await api(B, BKEY, '/admin/users')).filter(u => u.email.startsWith('shared-'));
-    check('unlink keeps attribution contributors (they own real photos)', attrib.length > 0,
-          `${attrib.length} kept`);
+    const afterUsers = (await api(B, BKEY, '/admin/users')).filter(u => u.email.startsWith('person-'));
+    check("unlink removed that server's people", afterUsers.length < before,
+          `${before} -> ${afterUsers.length}`);
+    // Their photos leave with them. Everything these accounts owned was a proxy whose bytes
+    // streamed from the peer, so once the link is gone the assets are unreachable and keeping
+    // them would only scatter broken thumbnails through albums here.
+    check('no account for that server survives the unlink',
+          afterUsers.every(u => !/\(via /.test(u.name || '')),
+          afterUsers.map(u => u.name).join(', ') || '(none)');
+    // SECURITY: deleting the accounts takes their album memberships with them, and nothing may be
+    // left behind for a later re-link to misread as a fresh invitation.
+    const leftBehind = [];
+    for (const al of await api(B, BKEY, '/albums').catch(() => [])) {
+      const d = await api(B, BKEY, `/albums/${al.id}?withoutAssets=true`).catch(() => null);
+      for (const au of d?.albumUsers || []) {
+        if ((au.user?.email || '').startsWith('person-')) leftBehind.push(au.user.email);
+      }
+    }
+    check('no membership is left behind for a re-link to misread as an invitation',
+          leftBehind.length === 0, leftBehind.join(', ') || 'none');
     const dead = await fetch(`${BS}/immich-shared-albums/unlink`,
       { method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': BKEY },
         body: JSON.stringify({ pub: target.pub }) });

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,24 +65,28 @@ export const UTILITY_SUFFIX = ' (via shared albums)';
 export const UTILITY_EMAIL_DOMAIN = 'immich-shared-albums.local';
 
 /**
- * The three kinds of bot user, in three separate namespaces.
+ * ONE local account per remote person, doing both jobs: it owns their mirrored photos, and it is
+ * what a human picks in Immich's album picker to share with them.
  *
- * This separation is load-bearing, not tidiness. Invitation detection reads "is this bot a
- * member of that album?" as a human's intent to share, which is only sound for bots the sidecar
- * NEVER adds to an album itself. Contributors are the opposite: the sidecar adds them for
- * attribution whenever their owner contributes a photo.
+ * They used to be two accounts, because invitation detection reads "this account is an album
+ * member" as human intent, and the sidecar adds accounts to albums itself for attribution.
+ * Immich forces that overlap — an album owner adding an asset owned by a NON-member is refused
+ * with `no_permission` — so the account must be a member wherever it owns content.
  *
- * Collapsing any two of these breaks sync. A single stand-in once served as both the household
- * invitation marker and the household's attribution contributor; the sidecar added it to a
- * mirror as `editor`, its own detector read that as an invitation, and origin and member
- * ping-ponged mirror/withdraw every poll — each offering the other a mirror of the other's
- * album. Keep the namespaces disjoint and that class of bug cannot be expressed.
+ * The distinction therefore moved out of the namespace and into two explicit records:
+ *  - `added` (store.addedRecord) says which memberships WE created, so only a human's counts as
+ *    an invitation. Its write order is a security property: record first, add second.
+ *  - `Contributor.directory` says we actually know which server the person is on, which only a
+ *    linked server's directory can tell us. Without it an account is attribution-only.
+ *
+ * `person-` is keyed on the person's user id on THEIR OWN server, so the same human resolves to
+ * the same local account whether we meet them through a directory or a relayed photo.
  */
 export const BOT_PREFIX = {
-  /** Owns mirrored stubs and carries attribution. The sidecar DOES add these to albums. */
+  /** One remote person, keyed by their user id on their home server. */
+  person: 'person-',
+  /** Album-owner stand-ins and other non-person helpers. */
   contributor: 'shared-',
-  /** One remote person. Sidecar never adds it — membership is a human's intent. */
-  invitePerson: 'invite-person-',
 } as const;
 
 /**
@@ -94,6 +98,19 @@ export const BOT_PREFIX = {
  * exist for the same remote person on the same server, and two identically-named users are
  * unpickable. There is no household-wide marker: a server link is not a person (see p2p/unlink).
  */
+/**
+ * Recover a person's real name from whatever decoration a local account carries.
+ *
+ * Accounts here are named for what they are locally — "(via The Smiths server)" for someone on a
+ * linked server, "(via shared albums)" for an attribution-only account — but the name that goes
+ * ON THE WIRE must be the person's own. Stripping only UTILITY_SUFFIX was not enough once markers
+ * carried a server name: the decorated name travelled as the "true" contributor, the receiver
+ * appended its own suffix, and the decoration accumulated one layer per relay hop
+ * ("Nan (via B server) (via shared albums)"). Greedy on purpose, so a doubled name collapses back
+ * to the person in one pass.
+ */
+export const personName = (name?: string) => (name || '').replace(/\s*\(via .*\)\s*$/, '').trim();
+
 export const markerName = {
   person: (personName: string, peerName: string) => `${personName} (via ${peerName} server)`,
 };

--- a/src/immich/contributors.ts
+++ b/src/immich/contributors.ts
@@ -5,7 +5,7 @@
  */
 import crypto from 'node:crypto';
 import { CFG, log, UTILITY_SUFFIX, ROUTE_PREFIX, UTILITY_EMAIL_DOMAIN, BOT_PREFIX } from '../config.ts';
-import { state, save, keys } from '../state.ts';
+import { state, save, keys, addedRecord } from '../state.ts';
 import { immichJson, jsonBody, usersById, USERS } from './client.ts';
 import { sign } from '../peers.ts';
 
@@ -66,6 +66,8 @@ export async function ensureUtilityUser(
     stateKey?: string;
     email?: string;
     fullName?: string;
+    /** The server this person lives on. Set ONLY by the directory sync. */
+    homePeer?: string;
   } = {}
 ) {
   const { peerPub, peerUserId } = opts;
@@ -73,14 +75,25 @@ export async function ensureUtilityUser(
   let c = state.contributors[slug];
   const wantedName = opts.fullName || `${displayName}${UTILITY_SUFFIX}`;
   if (c && c.key) {
-    // already fully provisioned — heal a stale display name
+    // already fully provisioned — heal a stale display name.
+    // Only a directory may say where someone lives. A relayed ref knows the person's id but not
+    // their server, so it must never set or move `homePeer` — that is what stops an album shared
+    // with a person at D from being handed to the C it travelled through.
+    if (opts.homePeer && c.homePeer !== opts.homePeer) {
+      c.homePeer = opts.homePeer;
+      save();
+    }
     if ((peerPub && c.peer !== peerPub) || (peerUserId && c.peerUserId !== peerUserId)) {
       c.peer = peerPub ?? c.peer;
       c.peerUserId = peerUserId ?? c.peerUserId;
       save();
     }
+    // The directory owns the name of anyone it has placed: it is the only caller that knows
+    // which server to name. An attribution ref arriving later must not rename them back to the
+    // generic suffix, or the two would overwrite each other on every poll.
+    const directoryOwnsName = !!c.homePeer && !opts.fullName;
     const current = (await usersById(10000))[c.userId]?.name;
-    if (current && current !== wantedName) {
+    if (!directoryOwnsName && current && current !== wantedName) {
       try {
         await immichJson(`/admin/users/${c.userId}`, { ...jsonBody({ name: wantedName }), method: 'PUT' });
         if (USERS[c.userId]) USERS[c.userId].name = wantedName;
@@ -185,6 +198,7 @@ export async function ensureUtilityUser(
     key: keyRes.secret,
     peer: peerPub ?? c?.peer,
     peerUserId: peerUserId ?? c?.peerUserId,
+    homePeer: opts.homePeer ?? c?.homePeer,
   };
   if (!passwordRetired)
     c.password = password; // keep it only if the roll failed, so a retry can resume
@@ -226,25 +240,79 @@ export async function syncAvatar(c, peerUrl, originUserId) {
     /* avatars are garnish */
   }
 }
+/**
+ * The remote person's local account, present in the album so it can own their photos.
+ *
+ * ONE account per remote person does both jobs: it is what a human picks in Immich's album
+ * picker to share with them, and it owns their mirrored photos so attribution survives. Immich
+ * forces that overlap — an album owner adding an asset owned by a NON-member is refused with
+ * `no_permission` — so the account has to be a member wherever it owns content.
+ *
+ * Which means album membership alone no longer tells us whether a human invited them. That
+ * distinction moves into the `added` ledger, and the order below is the security property:
+ *
+ *  1. read the album's current members
+ *  2. if the account is ALREADY a member, do nothing and record nothing — someone else put them
+ *     there, and that someone is a human whose intent we must not overwrite
+ *  3. otherwise record the membership as ours FIRST, then add it
+ *
+ * Recording after the add would leave, on any crash in between, a membership with no record —
+ * which reads as human intent and shares the album with a server nobody offered it to. This way
+ * the same crash leaves a record with no membership, which merely ignores a real invitation
+ * until the human re-adds. Always fail towards under-sharing.
+ */
 export async function ensureContributor(
   displayName,
   albumId,
   adminKey,
   peerUrl,
   originUserId,
-  peerPub?: string
+  peerPub?: string,
+  opts: { mayAdd?: boolean } = {}
 ) {
-  const c = await ensureUtilityUser(displayName, { peerPub });
+  // Key on the person's id on their OWN server when the ref carries it, so this is the same
+  // account the directory creates rather than a second entry for one human. No `fullName` and no
+  // `homePeer`: a ref proves neither what to call them nor where they live.
+  const c = await ensureUtilityUser(
+    displayName,
+    originUserId
+      ? {
+          peerPub,
+          peerUserId: originUserId,
+          stateKey: `${BOT_PREFIX.person}${originUserId}`,
+          email: `${BOT_PREFIX.person}${originUserId}@${UTILITY_EMAIL_DOMAIN}`,
+        }
+      : { peerPub, peerUserId: originUserId }
+  );
   if (!c.key) throw new Error(`contributor "${displayName}" has no API key yet — will retry`);
   await syncAvatar(c, peerUrl, originUserId);
+
+  let alreadyMember = false;
   try {
-    await immichJson(
-      `/albums/${albumId}/users`,
-      { ...jsonBody({ albumUsers: [{ userId: c.userId, role: 'editor' }] }), method: 'PUT' },
-      adminKey
-    );
+    const alb = await immichJson(`/albums/${albumId}?withoutAssets=true`, {}, adminKey);
+    alreadyMember = (alb.albumUsers || []).some(au => au.user?.id === c.userId);
   } catch {
-    /* already a member */
+    // Cannot read the album, so cannot prove the membership is not already a human's. Do not
+    // add: a blind add here could later be misread as an invitation. The next cycle retries.
+    return c;
+  }
+  if (!alreadyMember && opts.mayAdd === false) {
+    // An invited person who is not a member has been REVOKED. Do not put them back: the human's
+    // removal is the authority here, and the withdrawal sweep will retire the mapping shortly.
+    log(`"${displayName}" is no longer a member of this album — not re-adding (revoked)`);
+    return c;
+  }
+  if (!alreadyMember) {
+    addedRecord(albumId, c.userId); // record BEFORE the add — see the note above
+    try {
+      await immichJson(
+        `/albums/${albumId}/users`,
+        { ...jsonBody({ albumUsers: [{ userId: c.userId, role: 'editor' }] }), method: 'PUT' },
+        adminKey
+      );
+    } catch (e) {
+      log(`could not add "${displayName}" to the album: ${e.message} — will retry`);
+    }
   }
   return c;
 }

--- a/src/immich/materialise.ts
+++ b/src/immich/materialise.ts
@@ -36,13 +36,24 @@ export async function materialiseRef(mapping, peerUrl, fallbackName, ref) {
     bytes = Buffer.concat([STUB_JPEG, crypto.randomBytes(8)]);
   }
   const adminKey = mapping.adminSlug ? state.contributors[mapping.adminSlug]?.key : undefined;
+  // On an INVITATION album a human already added the people they chose — their membership IS the
+  // share. So for an invited person we must never add them: if they are missing, that absence is
+  // the revocation, and filling it in would overrule the human and quietly re-create the share.
+  // That, not a ledger, is what removes the revoke-versus-arriving-content race.
+  //
+  // Link-shared albums are the opposite: the link named a household, nobody named a person, so
+  // attribution has no membership to inherit and the sidecar does have to create one.
+  const contributorId = ref.contributor?.originUserId;
+  const wasInvited =
+    mapping.via === 'invite' && !!contributorId && (mapping.forPeerUserIds || []).includes(contributorId);
   const c = await ensureContributor(
     ref.contributor?.displayName || fallbackName,
     mapping.albumId,
     adminKey,
     peerUrl,
-    ref.contributor?.originUserId,
-    mapping.peer
+    contributorId,
+    mapping.peer,
+    { mayAdd: !wasInvited }
   );
   const ext = ref.kind === 'video' ? 'mp4' : 'jpg';
   // base64 checksums contain / and + — never let them into filenames

--- a/src/immich/refs.ts
+++ b/src/immich/refs.ts
@@ -4,7 +4,7 @@
  * and builds the manifest a member diffs against.
  */
 import type { AssetRef } from '../types.ts';
-import { CFG, UTILITY_SUFFIX } from '../config.ts';
+import { CFG, personName } from '../config.ts';
 import { usersById } from './client.ts';
 import { wireChecksum, ledgerByAsset, seenHas } from '../state.ts';
 
@@ -13,7 +13,7 @@ import { wireChecksum, ledgerByAsset, seenHas } from '../state.ts';
 // append locally is stripped so downstream hops don't stack "Shared by" twice.
 export async function assetToRef(a): Promise<AssetRef> {
   const u = (await usersById())[a.ownerId];
-  const displayName = u?.utility ? u.name.replace(UTILITY_SUFFIX, '') : a.owner?.name || u?.name || CFG.name;
+  const displayName = u?.utility ? personName(u.name) : a.owner?.name || u?.name || CFG.name;
   const description = (a.exifInfo?.description || '').replace(/(?:\n\n)?Shared by [^\n]*$/, '') || undefined;
   return {
     originAsset: a.id,

--- a/src/invariants.test.ts
+++ b/src/invariants.test.ts
@@ -10,6 +10,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { BOT_PREFIX, markerName, isUtilityEmail, UTILITY_EMAIL_DOMAIN, UTILITY_SUFFIX } from './config.ts';
+import { personName } from './config.ts';
 import { permissionFor } from './sync/invites.ts';
 import { diffInvitees } from './sync/invitees.ts';
 
@@ -84,4 +85,18 @@ test('an empty invitee list is never treated as "remove everyone"', () => {
     add: [],
     remove: [],
   });
+});
+
+test('personName recovers the human, however the account was decorated', () => {
+  // Names travel on the wire. Stripping only UTILITY_SUFFIX let a marker's "(via X server)" ride
+  // along as the "true" contributor, and each relay hop appended another layer:
+  // "Nan (via B server) (via shared albums)". Collapse it in one pass, whatever the nesting.
+  assert.equal(personName('Nan'), 'Nan');
+  assert.equal(personName(`Nan${UTILITY_SUFFIX}`), 'Nan');
+  assert.equal(personName('Nan (via The Smiths server)'), 'Nan');
+  // household names contain brackets of their own — the strip must not stop at the inner one
+  assert.equal(personName('Nan (via Demo household (B) server)'), 'Nan');
+  // the compounded form seen in run27, which is what this exists to prevent
+  assert.equal(personName('Nan (via Demo household (B) server) (via shared albums)'), 'Nan');
+  assert.equal(personName(undefined), '');
 });

--- a/src/p2p/mirror.ts
+++ b/src/p2p/mirror.ts
@@ -8,7 +8,7 @@
  * fills it in behind the answer.
  */
 import crypto from 'node:crypto';
-import { CFG, log, isUtilityEmail } from '../config.ts';
+import { CFG, log, isUtilityEmail, BOT_PREFIX, UTILITY_EMAIL_DOMAIN } from '../config.ts';
 import type { Mapping, Peer } from '../store.ts';
 import { state, save } from '../state.ts';
 import { immichJson, jsonBody } from '../immich/client.ts';
@@ -41,7 +41,22 @@ export type MirrorRequest = {
 export async function ensureMirror(req: MirrorRequest): Promise<{ mapping: Mapping; created: boolean }> {
   const { peer, album, permissions, forUserIds } = req;
   const ownerName = req.albumOwnerName || peer.name;
-  const host = await ensureUtilityUser(ownerName, { peerPub: peer.pub });
+  // The album's owner is a person on that peer, so key them by their id on THEIR server when we
+  // know it. That makes the account we create here and the one the directory creates the same
+  // human rather than two picker entries for one person. `homePeer` is deliberately NOT set: a
+  // redeem does not prove where they live, only a directory does.
+  const hostSlug = req.albumOwnerId ? `${BOT_PREFIX.person}${req.albumOwnerId}` : slugify(ownerName);
+  const host = await ensureUtilityUser(
+    ownerName,
+    req.albumOwnerId
+      ? {
+          peerPub: peer.pub,
+          peerUserId: req.albumOwnerId,
+          stateKey: hostSlug,
+          email: `${hostSlug}@${UTILITY_EMAIL_DOMAIN}`,
+        }
+      : { peerPub: peer.pub }
+  );
   await syncAvatar(host, peer.url, req.albumOwnerId);
 
   const addMembers = async (albumId: string) => {
@@ -103,7 +118,7 @@ export async function ensureMirror(req: MirrorRequest): Promise<{ mapping: Mappi
     remoteAlbumId: album.id,
     remoteMappingId: req.remoteMappingId,
     permissions,
-    adminSlug: slugify(ownerName),
+    adminSlug: hostSlug,
     via: req.via ?? 'link',
   };
   state.mappings.push(mapping);

--- a/src/p2p/unlink.ts
+++ b/src/p2p/unlink.ts
@@ -11,9 +11,11 @@
  *    so no album of dead placeholders is left behind;
  *  - albums we shared TO them lose their mapping and their entitlement, so we stop serving bytes;
  *  - their per-person invite markers are deleted, so they vanish from Immich's album picker;
- *  - attribution contributors are KEPT. They own real photos that local people can see (relayed
- *    contributions land in albums we own), and deleting the user deletes that content. An
- *    unlink must not be a data-loss event, so these are left for the operator to remove.
+ *  - this peer's people are deleted, and their photos go with them. Everything those accounts
+ *    own is a proxy whose bytes stream from the peer on demand, so once the link is gone the
+ *    assets are unreachable — keeping them would only scatter broken thumbnails through albums
+ *    here. Deleting the accounts also takes their album memberships, which is what stops a later
+ *    re-link from misreading a leftover membership as a fresh invitation.
  */
 import { CFG, log, BOT_PREFIX } from '../config.ts';
 import { state, save } from '../state.ts';
@@ -55,10 +57,17 @@ export async function unlinkPeer(pub: string): Promise<UnlinkResult> {
     }
   }
 
-  // Their invite markers exist only so our people could pick them. Once unlinked they are noise
-  // in every picker, so remove them — they own nothing, which is what makes this safe.
+  // Delete this peer's people, and their photos go with them.
+  //
+  // Everything these accounts own is a PROXY: a stub whose real bytes stream from the peer on
+  // demand. Once the link is gone those bytes are unreachable, so keeping the assets would leave
+  // broken thumbnails scattered through albums here. `force: true` removes the user and its
+  // assets together, which is also what `leaveAlbum` already does for a mirror's stubs.
+  //
+  // Deleting them takes their album memberships with them, which is what closes the re-link
+  // hole: nothing is left behind for a future directory sync to misread as a fresh invitation.
   for (const [slug, c] of Object.entries(state.contributors || {})) {
-    if (!slug.startsWith(BOT_PREFIX.invitePerson) || c.peer !== pub) continue;
+    if (!slug.startsWith(BOT_PREFIX.person) || (c.homePeer ?? c.peer) !== pub) continue;
     if (c.userId) {
       try {
         await immichJson(`/admin/users/${c.userId}`, {
@@ -68,7 +77,9 @@ export async function unlinkPeer(pub: string): Promise<UnlinkResult> {
         });
         markersRemoved++;
       } catch (e) {
-        log(`unlink: could not delete marker ${slug}: ${e.message}`);
+        // Left behind: keep the state entry so a re-link reuses it rather than minting a twin.
+        log(`unlink: could not delete ${slug}: ${e.message} — leaving it in place`);
+        continue;
       }
     }
     delete state.contributors[slug];
@@ -78,7 +89,7 @@ export async function unlinkPeer(pub: string): Promise<UnlinkResult> {
   if (pi >= 0) state.peers.splice(pi, 1);
   save();
   log(
-    `unlinked "${household}" — ${mirrorsRemoved} mirror(s) removed, ${sharesRevoked} share(s) revoked, ${markersRemoved} marker(s) deleted`
+    `unlinked "${household}" — ${mirrorsRemoved} mirror(s) removed, ${sharesRevoked} share(s) revoked, ${markersRemoved} account(s) removed with their proxied photos`
   );
   return { household, mirrorsRemoved, sharesRevoked, markersRemoved };
 }
@@ -93,7 +104,7 @@ export const linkedPeers = () =>
     sharedToThem: state.mappings.filter(m => m.peer === p.pub && m.role === 'owner' && !m.dead).length,
     sharedToUs: state.mappings.filter(m => m.peer === p.pub && m.role === 'member' && !m.dead).length,
     people: Object.entries(state.contributors || {}).filter(
-      ([k, c]) => k.startsWith(BOT_PREFIX.invitePerson) && c.peer === p.pub
+      ([k, c]) => k.startsWith(BOT_PREFIX.person) && c.peer === p.pub
     ).length,
   }));
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -37,5 +37,10 @@ export const seenAdd = (mappingId: string, checksum: string, localAssetId: strin
 // not the local file's checksum (a re-encoded preview), is what travels on the wire.
 export const ledgerByAsset = (assetId: string) => store.ledgerByAsset(assetId);
 export const wireChecksum = (a: { id: string; checksum: string }) => ledgerByAsset(a.id)?.c || a.checksum;
+// Memberships this sidecar created, as opposed to ones a human made. See store.addedRecord —
+// the write order is a security property, not a style choice.
+export const addedRecord = (albumId: string, userId: string) => store.addedRecord(albumId, userId);
+export const addedHas = (albumId: string, userId: string) => store.addedHas(albumId, userId);
+export const addedForget = (albumId: string, userId: string) => store.addedForget(albumId, userId);
 export const seenActHas = (id: string) => store.seenActHas(id);
 export const seenActAdd = (id: string) => store.seenActAdd(id);

--- a/src/store.ts
+++ b/src/store.ts
@@ -58,6 +58,17 @@ export type Contributor = {
   /** That person's user id ON THE PEER, for invite targets — what lets an invitation be routed
    *  to one specific person rather than the whole household. */
   peerUserId?: string;
+  /**
+   * The server this person actually LIVES on, set only by a directory sync — the one source that
+   * proves it.
+   *
+   * Distinct from `peer`, which is merely where we first heard of them. For relayed content those
+   * differ: a photo from someone at D arrives via C, so `peer` is C. Inviting them must route to
+   * D, so invitability tests `homePeer`, never `peer`. An account with no `homePeer` is
+   * attribution-only — it can own photos, but it is not a share destination, because we have no
+   * link over which to deliver one.
+   */
+  homePeer?: string;
 };
 
 export type Collections = {
@@ -93,6 +104,12 @@ export class Store {
       CREATE TABLE IF NOT EXISTS offered (m TEXT NOT NULL, a TEXT NOT NULL);
       CREATE UNIQUE INDEX IF NOT EXISTS offered_ma ON offered (m, a);
       CREATE INDEX IF NOT EXISTS offered_a ON offered (a);
+      -- Album memberships THIS SIDECAR created (album id, user id). See addedRecord: it is the
+      -- difference between "a human invited them" and "we put them there for attribution", and
+      -- getting it wrong in the unsafe direction shares an album nobody offered.
+      CREATE TABLE IF NOT EXISTS added (al TEXT NOT NULL, us TEXT NOT NULL);
+      CREATE UNIQUE INDEX IF NOT EXISTS added_alus ON added (al, us);
+      CREATE INDEX IF NOT EXISTS added_us ON added (us);
     `);
     this.state = {
       keys: this.kvGet('keys'),
@@ -179,6 +196,42 @@ export class Store {
       .prepare(`SELECT 1 FROM offered WHERE a = ? AND m IN (${holes})`)
       .get(assetId, ...mappingIds);
   }
+  /**
+   * Remember that WE added `userId` to `albumId`.
+   *
+   * Security-critical, and the ordering matters: callers must record BEFORE the add lands. A
+   * crash between the two then leaves a row with no membership, which makes us *ignore* a real
+   * invitation — visible, and the human just re-adds. Recording afterwards would leave a
+   * membership with no row, which reads as human intent and shares the album with a server
+   * nobody offered it to. Always fail towards under-sharing.
+   */
+  addedRecord(albumId: string, userId: string) {
+    this.db.prepare('INSERT OR IGNORE INTO added (al, us) VALUES (?, ?)').run(albumId, userId);
+  }
+  /** Is this membership ours rather than a human's? */
+  addedHas(albumId: string, userId: string): boolean {
+    return !!this.db.prepare('SELECT 1 FROM added WHERE al = ? AND us = ?').get(albumId, userId);
+  }
+  /**
+   * Drop the record once the membership itself is gone.
+   *
+   * This is what keeps the table self-healing rather than sticky: without it, an album we once
+   * added someone to could never afterwards be shared with them by hand, because their fresh
+   * membership would still match an old row and read as ours.
+   */
+  addedForget(albumId: string, userId: string) {
+    this.db.prepare('DELETE FROM added WHERE al = ? AND us = ?').run(albumId, userId);
+  }
+  /** Every album we put this user into — used when unlinking a server. */
+  addedAlbumsFor(userId: string): string[] {
+    return (this.db.prepare('SELECT al FROM added WHERE us = ?').all(userId) as { al: string }[]).map(
+      r => r.al
+    );
+  }
+  addedRemoveUser(userId: string) {
+    this.db.prepare('DELETE FROM added WHERE us = ?').run(userId);
+  }
+
   offeredRemoveMapping(mappingId: string) {
     this.db.prepare('DELETE FROM offered WHERE m = ?').run(mappingId);
   }

--- a/src/sync/comments.ts
+++ b/src/sync/comments.ts
@@ -3,7 +3,7 @@
  * members pull the canonical list and push their own, gated by a cheap activity-count
  * statistic so messages land in seconds without heavy polling. startCommentLoop runs it.
  */
-import { CFG, log, UTILITY_SUFFIX, ROUTE_PREFIX } from '../config.ts';
+import { CFG, log, ROUTE_PREFIX, personName } from '../config.ts';
 import { state, save, seenActHas, seenActAdd, keys } from '../state.ts';
 import { sign, signedFetch, nudgePeers, callingPeer, mappingFor } from '../peers.ts';
 import { immichJson, jsonBody, usersById } from '../immich/client.ts';
@@ -32,7 +32,7 @@ export async function materialiseComments(mapping, peerUrl, peerName, comments) 
   const local = await getComments(mapping.albumId, albumReaderKey(mapping));
   const localPairs = new Set(
     local.map(a => {
-      const n = (users[a.user?.id]?.name || a.user?.name || '').replace(UTILITY_SUFFIX, '');
+      const n = personName(users[a.user?.id]?.name || a.user?.name || '');
       return `${n}\u0000${a.comment}`;
     })
   );
@@ -85,7 +85,7 @@ export async function handleComments(req, albumMappingId) {
       id: a.id,
       comment: a.comment,
       createdAt: a.createdAt,
-      author: (users[a.user?.id]?.name || a.user?.name || CFG.name).replace(UTILITY_SUFFIX, ''),
+      author: personName(users[a.user?.id]?.name || a.user?.name || CFG.name) || CFG.name,
       authorUserId: a.user?.id,
     }));
   return [200, { comments }];

--- a/src/sync/invites.ts
+++ b/src/sync/invites.ts
@@ -25,9 +25,9 @@
  */
 import { CFG, log, isUtilityEmail, UTILITY_EMAIL_DOMAIN, BOT_PREFIX, markerName } from '../config.ts';
 import type { Mapping, Peer } from '../store.ts';
-import { state, save, store } from '../state.ts';
+import { state, save, store, addedHas, addedForget } from '../state.ts';
 import { immichJson, jsonBody } from '../immich/client.ts';
-import { ensureUtilityUser, slugify } from '../immich/contributors.ts';
+import { ensureUtilityUser } from '../immich/contributors.ts';
 import { signedGet } from '../peers.ts';
 import { ROUTE_PREFIX } from '../config.ts';
 import { ensureMirror, fillMirrorInBackground } from '../p2p/mirror.ts';
@@ -70,9 +70,12 @@ async function syncPeerDirectory(peer: Peer) {
       await ensureUtilityUser(person.name, {
         peerPub: peer.pub,
         peerUserId: person.id,
-        stateKey: `${BOT_PREFIX.invitePerson}${slugify(peer.name)}-${slugify(person.name)}`,
-        email: `${BOT_PREFIX.invitePerson}${slugify(peer.name)}-${slugify(person.name)}@${UTILITY_EMAIL_DOMAIN}`,
+        // Keyed on the person's id on THEIR server, so the same human resolves to the same
+        // account whether we meet them via this directory or via a relayed photo.
+        stateKey: `${BOT_PREFIX.person}${person.id}`,
+        email: `${BOT_PREFIX.person}${person.id}@${UTILITY_EMAIL_DOMAIN}`,
         fullName: markerName.person(person.name, peer.name),
+        homePeer: peer.pub,
       });
     } catch (e) {
       log(`could not create an invite target for "${person.name}": ${e.message}`);
@@ -80,11 +83,17 @@ async function syncPeerDirectory(peer: Peer) {
   }
 }
 
-/** Per-person invite markers for this peer. Never contributors — see BOT_PREFIX. */
+/**
+ * People we can actually invite to an album on this peer.
+ *
+ * `homePeer === peerPub` is the whole gate, and it is a security gate rather than a tidiness one.
+ * Attribution accounts are also created from incoming refs, and a ref carries the person's own
+ * user id but NOT their home server — for relayed content, `peer` is the hop it travelled
+ * through. Treating one of those as invitable would take an album a human shared with a person at
+ * D and hand it to C. Only a linked server's directory proves where someone lives.
+ */
 function inviteTargetsFor(peerPub: string) {
-  return Object.entries(state.contributors || {})
-    .filter(([k, c]) => k.startsWith(BOT_PREFIX.invitePerson) && c.peer === peerPub && c.key && c.userId)
-    .map(([, c]) => c);
+  return Object.values(state.contributors || {}).filter(c => c.homePeer === peerPub && c.key && c.userId);
 }
 
 /** Immich album roles map onto the permission a share link would have carried. */
@@ -116,7 +125,14 @@ async function albumsAsMarker(markerKey: string, markerUserId: string): Promise<
     visible.add(a.id);
     const mine = (a.albumUsers || []).find(au => au.user?.id === markerUserId);
     // 'owner' means this is a mirror we created for inbound content, not an invitation
-    if (!mine || mine.role === 'owner') continue;
+    if (!mine || mine.role === 'owner') {
+      // Membership gone (or ours as owner): drop any record, so a future hand-invite to this
+      // album still reads as intent rather than matching a stale row forever.
+      addedForget(a.id, markerUserId);
+      continue;
+    }
+    // WE put them here, for attribution. Not an invitation, however it looks.
+    if (addedHas(a.id, markerUserId)) continue;
     // v3 album responses carry no ownerId — the owner is only discoverable inside albumUsers
     const owner = (a.albumUsers || []).find(au => au.role === 'owner');
     invited.set(a.id, {
@@ -231,6 +247,25 @@ export async function detectInvitesOnce() {
       mp.dead = true;
       save();
       log(`invitation withdrawn: "${peer.name}" removed from "${mp.albumName}" — no longer syncing it`);
+      // Clean up after ourselves, or Immich keeps showing these people on an album we have
+      // stopped syncing — and that divergence is silent, because re-adding an existing member is
+      // a no-op that produces no new signal, so the share could never be restored by hand.
+      //
+      // ONLY memberships in the `added` ledger, i.e. ones we created for attribution. A human's
+      // membership is their decision and is never touched. Assets already in the album stay in
+      // it: membership governs who may ADD assets, not what the album holds.
+      for (const t of targets) {
+        if (!addedHas(mp.albumId, t.userId)) continue;
+        try {
+          await immichJson(`/albums/${mp.albumId}/user/${t.userId}`, { method: 'DELETE' });
+          addedForget(mp.albumId, t.userId);
+          log(`  removed our own attribution membership from "${mp.albumName}"`);
+        } catch (e) {
+          // Left in place, so the ledger row stays too — that keeps it non-invitable rather than
+          // letting a stale membership read as fresh intent on the next pass.
+          log(`  could not tidy our membership on "${mp.albumName}": ${e.message}`);
+        }
+      }
     }
   }
 }

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -66,8 +66,8 @@ export const PANEL =
  el.textContent=r.ok?('Joined "'+d.album+'" from '+d.from+' — '+d.photos+' photos syncing. It will appear in your app shortly.'):('Error: '+(d.error||r.status));
  if(r.ok)setTimeout(()=>location.reload(),2500)}
 async function unlink(pub,name){
- if(!confirm('Unlink "'+name+'"?\n\nAlbums they shared with you will be removed from this server, '
-  +'and albums you shared with them will stop syncing. Photos you own are not touched.'))return;
+ if(!confirm('Unlink "'+name+'"?\n\nTheir photos and albums are removed from this server, and '
+  +'albums you shared with them stop syncing. Your own photos are untouched.'))return;
  const el=document.getElementById('umsg');el.textContent='Unlinking…';
  const r=await fetch('${ROUTE_PREFIX}/unlink',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pub:pub})});
  const d=await r.json().catch(()=>({error:'failed'}));


### PR DESCRIPTION
Each remote person now has **one** local account doing both jobs: it owns their mirrored photos, and it is what a human picks in Immich's album picker to share with them. Two accounts existed only so the code could *infer* who had added an album membership. That inference is now explicit.

## Identity

Accounts are keyed on the person's user id **on their own server**, so the same human resolves to the same local account whether we meet them through a peer's directory or a relayed photo. That also unifies the album-owner stand-in with the directory account — previously a second entry for one person.

`Contributor.homePeer === peer` is what makes someone invitable, and **only a directory sync may set it**. A relayed ref carries the person's id but not their server, so an account built from one is attribution-only: it can own photos, but it is not a share destination. Without that gate, a photo from someone at D arriving via C would have made them look invitable to C — and sharing an album with them would have handed it to the wrong household.

## The sidecar stops overruling the human

**It no longer writes album membership on an invitation album at all.** A human already added the people they chose, so their membership *is* the share and a missing one is a revocation, not a gap to fill. Filling it in was the sidecar overriding a human decision — and it was the entire source of the revoke-versus-arriving-content race, which is now gone at the source rather than mitigated.

Link-shared albums still need the write, because the link named a household and nobody named a person. Those memberships go in a new `added` table so they can never be read as intent.

## Unlink

Deletes a peer's people **and their photos together**. Everything those accounts own is a proxy whose bytes stream from the peer, so once the link is gone the assets are unreachable and keeping them would only scatter broken thumbnails through albums here. Deleting the accounts also takes their album memberships, which is what stops a later re-link from misreading a leftover membership as a fresh invitation.

## A naming bug that compounded per relay hop

The true contributor name was recovered by stripping `UTILITY_SUFFIX`, but accounts now carry `(via X server)` — so the strip was a no-op, the decorated name travelled the wire, and the receiver appended its own suffix: `Nan (via B server) (via shared albums)`. One layer per hop. `personName` in `config.ts` is now the single source of truth and collapses any nesting in one pass, including household names containing their own brackets.

Caught by reading a **passing** assertion's printed detail, not by a failure — the check was a name-contains match and was satisfied by the corrupted name.

## Tests

**129 checks green.** New coverage includes a stage that revokes an invitation and pushes a photo at that same album in the same window, then asserts the revocation still wins and the member tears its mirror down; one account per person; no membership left behind after unlink; and `personName` pinned in the sub-second lane with the exact corrupted string as a case.

### Breaking

Bot accounts are re-keyed from name-derived slugs to `person-<user id>`. Existing installs keep their old accounts as orphans — delete them, or start clean. Household-wide anything is gone; sharing names a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)