### PR TITLE
feat: link two servers on their own, instead of via an album share link

### DIFF
--- a/demo/e2e/e2e-test.mjs
+++ b/demo/e2e/e2e-test.mjs
@@ -956,6 +956,66 @@ console.log('— stage: security (utility accounts cannot be signed into)');
   } else console.log('  (skipped password-retention check: cannot read demo/b-sidecar/state.db)');
 }
 
+// Server pairing: linking two servers as its own act, with no album involved. This replaces
+// bearer-based enrolment, where anyone holding an album share link could attach their server.
+// Runs LAST, alongside unlink, because it mutates the peer list.
+console.log('— stage: pairing links two servers on its own (no album)');
+{
+  const anonMint = await fetch(`${BS}/immich-shared-albums/pairings`, { method: 'POST' });
+  check('minting a pairing link needs a session', anonMint.status === 401, `status ${anonMint.status}`);
+  const anonPeer = await fetch(`${BS}/immich-shared-albums/pairings`);
+  check('listing pairing links needs a session', anonPeer.status === 401, `status ${anonPeer.status}`);
+
+  const res = await fetch(`${BS}/immich-shared-albums/pairings`,
+    { method: 'POST', headers: { 'x-api-key': BKEY } });
+  const minted = await res.json().catch(() => ({}));
+  check('an admin can mint a pairing link', res.ok && !!minted.link, JSON.stringify(minted).slice(0, 120));
+
+  if (minted.link) {
+    check('the link carries a secret in the fragment, not the path',
+          /#[A-Za-z0-9_-]{20,}$/.test(minted.link), minted.link.replace(/#.*/, '#<redacted>'));
+    check('the link expires within the hour', minted.expiresAt - Date.now() < 3600000,
+          `${Math.round((minted.expiresAt - Date.now()) / 60000)} min`);
+    // survives being pasted into a messenger: one line, no spaces
+    check('the link is a single line with no whitespace', !/\s/.test(minted.link));
+
+    // D redeems B's link. Neither has ever shared an album with the other.
+    const before = (await (await fetch(`${DS}/immich-shared-albums/peers`, { headers: { 'x-api-key': DKEY } })).json()).peers || [];
+    const rd = await fetch(`${DS}/immich-shared-albums/pair`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': DKEY },
+        body: JSON.stringify({ link: minted.link }) });
+    const rdOut = await rd.json().catch(() => ({}));
+    check('another server can redeem it and the two are linked', rd.ok && !!rdOut.linked,
+          JSON.stringify(rdOut).slice(0, 140));
+
+    const after = (await (await fetch(`${DS}/immich-shared-albums/peers`, { headers: { 'x-api-key': DKEY } })).json()).peers || [];
+    check('the redeeming side now lists the other server', after.length > before.length,
+          `${before.length} -> ${after.length}`);
+    const bPeers = (await (await fetch(`${BS}/immich-shared-albums/peers`, { headers: { 'x-api-key': BKEY } })).json()).peers || [];
+    check('the minting side lists it too (one round trip pairs both)',
+          bPeers.some(p => (p.name || '').includes('(D)')), bPeers.map(p => p.name).join(', '));
+
+    // SECURITY: single-use. A forwarded copy must be inert.
+    const replay = await fetch(`${DS}/immich-shared-albums/pair`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': DKEY },
+        body: JSON.stringify({ link: minted.link }) });
+    check('a pairing link cannot be redeemed twice', !replay.ok, `status ${replay.status}`);
+
+    // SECURITY: pairing conveys no access to any photo. The newly linked peer must carry zero
+    // albums in either direction — what they may see is decided afterwards, per person.
+    const linked = after.find(p => !before.some(b => b.pub === p.pub));
+    check('pairing on its own shares no albums in either direction',
+          !!linked && linked.sharedToUs === 0 && linked.sharedToThem === 0,
+          linked ? `${linked.name}: ${linked.sharedToUs} in, ${linked.sharedToThem} out` : 'new peer not found');
+
+    // SECURITY: a made-up code must be refused.
+    const bogus = await fetch(`${DS}/immich-shared-albums/pair`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': DKEY },
+        body: JSON.stringify({ link: minted.link.replace(/#.*/, '#' + 'x'.repeat(43)) }) });
+    check('an invented pairing code is refused', !bogus.ok, `status ${bogus.status}`);
+  }
+}
+
 // LAST STAGE, deliberately: unlinking is destructive, so it runs after everything that needs
 // the B<->C link. Server links are admin-owned objects managed from the panel — not something
 // expressed by removing a bot from an album.

--- a/src/p2p/pair.ts
+++ b/src/p2p/pair.ts
@@ -1,0 +1,193 @@
+/**
+ * p2p/pair.ts — linking two servers, as its own act.
+ *
+ * Until now a link only came into being as a side effect of redeeming an ALBUM share link, which
+ * made enrolment bearer-based: whoever held that link (and its password) could attach their
+ * server to yours, using a credential meant to grant one album to one person. This replaces that
+ * with a purpose-built one, and being purpose-built is what lets it be strict:
+ *
+ *  - **single-use** — consumed the moment it is redeemed, so a forwarded copy is inert;
+ *  - **short-lived** — minutes, not the 24 hours an Immich share-link token lives;
+ *  - **high-entropy** — 32 random bytes, so guessing is not a threat model;
+ *  - **revocable before use** — the panel can drop an unredeemed code;
+ *  - **not an album grant** — pairing conveys no access to any photo. What the two servers may
+ *    see of each other is decided afterwards, per person, in Immich's own picker.
+ *
+ * Nobody has to be able to *open* this string in a browser, which is exactly why it can be
+ * tighter than the banner flow it sits alongside.
+ */
+import crypto from 'node:crypto';
+import { CFG, log, ROUTE_PREFIX, SIDECAR_VERSION } from '../config.ts';
+import { PROTOCOL_VERSION } from '../types.ts';
+import { state, save, store, keys } from '../state.ts';
+import { assertPeerUrlAllowed, verify, sign } from '../peers.ts';
+
+/** How long a freshly minted code stays redeemable. Long enough to paste into a chat. */
+const CODE_TTL_MS = 15 * 60 * 1000;
+
+export type PairingCode = { code: string; createdAt: number; expiresAt: number };
+
+const load = (): PairingCode[] => store.kv('pairings') ?? [];
+const persist = (list: PairingCode[]) => store.kvSet('pairings', list);
+
+/** Drop anything expired. Called on every read path so stale codes cannot pile up. */
+function live(): PairingCode[] {
+  const now = Date.now();
+  const list = load().filter(p => p.expiresAt > now);
+  if (list.length !== load().length) persist(list);
+  return list;
+}
+
+/**
+ * Mint a code and return the string to hand to the other admin.
+ *
+ * A URL, because that is the one shape a messenger will not mangle: no newlines, nothing that
+ * gets linkified into something else, and it survives being pasted into WhatsApp or a text.
+ * PUBLIC_URL has to be set for it to mean anything — the other server dials it.
+ */
+export function mintPairing(): { link: string; expiresAt: number } {
+  if (!CFG.publicUrl) {
+    throw new Error('PUBLIC_URL is not set, so the other server would have no address to reach');
+  }
+  const code = crypto.randomBytes(32).toString('base64url');
+  const now = Date.now();
+  const entry = { code, createdAt: now, expiresAt: now + CODE_TTL_MS };
+  persist([...live(), entry]);
+  log(`minted a pairing code, valid for ${CODE_TTL_MS / 60000} minutes`);
+  return { link: `${CFG.publicUrl}${ROUTE_PREFIX}/pair#${code}`, expiresAt: entry.expiresAt };
+}
+
+/** What the panel shows: unredeemed codes, newest first. */
+export const pendingPairings = () =>
+  live()
+    .slice()
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .map(p => ({
+      link: `${CFG.publicUrl}${ROUTE_PREFIX}/pair#${p.code}`,
+      expiresAt: p.expiresAt,
+    }));
+
+export function revokePairing(code: string) {
+  persist(live().filter(p => p.code !== code));
+}
+
+/** Constant-time, so a wrong code leaks nothing about how wrong it was. */
+function codeMatches(candidate: string): PairingCode | undefined {
+  const want = Buffer.from(candidate);
+  return live().find(p => {
+    const have = Buffer.from(p.code);
+    if (have.length !== want.length) {
+      crypto.timingSafeEqual(have, have);
+      return false;
+    }
+    return crypto.timingSafeEqual(have, want);
+  });
+}
+
+/**
+ * MINTING side: another server is redeeming a code we issued.
+ *
+ * Signature-bound to the key being enrolled, exactly as album redeem is: it proves the caller
+ * holds the private half of the identity it is asking us to trust, so the enrolled key cannot be
+ * forged or swapped later. Consuming the code before answering means a replay finds nothing.
+ */
+export async function handlePair(req, body: string) {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return [400, { error: 'malformed request' }];
+  }
+  const { code, household } = parsed;
+  if (!code || !household?.publicKey || !household?.url) {
+    return [400, { error: 'malformed pairing request' }];
+  }
+  if (!verify(body, (req.headers['x-isa-sig'] as string) || '', household.publicKey)) {
+    return [403, { error: 'pairing signature does not match the household key' }];
+  }
+  const entry = codeMatches(String(code));
+  if (!entry) {
+    log('pairing refused: unknown or expired code');
+    return [403, { error: 'that pairing link is not valid — it may have expired or been used' }];
+  }
+  try {
+    await assertPeerUrlAllowed(household.url);
+  } catch (e) {
+    return [400, { error: e.message }];
+  }
+  // Single-use: burn it before doing anything else, so a replay cannot land twice.
+  revokePairing(entry.code);
+
+  const existing = state.peers.find(p => p.pub === household.publicKey);
+  if (existing) {
+    existing.url = household.url;
+    existing.name = household.name || existing.name;
+    if (parsed.version) existing.version = parsed.version;
+  } else {
+    state.peers.push({
+      pub: household.publicKey,
+      url: household.url,
+      name: household.name || 'Unnamed household',
+      version: parsed.version,
+    });
+  }
+  save();
+  log(`paired with "${household.name}" — their people can now be invited to albums`);
+  return [
+    200,
+    {
+      household: { publicKey: keys.pub, url: CFG.publicUrl, name: CFG.name },
+      protocol: PROTOCOL_VERSION,
+      version: SIDECAR_VERSION,
+    },
+  ];
+}
+
+/**
+ * REDEEMING side: an admin pasted a link another server gave them.
+ *
+ * One round trip pairs both ends: they learn our key from the signed request, we learn theirs
+ * from the answer. Neither side gains access to a single photo by doing this — that is decided
+ * afterwards, per person, in Immich's own album picker.
+ */
+export async function redeemPairing(link: string) {
+  const m = String(link ?? '')
+    .trim()
+    .match(/^(https?:\/\/[^/]+)(?:\/[^#]*)?#([A-Za-z0-9_-]+)$/);
+  if (!m) throw new Error('that does not look like a server link');
+  const [, origin, code] = m;
+  await assertPeerUrlAllowed(origin);
+
+  const body = JSON.stringify({
+    code,
+    protocol: PROTOCOL_VERSION,
+    version: SIDECAR_VERSION,
+    household: { publicKey: keys.pub, url: CFG.publicUrl, name: CFG.name },
+  });
+  const r = await fetch(`${origin}${ROUTE_PREFIX}/api/v1/pair`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-isa-key': keys.pub, 'x-isa-sig': sign(body) },
+    body,
+    signal: AbortSignal.timeout(30000),
+  });
+  const res = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(res.error || `pairing failed (${r.status})`);
+  if (!res.household?.publicKey) throw new Error('that server did not identify itself');
+
+  const existing = state.peers.find(p => p.pub === res.household.publicKey);
+  if (existing) {
+    existing.url = res.household.url || origin;
+    existing.name = res.household.name || existing.name;
+    if (res.version) existing.version = res.version;
+  } else {
+    state.peers.push({
+      pub: res.household.publicKey,
+      url: res.household.url || origin,
+      name: res.household.name || 'Unnamed household',
+      version: res.version,
+    });
+  }
+  save();
+  log(`paired with "${res.household.name}" — their people can now be invited to albums`);
+  return { linked: res.household.name || origin };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -119,6 +119,18 @@ export class Store {
     };
   }
 
+  /**
+   * Generic kv access, for small side-tables that do not deserve a typed field on `state` —
+   * currently just unredeemed pairing codes. Deliberately narrow: the four main collections have
+   * their own fields and their own save path, and this must not become a second way to write them.
+   */
+  kv(name: string) {
+    return this.kvGet(name);
+  }
+  kvSet(name: string, value: unknown) {
+    this.db.prepare('INSERT OR REPLACE INTO kv (name, value) VALUES (?, ?)').run(name, JSON.stringify(value));
+  }
+
   private kvGet(name: string) {
     const row = this.db.prepare('SELECT value FROM kv WHERE name = ?').get(name) as
       { value: string } | undefined;

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -37,6 +37,16 @@ export const PANEL =
   <div id="msg"></div></div>
  <div class="card"><b style="font-size:14px">Shared albums</b>
   ${state.mappings.map(m => `<div class="item"><span>${m.albumName}</span><span class="muted">${m.role} · ${(state.peers.find(p => p.pub === m.peer) || {}).name || ''}</span></div>`).join('') || '<p class="muted" style="font-size:13px">None yet.</p>'}</div>
+ <div class="card"><b style="font-size:14px">Link a server</b>
+  <p class="muted" style="font-size:13px">Send this link to the other server's admin, who pastes it
+   into their own panel. It links the two servers so you can invite each other's people to albums
+   in Immich. It is single-use, expires in 15 minutes, and grants access to no photos on its own.</p>
+  <div style="display:flex;gap:8px"><button onclick="mint()">Create a link</button>
+   <button onclick="document.getElementById('pastebox').style.display='flex'">I have a link</button></div>
+  <div id="minted"></div>
+  <form id="pastebox" style="display:none;margin-top:10px" onsubmit="redeem(event)">
+   <input id="plink" placeholder="Paste the link they sent you"><button>Link</button></form>
+  <div id="pmsg"></div></div>
  <div class="card"><b style="font-size:14px">Connected servers</b>
   <p class="muted" style="font-size:13px">Once a server is connected, its people appear in Immich's
    own “share album” picker. Unlinking removes them from the picker, tears down the albums they
@@ -65,6 +75,31 @@ export const PANEL =
   el.textContent='This album is password protected — enter the same password you would use to view it.';return}
  el.textContent=r.ok?('Joined "'+d.album+'" from '+d.from+' — '+d.photos+' photos syncing. It will appear in your app shortly.'):('Error: '+(d.error||r.status));
  if(r.ok)setTimeout(()=>location.reload(),2500)}
+async function mint(){
+ const el=document.getElementById('pmsg');el.textContent='Creating…';
+ const r=await fetch('${ROUTE_PREFIX}/pairings',{method:'POST'});
+ const d=await r.json().catch(()=>({error:'failed'}));
+ if(!r.ok){el.textContent='Error: '+(d.error||r.status);return}
+ el.textContent='';
+ const mins=Math.max(1,Math.round((d.expiresAt-Date.now())/60000));
+ const box=document.getElementById('minted');
+ box.innerHTML='<p class="muted" style="font-size:13px;margin:10px 0 6px">Send this to them — it works once, and expires in '+mins+' minutes.</p>';
+ const inp=document.createElement('input');inp.readOnly=true;inp.value=d.link;inp.style.width='100%';
+ const row=document.createElement('div');row.style.display='flex';row.style.gap='8px';
+ const copy=document.createElement('button');copy.textContent='Copy';
+ // navigator.clipboard needs a secure context, so it is absent on a plain-HTTP LAN panel.
+ // Selecting the text is the fallback, otherwise the button looks broken for exactly the
+ // people running the simplest setups.
+ copy.onclick=async()=>{try{await navigator.clipboard.writeText(d.link);copy.textContent='Copied'}
+  catch{inp.select();copy.textContent='Press Ctrl/Cmd+C'}};
+ row.appendChild(inp);row.appendChild(copy);box.appendChild(row)}
+async function redeem(e){e.preventDefault();
+ const el=document.getElementById('pmsg'),v=document.getElementById('plink').value;
+ el.textContent='Linking…';
+ const r=await fetch('${ROUTE_PREFIX}/pair',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({link:v})});
+ const d=await r.json().catch(()=>({error:'failed'}));
+ el.textContent=r.ok?('Linked with '+d.linked+' — their people can now be invited to albums.'):('Error: '+(d.error||r.status));
+ if(r.ok)setTimeout(()=>location.reload(),1800)}
 async function unlink(pub,name){
  if(!confirm('Unlink "'+name+'"?\n\nTheir photos and albums are removed from this server, and '
   +'albums you shared with them stop syncing. Your own photos are untouched.'))return;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -28,6 +28,7 @@ import { handleRedeem, handleRefs, handleVersion, handleNudge, handleManifest } 
 import { join } from '../p2p/join.ts';
 import { leaveAlbum } from '../sync/leave.ts';
 import { unlinkPeer, linkedPeers, localHousehold } from '../p2p/unlink.ts';
+import { handlePair, mintPairing, pendingPairings, revokePairing, redeemPairing } from '../p2p/pair.ts';
 import { handleActivity, handleComments } from '../sync/comments.ts';
 import { invitationsFor, localDirectory } from '../sync/invites.ts';
 
@@ -154,6 +155,52 @@ export const server = http.createServer(async (req, res) => {
       if (!caller.isAdmin) return send(403, { error: 'only an admin can see connected servers' });
       return send(200, { household: localHousehold(), peers: linkedPeers() });
     }
+    if (path === `${ROUTE_PREFIX}/pairings` && req.method === 'GET') {
+      const caller = await callerIdentity(req);
+      if (!caller) return send(401, signInRequired('link a server'));
+      if (!caller.isAdmin) return send(403, { error: 'only an admin can link a server' });
+      return send(200, { pairings: pendingPairings(), publicUrl: CFG.publicUrl });
+    }
+    if (path === `${ROUTE_PREFIX}/pairings` && req.method === 'POST') {
+      const caller = await callerIdentity(req);
+      if (!caller) return send(401, signInRequired('link a server'));
+      if (!caller.isAdmin) return send(403, { error: 'only an admin can link a server' });
+      try {
+        return send(200, mintPairing());
+      } catch (e) {
+        return send(400, { error: e.message });
+      }
+    }
+    if (path === `${ROUTE_PREFIX}/pairings/revoke` && req.method === 'POST') {
+      const caller = await callerIdentity(req);
+      if (!caller) return send(401, signInRequired('revoke a pairing link'));
+      if (!caller.isAdmin) return send(403, { error: 'only an admin can revoke a pairing link' });
+      try {
+        const b = JSON.parse(body);
+        // Accept the whole link, so the panel can pass back exactly what it displayed.
+        const code =
+          String(b.link || b.code || '')
+            .split('#')
+            .pop() ?? '';
+        revokePairing(code);
+        return send(200, { revoked: true });
+      } catch (e) {
+        return send(400, { error: e.message });
+      }
+    }
+    // Pasting a link another server gave us. This is the standalone way to link two servers:
+    // no album is involved, and pairing conveys no access to any photo.
+    if (path === `${ROUTE_PREFIX}/pair` && req.method === 'POST') {
+      const caller = await callerIdentity(req);
+      if (!caller) return send(401, signInRequired('link a server'));
+      if (!caller.isAdmin) return send(403, { error: 'only an admin can link a server' });
+      try {
+        const b = JSON.parse(body);
+        return send(200, await redeemPairing(b.link));
+      } catch (e) {
+        return send(400, { error: e.message });
+      }
+    }
     if (path === `${ROUTE_PREFIX}/unlink` && req.method === 'POST') {
       const caller = await callerIdentity(req);
       if (!caller) return send(401, signInRequired('unlink a server'));
@@ -164,6 +211,12 @@ export const server = http.createServer(async (req, res) => {
       } catch (e) {
         return send(400, { error: e.message });
       }
+    }
+    // Another server redeeming a code we minted. Signature-bound to the key being enrolled, and
+    // deliberately NOT session-authed: the caller is a server, not a person.
+    if (path === `${ROUTE_PREFIX}/api/v1/pair` && req.method === 'POST') {
+      const [code, obj] = await handlePair(req, body);
+      return send(code, obj);
     }
     if (path === `${ROUTE_PREFIX}/api/v1/invites/redeem` && req.method === 'POST') {
       const [code, obj] = await handleRedeem(req, body);


### PR DESCRIPTION
Until now a server link only came into being as a **side effect of redeeming an album share link** — so enrolment was bearer-based: whoever held that link (and its password) could attach their server to yours, using a credential meant to grant one album to one person. This adds the linking act itself.

## Why a purpose-built credential can be stricter

Nobody has to be able to *open* this string in a browser, which is exactly what lets it be tighter than the banner flow it sits alongside:

| | |
|---|---|
| **Single-use** | burned *before* the response is sent, so a replay finds nothing |
| **15 minutes** | against the 24 hours an Immich share-link token lives |
| **32 random bytes** | compared in constant time |
| **Signature-bound** | signed with the key being enrolled, proving the caller holds its private half — the identity cannot be forged or swapped later |
| **Revocable** | before use, from the panel |
| **No album access** | pairing means *these two servers know each other*, nothing more |

That last row is the point: what the servers may see of each other is decided afterwards, **per person, in Immich's own picker**. It's the split the roadmap's keystone item is named for.

The secret rides in the URL **fragment** rather than the path, and one round trip pairs both ends — they learn our key from the signed request, we learn theirs from the answer. It's a URL because that's the one shape a messenger won't mangle.

## Panel

A "Link a server" card: **Create a link** mints one with a copy button, **I have a link** reveals a paste box. The copy button falls back to selecting the text, because `navigator.clipboard` needs a secure context and would otherwise look broken for exactly the people running a plain-HTTP LAN panel.

`POST <prefix>/api/v1/pair` is peer-facing and **signature-authed, not session-authed** — the caller is a server, not a person. The `/pairings` routes and the redeem route are admin-only, because linking a server is an admin act.

## Tests

**141 checks green.** The new stage links two servers that have never shared an album (D redeems B's link) and pins the security properties: unauthenticated mint refused, no second redemption, invented codes refused, and the freshly linked peer carrying **0 albums in either direction**.

## Not in this PR

The panel's "Join an album" box stays for now. Removing it is **unblocked** by this — linking no longer depends on it — and is the immediate follow-up, along with making the panel solely about server linking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)