### PR TITLE
docs: project conventions, the two bedrock docs, and the fast gate enforced in code

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,8 @@
 #!/bin/sh
-# Fast gate on every commit: seconds, no containers. The e2e suite stays in CI —
-# a seven-minute hook is a hook people bypass.
-# Enabled automatically by `npm install` (the prepare script sets core.hooksPath).
+# .githooks/pre-commit — fast gate on every commit. See ../AGENTS.md ("How changes land").
 set -e
 echo "pre-commit: verify:fast (bundles, format, lint, types, cycles)"
 npm run --silent verify:fast || exit 1
-# The bundles are generated from src/web/{panel,accept}/** — stage what the build refreshed,
-# or the commit ships UI that differs from its source.
+# build:panel regenerated both bundles; stage them or the commit ships stale UI.
 git add src/web/panel.bundle.js src/web/accept.bundle.js
 echo "pre-commit: ok"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,17 +1,11 @@
 #!/bin/sh
-# Fast gate on every commit: seconds, no containers. The e2e suite stays in CI and in
-# `bash demo/run-mock-e2e.sh` — putting a seven-minute run in a hook is how hooks get bypassed.
-#
-# Enable once per clone:  git config core.hooksPath .githooks
+# Fast gate on every commit: seconds, no containers. The e2e suite stays in CI —
+# a seven-minute hook is a hook people bypass.
+# Enabled automatically by `npm install` (the prepare script sets core.hooksPath).
 set -e
-echo "pre-commit: panel bundle, format check, lint, typecheck, cycles"
-# Rebuild the committed panel bundle, then stage it: it is generated from src/web/panel/**, and a
-# stale copy would silently ship different UI than the source says.
-npm run --silent build:panel >/dev/null || { echo "  ✗ panel build failed"; exit 1; }
-git add src/web/panel.bundle.js
-npx prettier --check "src/**/*.ts" "scripts/**/*.mjs" >/dev/null || {
-  echo "  ✗ formatting — run: npm run format"; exit 1; }
-npx eslint src || exit 1
-npx tsc --noEmit || exit 1
-node scripts/check-cycles.mjs >/dev/null || exit 1
+echo "pre-commit: verify:fast (bundles, format, lint, types, cycles)"
+npm run --silent verify:fast || exit 1
+# The bundles are generated from src/web/{panel,accept}/** — stage what the build refreshed,
+# or the commit ships UI that differs from its source.
+git add src/web/panel.bundle.js src/web/accept.bundle.js
 echo "pre-commit: ok"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,17 @@ on:
     - cron: '0 6 * * 1' # weekly: catch breakage in immich-server:release before users do
 
 jobs:
+  pr-title:
+    # The squashed PR title is what release-please parses. See ../../AGENTS.md ("How changes land").
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR title is a conventional commit
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "$TITLE" | grep -qE '^(feat|fix|chore|docs|refactor|perf|test|build|ci|revert)(\([a-z0-9-]+\))?!?: .+' \
+            || { echo "::error::PR title must be conventional (feat:/fix:/chore:/…) — it becomes the release commit"; exit 1; }
   # Its own job, not a step in e2e: a lint failure should report as "checks", not as a
   # confusing e2e failure, and it finishes in ~1 minute instead of waiting on Immich to boot.
   # Worth marking as a required status check in branch protection alongside e2e.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,24 @@ saying so.
   Any behaviour change updates the relevant doc(s) **in the same change**. A doc that lies is
   worse than no doc: treat drift as a bug and fix it with the code that caused it.
 
-  This matters more than it used to. Explanation deliberately lives in these docs rather than in
-  comments — naming carries the *what*, docs carry the *why* (see the naming section below). That
+  Explanation lives in these docs rather than in comments — naming carries the *what*, docs carry the *why* (see the naming section below). That
   only works while they track the code, so the further an explanation sits from what it explains,
   the more strictly this rule applies. Moving prose out of a source file and then letting it rot
   is worse than having left it inline.
+
+  Four rules for writing them:
+
+  - **Dense over flowing.** Bullets, tables and short declaratives — not paragraphs of prose. A
+    doc is reference material read under time pressure, usually to answer one question. Maximise
+    facts per line.
+  - **Every claim must be checkable, and checked.** Name the real symbol, the real route, the
+    real env var. Prose that paraphrases behaviour cannot be verified and rots invisibly; a doc
+    saying `handleVersion` answers `…/version` can be grepped in a second.
+  - **State what the code does, not what it should do.** Re-read the doc against the
+    implementation before you land it. A doc written from a plan describes the design you may
+    have since rejected, and reads as authoritative while doing it.
+  - **Boy-scout, never batch** — see the section below. Verify a doc when you touch the code it
+    describes; do not mass-rewrite docs you are not otherwise changing.
 - **Never test against a real server.** Use the throwaway mock rig in `demo/`. Never run
   the suite or experiments against anyone's production Immich, and never modify a real
   user's library.
@@ -58,24 +71,22 @@ saying so.
 
 ## How changes land
 
-- **Everything goes through a pull request**, gated on the e2e suite (123 checks + a browser
-  lane) and the fast gate below. Branch protection enforces it; merges are squash-only.
+- **Everything goes through a pull request**, gated on both e2e lanes and the fast gate below. Branch protection enforces it; merges are squash-only.
 - **Conventional commits** decide the version automatically via release-please
   (`fix:` → patch, `feat:` → minor, `feat!:` → major). Don't hand-edit version numbers.
 - **Before pushing:** `npm run verify` clean (format, lint, types, runtime load, import cycles,
   unit tests — seconds), then BOTH e2e lanes:
 
   ```
-  bash demo/run-mock-e2e.sh                       # API suite, 141 checks
+  bash demo/run-mock-e2e.sh                       # API suite
   cd demo/e2e && CKEY=<origin key> \
     HOST_RESOLVER_RULES="MAP host.docker.internal 127.0.0.1" node browser-test.mjs
   ```
 
   **Run the browser lane whenever you touch a page.** It is the only coverage of the banner and
-  accept flows — the API suite has 141 checks and not one of them loads a page in a browser. The
-  accept page was converted to components with the API suite fully green, and CI caught two real
-  breakages: the element ids the lane drives, and an invite that evaporated mid-join. The resolver
-  rule exists so this runs on a dev machine without editing /etc/hosts.
+  accept flows — nothing in the API suite loads a page in a browser, so a page can break with that
+  suite fully green. The resolver rule exists so this runs on a dev machine without editing
+  /etc/hosts.
 
   Run against a FRESHLY PURGED rig. `run-mock-e2e.sh` purges; recreating containers by hand does
   not, and stale bot keys in `state.db` produce `Invalid API key` failures that look like product
@@ -124,7 +135,7 @@ a stored fact is also a stored liability:**
   the bot accounts' API keys, so anything added inherits that blast radius. (The *admin* key is
   not in there — it comes from `IMMICH_API_KEY` in the environment.) Two rules follow, neither
   about compliance:
-  - The bot password is rolled to a value nobody keeps (`ensureUtilityUser`), because it existed
+  - The bot password is rolled to a value nobody keeps (`ensureLocalAccountFor`), because it existed
     only to mint one API key and has no purpose afterwards. The concrete gain is small but real:
     a bot key deliberately lacks `apiKey.create`, so it can do its 22 things and no more, whereas
     a password logs in interactively and can mint an unrestricted key for that account. Keeping it
@@ -147,6 +158,180 @@ a stored fact is also a stored liability:**
 Corollary: a fact only counts as known if something *proved* it. `Contributor.homePeer` is set
 only by a linked server's directory, never by an incoming photo — a relayed ref names the person
 but not their server, and guessing would route someone's album to the wrong household.
+
+## Every source file opens with one line: what it is, and where its doc is
+
+A single line, first line, no exceptions:
+
+```ts
+/** sync/invites.ts — sharing an album by inviting a PERSON in Immich's own picker. See sync-loops.md. */
+/** sync/leave.ts — undoing a join. See sync-loops.md. */
+```
+
+Format: `path — brief description. See <doc>.md.`
+
+This is the one comment whose job cannot be done by naming, because it answers a question the code
+cannot: **where is the context for this file?** Some files have a doc of their own beside them
+(a `config.md` beside `config.ts`, once one earns it); others are covered by a folder doc under a
+different name
+(`p2p/protocol.ts` → `wire-protocol.md`). Without the pointer you would have to guess or grep.
+
+It also makes the link machine-followable, which matters because agents work here: open the file,
+read one line, know exactly which doc to load for context before changing anything.
+
+Two rules keep it honest:
+
+- **Keep the pointer accurate.** A header pointing at a doc that no longer exists, or at the wrong
+  one, is worse than none — it sends the next reader somewhere useless. Renaming or moving a doc
+  means updating every header that references it.
+- **Do not let it grow.** It is a pointer, not a summary. If you find yourself adding a second
+  sentence, that sentence belongs in the doc.
+
+## Boy-scout rule: any file you touch comes up to standard
+
+**A file you edit for any reason leaves your change compliant.** The conventions below are applied
+per-change, not by sweeping the tree, so the codebase converges as work moves through it.
+
+Six checks, all of them seconds:
+
+| Check | Standard | Where it is written |
+| --- | --- | --- |
+| Header | line 1 is `path — description. See doc.md.`, and a whole sentence | *Every source file opens with one line* |
+| Comments | the header, load-bearing lines and TODOs — nothing else | *Comments: a paired doc is the default* |
+| Names | **rename rather than explain** — any name you must explain is not descriptive enough | *A name that needs a comment* |
+| Doc placement | one exists at the right level for what you touched | *Where a doc lives* |
+| Doc truth | you re-read it against the code you just changed | *Keep the docs in sync* |
+| Doc style | dense bullets, every claim naming a real symbol | *Keep the docs in sync* |
+
+Two things this rule is deliberately **not**:
+
+- **Not a licence to batch-migrate.** Do not sweep files you are not otherwise changing. The
+  verification is the expensive half, and it is only cheap while you have the code in your head.
+- **Not a blocker on unrelated work.** If a file you touched is far off standard and fixing it
+  would swamp the actual change, bring the part you touched up to standard and say what you left.
+
+**Removing a comment is a move, never a delete.** Its content goes to one of two places, and
+choosing is the whole job:
+
+- **Into the name**, when it explained *what* something is. Three that are waiting in this tree,
+  as worked examples: `mayAdd` carries a comment about revoked members — it should be
+  `reAddIfMissing`, and the comment goes with the rename. `WATCH_RUNNING` carries one about
+  stampeding the host — it should be `watchCycleInFlight`. `(cacheMaxMb * 1024 * 1024) / 10`
+  carries one about the per-item cap — the divisor should be a named constant. Renaming a
+  parameter, extracting a named constant and splitting a condition into a named boolean are all in
+  scope of the change that deleted the comment; do not stop at deletion and leave the name as it
+  was.
+- **Into the doc**, when it explained *why* — design reasoning, an Immich quirk, history.
+
+If neither fits and the line is a hazard at its trigger point, it stays inline as one line.
+
+All six are judgement calls, which is why they are written down rather than left implied.
+
+## Where a doc lives: as close to the code as it needs to be, and no closer
+
+Granular on purpose. Pick the nearest level that earns one:
+
+- **File-level** — one module carrying dense reasoning of its own, e.g. a `store.md` next to
+  `store.ts`. None exist yet; create one the first time a module earns it.
+- **Folder-level** (`wire-protocol.md`, `sync-loops.md`) — a concern spanning several files, where
+  the useful explanation is how they fit together.
+- **Neither** — most files. A module whose names already say what it does needs no doc; it still
+  carries a header pointing at whichever doc covers it.
+- **Both** is fine. A file-level doc for the hard module, a folder doc for the concern around it.
+
+A concern starts as one file at `src/` root, and graduates to a folder with its own doc when it
+needs several files. `src/ARCHITECTURE.md` describes the whole tree.
+
+## Comments: a paired doc is the default, inline is the exception
+
+**The target state for any file: the one-line header, plus load-bearing lines and TODOs. Nothing
+else.** If a file you are working in carries more than a couple of comments, the explanation
+belongs in its doc and the rest belongs in better names.
+
+Explanation belongs in a Markdown doc beside the code, not in the code. Naming carries the *what*;
+the doc carries the *why*. Code that reads cleanly and a doc that explains fully beats a file where
+both are tangled — and a doc can hold far more context than anyone would tolerate inline.
+
+**The test for keeping a comment inline: would moving it to the doc stop it doing its job?**
+
+Almost always the answer is no, so it moves. Two cases where it is yes, and they are the only ones:
+
+- **A hazard at the trigger line.** `record BEFORE the add`, `splice, never reassign`,
+  `ORDER IS LOAD-BEARING`. The person editing that exact statement must see the warning without
+  knowing a doc exists. One line, and it may point at the doc for the reasoning.
+- **A test case's rationale.** *"the doubled form a relay hop produces, which is what this exists
+  to prevent"* — that sentence IS the case's meaning. Without it the assertion is a bare comparison
+  that a later reader deletes as redundant, or "fixes" to match new behaviour. The reader who needs
+  it is looking at the assertion, so it cannot live anywhere else.
+
+- **A one-line JSDoc on an exported type field or function.** Editors surface it on hover at every
+  use site, which no doc can do. `/** Mutable hint — where to reach them right now. */` on
+  `Household.url` earns its place; a paragraph above the type does not.
+
+Everything else goes: background, design reasoning, Immich quirks, "why this shape", history. The
+reader who needs those is trying to understand the module and will be reading its doc. Inline, they
+are noise standing between someone and the code.
+
+Corollary, and the reason this is worth the effort: comments rot **silently**. Prose in a doc gets
+reviewed as prose; prose wedged between statements gets skipped, and goes on asserting things that
+stopped being true several changes ago.
+
+### What survives, concretely
+
+Every comment that stays must fall into one of these categories. If the one you are about to keep
+fits none of them, it belongs in the doc:
+
+| Category | Example |
+| --- | --- |
+| Deliberate-swallow marker on an empty `catch` | `/* already gone */`, `/* fail-open */` |
+| Ordering or aliasing hazard at the line | `record BEFORE the add`, `Splice, NEVER reassign` |
+| A revocation rule (fails towards under-sharing) | `missing member on an invitation album = REVOKED` |
+| A test contract other tooling depends on | `#who/#go/#out are a TEST CONTRACT` |
+| A wire route a type name cannot hold | `POST …/albums/:mappingId/refs` |
+| An external contract we do not get to name | the Immich API's response shape, a CGNAT regex |
+| A tooling marker | `// x-release-please-version` |
+
+A bare `catch {}` reads as a forgotten branch, so three words saying the swallow is intended is
+load-bearing — that is why the first row exists and why it is the largest group.
+
+Two traps when doing this work. **Judge each comment; never keyword-match it** — a block containing
+`ONLY` or `NEVER` is not automatically a hazard, and design prose hides behind those words. And
+**a mechanical strip truncates**: it leaves fragments that end mid-clause but still read like
+instructions. Re-read every comment you touch, in full.
+
+## A name that needs a comment is the wrong name
+
+This is the default, and it comes before every other rule about comments: **if you have to explain
+a name, the name is not descriptive enough. Rename it.** The comment is a symptom; fix the cause.
+
+It applies to everything you get to name — functions, variables, constants, parameters, type
+fields, files, routes, env vars, test titles, doc headings. Nothing is exempt for being small or
+local.
+
+The test is whether a reader who has never seen the code guesses right from the name alone:
+
+- `/** How often to re-check whether they have signed in. */` above `POLL` → `SIGN_IN_POLL_MS`.
+- `/** The server this person actually lives on. */` above `peer` → `homePeer`.
+- `(CFG.cacheMaxMb * 1024 * 1024) / 10` with `// no single item >10% of cap` →
+  `/ MAX_ITEM_SHARE_OF_CACHE`.
+- `mayAdd`, with a comment about revoked members — **still wrong**, which is the point: it says
+  permission where the real meaning is "if they are missing, put them back". Renamed to
+  `reAddIfMissing`, and its two comments went with it. Getting one rename in and still needing the
+  comment means go again, not settle.
+
+Reach for a longer name before reaching for a comment. `startPollingUntilSignedIn` needs no
+explanation; `tick` needs a paragraph. A name is read every time it is used; a comment is read
+once, if at all, and then rots.
+
+What survives this rule is only what a name **cannot** carry:
+
+- a hazard about ORDER or CONCURRENCY at the exact line it applies to
+- a reference to an external behaviour that is not in this codebase — an Immich quirk, a browser
+  constraint — and even then prefer the paired doc unless the reader of that line needs it
+- a `TODO` with enough context to act on
+
+If you find yourself writing "this is needed because…", that is doc material, not a comment. If you
+find yourself writing "this does X", the name should have said X.
 
 ## Name things so the next reader does not have to decode them
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,11 @@ worse without saying so**, and chip at the key one whenever a change touches key
     Applies to this file as much as to any other.
   - **Boy-scout, never batch** — see the section below. Verify a doc when you touch the code it
     describes; do not mass-rewrite docs you are not otherwise changing.
+- **Never enforce in prose what code can enforce.** An instruction in this file relies on being
+  read, remembered and obeyed every time; a hook, a lint rule, a test or an npm script does not.
+  Before adding a "remember to…" here, try to make it impossible to forget instead — and when a
+  rule below says something is enforced, that is a property to preserve, not decoration. This file
+  is for judgement calls code cannot make.
 - **Never test against a real server.** Use the throwaway mock rig in `demo/`. Never run
   the suite or experiments against anyone's production Immich, and never modify a real
   user's library.
@@ -76,8 +81,8 @@ worse without saying so**, and chip at the key one whenever a change touches key
   Branch protection enforces it; merges are squash-only.
 - **Conventional commits** decide the version automatically via release-please
   (`fix:` → patch, `feat:` → minor, `feat!:` → major). Don't hand-edit version numbers.
-- **Before pushing:** `npm run verify` clean (format, lint, types, runtime load, import cycles,
-  unit tests — seconds), then BOTH e2e lanes:
+- **CI gates every PR** on the fast checks and both e2e lanes — passing locally first is a
+  time-saver, not the enforcement. `npm run verify`, then:
 
   ```
   bash demo/run-mock-e2e.sh                       # API suite
@@ -93,9 +98,9 @@ worse without saying so**, and chip at the key one whenever a change touches key
   Run against a FRESHLY PURGED rig. `run-mock-e2e.sh` purges; recreating containers by hand does
   not, and stale bot keys in `state.db` produce `Invalid API key` failures that look like product
   bugs and are not.
-- **Enable the hook once per clone:** `git config core.hooksPath .githooks`. It runs the fast
-  gate on commit. The e2e suite is deliberately NOT in the hook — a seven-minute hook is a hook
-  people bypass.
+- **The pre-commit hook runs the fast gate** (`verify:fast`) and is enabled by `npm install`
+  (the `prepare` script sets `core.hooksPath`). The e2e suite is deliberately NOT in the hook —
+  a seven-minute hook is a hook people bypass.
 - **Formatting is Prettier's, correctness is ESLint's.** They do not overlap: `eslint.config.mjs`
   contains zero formatting rules, and that is a property to preserve. Never add
   `tseslint.configs.stylistic`/`recommended` or a whitespace rule there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ it as Immich's problem. Concretely, and these are design rules not sentiments:
 - **Anything shared can be fully withdrawn, and withdrawal reclaims the space.** `leaveAlbum`
   purges every stub a join created; unlinking deletes a peer's people *and their proxied photos*,
   because holding someone's content after they have gone is exactly the thing this opposes.
-- **Every sharing ACTION happens in Immich's own UI** (see the product rule below). The addon adds
+- **Every sharing ACTION happens in Immich's own UI.** The addon adds
   no second way to share, so nobody has to learn our surface to use their own photos.
 - **Minimise the footprint in someone else's instance.** Every user, album, and permission this
   addon creates is a liability the operator did not ask for.
@@ -153,89 +153,51 @@ Corollary: a fact only counts as known if something *proved* it. `Contributor.ho
 only by a linked server's directory, never by an incoming photo — a relayed ref names the person
 but not their server, and guessing would route someone's album to the wrong household.
 
-## Every source file opens with one line: what it is, and where its doc is
+## A name that needs a comment is the wrong name
 
-A single line, first line, no exceptions:
+The default, and it comes before every other rule about comments: **if you have to explain a name,
+the name is not descriptive enough. Rename it.** The comment is a symptom; fix the cause. This is
+not style policing — **bad names hide bugs.** A cleanup returned from inside a `.then()` rather than
+from the effect itself is dead code, because Preact honours only what the effect returns; in a body
+of `tick`/`u`/`iv`/`stop` that is invisible, and in one named for what it holds it is obvious.
 
-```ts
-/** sync/invites.ts — sharing an album by inviting a PERSON in Immich's own picker. See sync-loops.md. */
-/** sync/leave.ts — undoing a join. See sync-loops.md. */
-```
+Applies to everything you get to name — functions, variables, constants, parameters, type fields,
+files, routes, env vars, test titles, doc headings. Nothing is exempt for being small or local, test
+code included: an assertion whose message does not say what broke costs a debugging cycle every time
+it fires.
 
-Format: `path — brief description. See <doc>.md.`
+**The test:** would a reader who has never seen the code guess right from the name alone?
 
-The one comment naming cannot replace, because it answers a question the code cannot: **where is
-the context for this file?**
+| Name, with the comment it needs | Should be |
+| --- | --- |
+| `POLL` — *"how often to re-check whether they have signed in"* | `SIGN_IN_POLL_MS` |
+| `peer` — *"the server this person actually lives on"* | `homePeer` |
+| `(cacheMaxMb * 1024 * 1024) / 10` — *"no single item past 10% of cap"* | a named divisor |
+| `WATCH_RUNNING` — *"overlapping cycles stampede the host"* | `watchCycleInFlight` |
+| `mayAdd` — *"missing members are revoked, do not re-add"* | `reAddIfMissing` |
 
-- A doc may sit beside the file (a `config.md` next to `config.ts`, once one earns it) or cover the
-  folder under a different name (`p2p/protocol.ts` → `wire-protocol.md`). Without the pointer you
-  would guess or grep.
-- It is machine-followable, which matters because agents work here: open the file, read one line,
-  load exactly the right doc before changing anything.
+`mayAdd` is the instructive one: already renamed once, and still needing a comment because it says
+*permission* where the meaning is "if they are missing, put them back". Needing a comment after one
+rename means go again, not settle.
 
-Two rules keep it honest:
+How to choose the name:
 
-- **Keep the pointer accurate.** A header pointing at a doc that no longer exists, or at the wrong
-  one, is worse than none — it sends the next reader somewhere useless. Renaming or moving a doc
-  means updating every header that references it.
-- **Do not let it grow.** It is a pointer, not a summary. If you find yourself adding a second
-  sentence, that sentence belongs in the doc.
+- **Name a variable for what it holds**, not its type or position. `signedInUser`, not `u`.
+  `pollTimer`, not `iv`. `outcome`, not `d`. `minutesLeft`, not `minutes`.
+- **Name a function for what it does to the world**, and make the verb match: `acceptInvite`,
+  `startPollingUntilSignedIn`, `copyToClipboard` — not `accept`, `tick`, `copy`.
+- **Single letters only in a genuinely anonymous one-line scope** — `xs.map(x => x.id)`. Never for
+  anything living more than a couple of lines, and never for a caught error you go on to inspect.
+- **Magic numbers get a named constant with a unit**: `SIGN_IN_POLL_MS`, `SYNC_WAIT_LIMIT_MS`. A
+  bare `2500` tells the reader nothing about whether it is safe to change.
+- **Extract the condition rather than commenting it.** `const waitedTooLong = Date.now() - since >
+  LIMIT_MS` beats the inequality inline, and puts the reasoning in the name.
+- **Reach for a longer name before reaching for a comment.** A name is read every time it is used;
+  a comment is read once, if at all, and then rots.
 
-## Boy-scout rule: any file you touch comes up to standard
-
-**A file you edit for any reason leaves your change compliant.** The conventions below are applied
-per-change, not by sweeping the tree, so the codebase converges as work moves through it.
-
-Six checks, all of them seconds:
-
-| Check | Standard | Where it is written |
-| --- | --- | --- |
-| Header | line 1 is `path — description. See doc.md.`, and a whole sentence | *Every source file opens with one line* |
-| Comments | the header, load-bearing lines and TODOs — nothing else | *Comments: a paired doc is the default* |
-| Names | **rename rather than explain** — any name you must explain is not descriptive enough | *A name that needs a comment* |
-| Doc placement | one exists at the right level for what you touched | *Where a doc lives* |
-| Doc truth | you re-read it against the code you just changed | *Keep the docs in sync* |
-| Doc style | dense bullets, every claim naming a real symbol | *Keep the docs in sync* |
-
-Two things this rule is deliberately **not**:
-
-- **Not a licence to batch-migrate.** Do not sweep files you are not otherwise changing. The
-  verification is the expensive half, and it is only cheap while you have the code in your head.
-- **Not a blocker on unrelated work.** If a file you touched is far off standard and fixing it
-  would swamp the actual change, bring the part you touched up to standard and say what you left.
-
-**Removing a comment is a move, never a delete.** Its content goes to one of two places, and
-choosing is the whole job:
-
-- **Into the name**, when it explained *what* something is. Renaming a parameter, extracting a
-  named constant and splitting a condition into a named boolean are all in scope of the change that
-  deleted the comment. Three waiting in this tree, as worked examples:
-
-  | Today | Its comment says | Should be |
-  |---|---|---|
-  | `mayAdd` | missing members are revoked, do not re-add | `reAddIfMissing` |
-  | `WATCH_RUNNING` | overlapping cycles stampede the host | `watchCycleInFlight` |
-  | `(cacheMaxMb * 1024 * 1024) / 10` | no single item past 10% of the cap | a named divisor |
-- **Into the doc**, when it explained *why* — design reasoning, an Immich quirk, history.
-
-If neither fits and the line is a hazard at its trigger point, it stays inline as one line.
-
-All six are judgement calls, which is why they are written down rather than left implied.
-
-## Where a doc lives: as close to the code as it needs to be, and no closer
-
-Granular on purpose. Pick the nearest level that earns one:
-
-- **File-level** — one module carrying dense reasoning of its own, e.g. a `store.md` next to
-  `store.ts`. None exist yet; create one the first time a module earns it.
-- **Folder-level** (`wire-protocol.md`, `sync-loops.md`) — a concern spanning several files, where
-  the useful explanation is how they fit together.
-- **Neither** — most files. A module whose names already say what it does needs no doc; it still
-  carries a header pointing at whichever doc covers it.
-- **Both** is fine. A file-level doc for the hard module, a folder doc for the concern around it.
-
-A concern starts as one file at `src/` root, and graduates to a folder with its own doc when it
-needs several files. `src/ARCHITECTURE.md` describes the whole tree.
+If you are writing "this does X", the name should have said X. If you are writing "this is needed
+because…", that is doc material. What may stay inline regardless is only what a name cannot carry —
+the categories in *What survives, concretely* below.
 
 ## Comments: a paired doc is the default, inline is the exception
 
@@ -294,50 +256,82 @@ Two traps when doing this work. **Judge each comment; never keyword-match it** �
 **a mechanical strip truncates**: it leaves fragments that end mid-clause but still read like
 instructions. Re-read every comment you touch, in full.
 
-## A name that needs a comment is the wrong name
+## Where a doc lives: as close to the code as it needs to be, and no closer
 
-The default, and it comes before every other rule about comments: **if you have to explain a name,
-the name is not descriptive enough. Rename it.** The comment is a symptom; fix the cause. This is
-not style policing — **bad names hide bugs.** A cleanup returned from inside a `.then()` rather than
-from the effect itself is dead code, because Preact honours only what the effect returns; in a body
-of `tick`/`u`/`iv`/`stop` that is invisible, and in one named for what it holds it is obvious.
+Granular on purpose. Pick the nearest level that earns one:
 
-Applies to everything you get to name — functions, variables, constants, parameters, type fields,
-files, routes, env vars, test titles, doc headings. Nothing is exempt for being small or local, test
-code included: an assertion whose message does not say what broke costs a debugging cycle every time
-it fires.
+- **File-level** — one module carrying dense reasoning of its own, e.g. a `store.md` next to
+  `store.ts`. None exist yet; create one the first time a module earns it.
+- **Folder-level** (`wire-protocol.md`, `sync-loops.md`) — a concern spanning several files, where
+  the useful explanation is how they fit together.
+- **Neither** — most files. A module whose names already say what it does needs no doc; it still
+  carries a header pointing at whichever doc covers it.
+- **Both** is fine. A file-level doc for the hard module, a folder doc for the concern around it.
 
-**The test:** would a reader who has never seen the code guess right from the name alone?
+A concern starts as one file at `src/` root, and graduates to a folder with its own doc when it
+needs several files. `src/ARCHITECTURE.md` describes the whole tree.
 
-| Name, with the comment it needs | Should be |
-| --- | --- |
-| `POLL` — *"how often to re-check whether they have signed in"* | `SIGN_IN_POLL_MS` |
-| `peer` — *"the server this person actually lives on"* | `homePeer` |
-| `(cacheMaxMb * 1024 * 1024) / 10` — *"no single item past 10% of cap"* | a named divisor |
-| `mayAdd` — *"missing members are revoked, do not re-add"* | `reAddIfMissing` |
+## Every source file opens with one line: what it is, and where its doc is
 
-`mayAdd` is the instructive one: already renamed once, and still needing a comment because it says
-*permission* where the meaning is "if they are missing, put them back". Needing a comment after one
-rename means go again, not settle.
+A single line, first line, no exceptions:
 
-How to choose the name:
+```ts
+/** sync/invites.ts — sharing an album by inviting a PERSON in Immich's own picker. See sync-loops.md. */
+/** sync/leave.ts — undoing a join. See sync-loops.md. */
+```
 
-- **Name a variable for what it holds**, not its type or position. `signedInUser`, not `u`.
-  `pollTimer`, not `iv`. `outcome`, not `d`. `minutesLeft`, not `minutes`.
-- **Name a function for what it does to the world**, and make the verb match: `acceptInvite`,
-  `startPollingUntilSignedIn`, `copyToClipboard` — not `accept`, `tick`, `copy`.
-- **Single letters only in a genuinely anonymous one-line scope** — `xs.map(x => x.id)`. Never for
-  anything living more than a couple of lines, and never for a caught error you go on to inspect.
-- **Magic numbers get a named constant with a unit**: `SIGN_IN_POLL_MS`, `SYNC_WAIT_LIMIT_MS`. A
-  bare `2500` tells the reader nothing about whether it is safe to change.
-- **Extract the condition rather than commenting it.** `const waitedTooLong = Date.now() - since >
-  LIMIT_MS` beats the inequality inline, and puts the reasoning in the name.
-- **Reach for a longer name before reaching for a comment.** A name is read every time it is used;
-  a comment is read once, if at all, and then rots.
+Format: `path — brief description. See <doc>.md.`
 
-If you are writing "this does X", the name should have said X. If you are writing "this is needed
-because…", that is doc material. What may stay inline regardless is only what a name cannot carry —
-the categories in *What survives, concretely* above.
+The one comment naming cannot replace, because it answers a question the code cannot: **where is
+the context for this file?**
+
+- A doc may sit beside the file (a `config.md` next to `config.ts`, once one earns it) or cover the
+  folder under a different name (`p2p/protocol.ts` → `wire-protocol.md`). Without the pointer you
+  would guess or grep.
+- It is machine-followable, which matters because agents work here: open the file, read one line,
+  load exactly the right doc before changing anything.
+
+Two rules keep it honest:
+
+- **Keep the pointer accurate.** A header pointing at a doc that no longer exists, or at the wrong
+  one, is worse than none — it sends the next reader somewhere useless. Renaming or moving a doc
+  means updating every header that references it.
+- **Do not let it grow.** It is a pointer, not a summary. If you find yourself adding a second
+  sentence, that sentence belongs in the doc.
+
+## Boy-scout rule: any file you touch comes up to standard
+
+**A file you edit for any reason leaves your change compliant.** The conventions above are applied
+per-change, not by sweeping the tree, so the codebase converges as work moves through it. This
+checklist is the recap:
+
+| Check | Standard | Where it is written |
+| --- | --- | --- |
+| Header | line 1 is `path — description. See doc.md.`, and a whole sentence | *Every source file opens with one line* |
+| Comments | the header, load-bearing lines and TODOs — nothing else | *Comments: a paired doc is the default* |
+| Names | **rename rather than explain** — any name you must explain is not descriptive enough | *A name that needs a comment* |
+| Doc placement | one exists at the right level for what you touched | *Where a doc lives* |
+| Doc truth | you re-read it against the code you just changed | *Keep the docs in sync* |
+| Doc style | dense bullets, every claim naming a real symbol | *Keep the docs in sync* |
+
+Two things this rule is deliberately **not**:
+
+- **Not a licence to batch-migrate.** Do not sweep files you are not otherwise changing. The
+  verification is the expensive half, and it is only cheap while you have the code in your head.
+- **Not a blocker on unrelated work.** If a file you touched is far off standard and fixing it
+  would swamp the actual change, bring the part you touched up to standard and say what you left.
+
+**Removing a comment is a move, never a delete.** Its content goes to one of two places, and
+choosing is the whole job:
+
+- **Into the name**, when it explained *what* something is. Renaming a parameter, extracting a
+  named constant and splitting a condition into a named boolean are all in scope of the change that
+  deleted the comment — worked examples are the table in *A name that needs a comment* above.
+- **Into the doc**, when it explained *why* — design reasoning, an Immich quirk, history.
+
+If neither fits and the line is a hazard at its trigger point, it stays inline as one line.
+
+All six are judgement calls, which is why they are written down rather than left implied.
 
 ## Invariants that will bite you
 
@@ -368,4 +362,4 @@ Enforced by lint or tests wherever that is possible.
 
 Code is grouped by concern under `src/` (a `config`/`state`/`peers` core, then `immich/`,
 `p2p/`, `sync/`, `media/`, `web/`). See [src/ARCHITECTURE.md](./src/ARCHITECTURE.md) for the
-module map, the data flow, and the doc conventions.
+module map and the data flow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,12 @@ saying so:
   - **State what the code does, not what it should do.** Re-read the doc against the
     implementation before you land it. A doc written from a plan describes the design you may
     have since rejected, and reads as authoritative while doing it.
+  - **No narrative.** A doc states the design as it is. It is not a changelog, a diary or a
+    post-mortem: no "used to", no "we found", no retelling the bug that motivated a rule, no
+    before/after counts. Git history already records how the code got here, and prose about the
+    past is the first thing to become false — the sentence stays true of a version nobody runs.
+    A one-clause reason is fine where it makes a rule followable; a retold incident is not.
+    Applies to this file as much as to any other.
   - **Boy-scout, never batch** — see the section below. Verify a doc when you touch the code it
     describes; do not mass-rewrite docs you are not otherwise changing.
 - **Never test against a real server.** Use the throwaway mock rig in `demo/`. Never run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,13 +124,13 @@ Two lanes, and the right one depends on whether Immich is involved.
 
 ## Store the fact, don't infer it — but only if the fact is safe to hold
 
-**Prefer a column in `state.db` over a rule in someone's head.** Nearly every sync bug here came
-from deducing what the code could have recorded — each inference correct when written, wrong later:
+**Prefer a column in `state.db` over a rule in someone's head.** An inference is correct when
+written and wrong later. Three shapes to avoid:
 
-- two accounts per person, so "who added this membership" could be inferred from which one it was
-- a boolean saying "we know where this person lives" instead of storing *where*
-- a mapping pointing at an account by a name-derived slug instead of its id — it stopped resolving
-  the moment the account was keyed differently
+- deriving "who added this membership" from *which account* it is, instead of recording it
+- a boolean saying "we know where this person lives" instead of storing **where**
+- pointing at an account by a name-derived slug instead of its id — it stops resolving the moment
+  the account is keyed differently
 
 Two constraints, because a stored fact is also a stored liability:
 
@@ -335,10 +335,10 @@ find yourself writing "this does X", the name should have said X.
 
 ## Name things so the next reader does not have to decode them
 
-Not style policing — **bad names hide bugs.** A `useEffect` named `tick`/`u`/`iv`/`stop` concealed
-a `return () => clearInterval(iv)` inside a `.then()`: dead code, because Preact honours only the
-value the effect itself returns, so the poll outlived the page. Named for what they held, the
-missing cleanup was obvious on sight.
+Not style policing — **bad names hide bugs.** Terse names conceal control-flow errors. A cleanup
+returned from inside a `.then()` rather than from the effect itself is dead code — Preact honours
+only what the effect returns — and in a body of `tick`/`u`/`iv`/`stop` that is invisible. Named for
+what they hold, it is obvious on sight.
 
 - **Name a variable for what it holds, not its type or its position.** `signedInUser`, not `u`.
   `pollTimer`, not `iv`. `outcome`, not `d`. `minutesLeft`, not `minutes`.
@@ -360,7 +360,7 @@ debugging cycle every time it fires.
 
 ## Invariants that will bite you
 
-These are enforced by lint or tests where possible, because each one has already caused a bug.
+Enforced by lint or tests wherever that is possible.
 
 - **Bot namespaces stay disjoint** — no `BOT_PREFIX` may prefix another (`invariants.test.ts`
   asserts it).
@@ -376,8 +376,7 @@ These are enforced by lint or tests where possible, because each one has already
 - **Never reassign shared state arrays.** `state.mappings = state.mappings.filter(...)` discards
   whatever a concurrent loop pushed onto the old reference. Splice in place. (ESLint enforces it.)
 - **Never inline a single-source-of-truth constant** — the bot email domain, `PROTOCOL_VERSION`.
-  The last naming bug was one predicate inlined in eleven places that drifted apart. (ESLint
-  enforces both.)
+  An inlined predicate drifts the moment one copy changes. (ESLint enforces both.)
 - **Owner and member mappings are not interchangeable.** Origin-side logic must filter
   `role === 'owner'`; a member's mirror always looks "withdrawn" to origin-side checks, and
   retiring it kills a live album one poll after it was created.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,10 @@ it as Immich's problem. Concretely, and these are design rules not sentiments:
 - **Minimise the footprint in someone else's instance.** Every user, album, and permission this
   addon creates is a liability the operator did not ask for.
 
-**Where this falls short today** — known costs, not oversights. Do not make either worse without
-saying so:
-
-- **An all-permissions admin API key**, so the blast radius is the whole instance. The sharpest
-  contradiction of this ethos in the codebase; worth chipping at whenever a change touches keys.
-- **Real user accounts in your Immich**, one per remote person, appearing in every picker — Immich
-  has no service-account flag.
+Two known costs contradict this today — an all-permissions admin key, and one real Immich account
+per remote person. They are listed in
+[src/ARCHITECTURE.md](./src/ARCHITECTURE.md) "Where this falls short today". **Do not make either
+worse without saying so**, and chip at the key one whenever a change touches key handling.
 
 ## Golden rules
 
@@ -39,20 +36,16 @@ saying so:
   services, database, or upload folders. Everything must fail open — Immich has to work
   perfectly with the sidecar dead. (Design invariants: [src/ARCHITECTURE.md](./src/ARCHITECTURE.md)
   "Iron rules".)
-- **Keep the docs in sync — and this rule is load-bearing, not housekeeping.** `src/` carries
-  Markdown docs at whatever level earns one: a folder doc where modules are small and cohesive, a
-  file-level doc next to anything with dense reasoning of its own, and neither where a file needs
-  no explaining. `src/ARCHITECTURE.md` describes the whole.
+- **Keep the docs in sync — and this rule is load-bearing, not housekeeping.** Any behaviour change
+  updates the relevant doc(s) **in the same change**. A doc that lies is worse than no doc: treat
+  drift as a bug and fix it with the code that caused it. Which doc, and at what level, is *Where a
+  doc lives* below.
 
-  Any behaviour change updates the relevant doc(s) **in the same change**. A doc that lies is
-  worse than no doc: treat drift as a bug and fix it with the code that caused it.
+  This is load-bearing because explanation deliberately lives in those docs rather than in
+  comments. The further an explanation sits from what it explains, the more strictly the rule
+  applies: moving prose out of a file and then letting it rot is worse than leaving it inline.
 
-  Explanation lives in these docs, not in comments: naming carries the *what*, docs carry the
-  *why*. That only holds while they track the code, so the further an explanation sits from what it
-  explains, the more strictly this rule applies. Moving prose out of a file and letting it rot is
-  worse than leaving it inline.
-
-  Four rules for writing them:
+  Five rules for writing them:
 
   - **Dense over flowing.** Bullets, tables and short declaratives — not paragraphs of prose. A
     doc is reference material read under time pressure, usually to answer one question. Maximise
@@ -121,6 +114,8 @@ Two lanes, and the right one depends on whether Immich is involved.
   - `GET /albums` is scoped **per user** — the admin key sees only the admin's own albums.
   - Adding a user who is already the owner returns **200**, silently ignored.
   - Album responses carry **no `ownerId`** — the owner is inside `albumUsers`.
+
+Either lane:
 
 - **Assert invariants, not strings.** "No two users share a display name" survives every future
   rename. A test pinning one literal name gets edited whenever behaviour changes — and a test
@@ -254,13 +249,13 @@ needs several files. `src/ARCHITECTURE.md` describes the whole tree.
 else.** If a file you are working in carries more than a couple of comments, the explanation
 belongs in its doc and the rest belongs in better names.
 
-Explanation belongs in a Markdown doc beside the code, not in the code. Naming carries the *what*;
-the doc carries the *why*. Code that reads cleanly and a doc that explains fully beats a file where
-both are tangled — and a doc can hold far more context than anyone would tolerate inline.
+Naming carries the *what*; the doc carries the *why*. Code that reads cleanly plus a doc that
+explains fully beats a file where both are tangled — and a doc holds far more context than anyone
+would tolerate inline.
 
 **The test for keeping a comment inline: would moving it to the doc stop it doing its job?**
 
-Almost always the answer is no, so it moves. Two cases where it is yes, and they are the only ones:
+Almost always the answer is no, so it moves. Three cases where it is yes:
 
 - **A hazard at the trigger line.** `record BEFORE the add`, `splice, never reassign`,
   `ORDER IS LOAD-BEARING`. The person editing that exact statement must see the warning without
@@ -271,8 +266,8 @@ Almost always the answer is no, so it moves. Two cases where it is yes, and they
   it is looking at the assertion, so it cannot live anywhere else.
 
 - **A one-line JSDoc on an exported type field or function.** Editors surface it on hover at every
-  use site, which no doc can do. `/** Mutable hint — where to reach them right now. */` on
-  `Household.url` earns its place; a paragraph above the type does not.
+  use site, which no doc can do. `/** Mutable hint — where to reach the sidecar right now. */`
+  on `Household.url` earns its place; a paragraph above the type does not.
 
 Everything else goes: background, design reasoning, Immich quirks, "why this shape", history. The
 reader who needs those is trying to understand the module and will be reading its doc. Inline, they
@@ -307,62 +302,48 @@ instructions. Re-read every comment you touch, in full.
 
 ## A name that needs a comment is the wrong name
 
-This is the default, and it comes before every other rule about comments: **if you have to explain
-a name, the name is not descriptive enough. Rename it.** The comment is a symptom; fix the cause.
+The default, and it comes before every other rule about comments: **if you have to explain a name,
+the name is not descriptive enough. Rename it.** The comment is a symptom; fix the cause. This is
+not style policing — **bad names hide bugs.** A cleanup returned from inside a `.then()` rather than
+from the effect itself is dead code, because Preact honours only what the effect returns; in a body
+of `tick`/`u`/`iv`/`stop` that is invisible, and in one named for what it holds it is obvious.
 
-It applies to everything you get to name — functions, variables, constants, parameters, type
-fields, files, routes, env vars, test titles, doc headings. Nothing is exempt for being small or
-local.
+Applies to everything you get to name — functions, variables, constants, parameters, type fields,
+files, routes, env vars, test titles, doc headings. Nothing is exempt for being small or local, test
+code included: an assertion whose message does not say what broke costs a debugging cycle every time
+it fires.
 
-The test is whether a reader who has never seen the code guesses right from the name alone:
+**The test:** would a reader who has never seen the code guess right from the name alone?
 
-- `/** How often to re-check whether they have signed in. */` above `POLL` → `SIGN_IN_POLL_MS`.
-- `/** The server this person actually lives on. */` above `peer` → `homePeer`.
-- `(CFG.cacheMaxMb * 1024 * 1024) / 10` with `// no single item >10% of cap` →
-  `/ MAX_ITEM_SHARE_OF_CACHE`.
-- `mayAdd`, with a comment about revoked members — **still wrong**, which is the point: it says
-  permission where the real meaning is "if they are missing, put them back". Renamed to
-  `reAddIfMissing`, and its two comments went with it. Getting one rename in and still needing the
-  comment means go again, not settle.
+| Name, with the comment it needs | Should be |
+| --- | --- |
+| `POLL` — *"how often to re-check whether they have signed in"* | `SIGN_IN_POLL_MS` |
+| `peer` — *"the server this person actually lives on"* | `homePeer` |
+| `(cacheMaxMb * 1024 * 1024) / 10` — *"no single item past 10% of cap"* | a named divisor |
+| `mayAdd` — *"missing members are revoked, do not re-add"* | `reAddIfMissing` |
 
-Reach for a longer name before reaching for a comment. `startPollingUntilSignedIn` needs no
-explanation; `tick` needs a paragraph. A name is read every time it is used; a comment is read
-once, if at all, and then rots.
+`mayAdd` is the instructive one: already renamed once, and still needing a comment because it says
+*permission* where the meaning is "if they are missing, put them back". Needing a comment after one
+rename means go again, not settle.
 
-What survives this rule is only what a name **cannot** carry:
+How to choose the name:
 
-- a hazard about ORDER or CONCURRENCY at the exact line it applies to
-- a reference to an external behaviour that is not in this codebase — an Immich quirk, a browser
-  constraint — and even then prefer the paired doc unless the reader of that line needs it
-- a `TODO` with enough context to act on
-
-If you find yourself writing "this is needed because…", that is doc material, not a comment. If you
-find yourself writing "this does X", the name should have said X.
-
-## Name things so the next reader does not have to decode them
-
-Not style policing — **bad names hide bugs.** Terse names conceal control-flow errors. A cleanup
-returned from inside a `.then()` rather than from the effect itself is dead code — Preact honours
-only what the effect returns — and in a body of `tick`/`u`/`iv`/`stop` that is invisible. Named for
-what they hold, it is obvious on sight.
-
-- **Name a variable for what it holds, not its type or its position.** `signedInUser`, not `u`.
+- **Name a variable for what it holds**, not its type or position. `signedInUser`, not `u`.
   `pollTimer`, not `iv`. `outcome`, not `d`. `minutesLeft`, not `minutes`.
 - **Name a function for what it does to the world**, and make the verb match: `acceptInvite`,
   `startPollingUntilSignedIn`, `copyToClipboard` — not `accept`, `tick`, `copy`.
-- **Single letters only for a genuinely anonymous, one-line scope** — `xs.map(x => x.id)`. Never
-  for anything that lives more than a couple of lines, and never for a caught error you go on to
-  inspect.
-- **Magic numbers get a named constant with a unit**: `SIGN_IN_POLL_MS`, `SYNC_WAIT_LIMIT_MS`.
-  `2500` in the middle of an effect tells the reader nothing about whether it is safe to change.
+- **Single letters only in a genuinely anonymous one-line scope** — `xs.map(x => x.id)`. Never for
+  anything living more than a couple of lines, and never for a caught error you go on to inspect.
+- **Magic numbers get a named constant with a unit**: `SIGN_IN_POLL_MS`, `SYNC_WAIT_LIMIT_MS`. A
+  bare `2500` tells the reader nothing about whether it is safe to change.
 - **Extract the condition rather than commenting it.** `const waitedTooLong = Date.now() - since >
-  LIMIT_MS` reads better than the inequality inline, and it puts the reasoning in the name.
-- **Comments say WHY, names say WHAT.** If a comment is needed to explain what a line does, the
-  names are wrong. Reserve comments for the reason: which Immich quirk forced this, which failure
-  it protects against, which direction it fails in.
+  LIMIT_MS` beats the inequality inline, and puts the reasoning in the name.
+- **Reach for a longer name before reaching for a comment.** A name is read every time it is used;
+  a comment is read once, if at all, and then rots.
 
-This applies to test code too. An assertion whose message does not say what broke costs a
-debugging cycle every time it fires.
+If you are writing "this does X", the name should have said X. If you are writing "this is needed
+because…", that is doc material. What may stay inline regardless is only what a name cannot carry —
+the categories in *What survives, concretely* above.
 
 ## Invariants that will bite you
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,26 +81,15 @@ worse without saying so**, and chip at the key one whenever a change touches key
   Branch protection enforces it; merges are squash-only.
 - **Conventional commits** decide the version automatically via release-please
   (`fix:` → patch, `feat:` → minor, `feat!:` → major). Don't hand-edit version numbers.
-- **CI gates every PR** on the fast checks and both e2e lanes — passing locally first is a
-  time-saver, not the enforcement. `npm run verify`, then:
-
-  ```
-  bash demo/run-mock-e2e.sh                       # API suite
-  cd demo/e2e && CKEY=<origin key> \
-    HOST_RESOLVER_RULES="MAP host.docker.internal 127.0.0.1" node browser-test.mjs
-  ```
-
-  **Run the browser lane whenever you touch a page.** It is the only coverage of the banner and
-  accept flows — nothing in the API suite loads a page in a browser, so a page can break with that
-  suite fully green. The resolver rule exists so this runs on a dev machine without editing
-  /etc/hosts.
-
-  Run against a FRESHLY PURGED rig. `run-mock-e2e.sh` purges; recreating containers by hand does
-  not, and stale bot keys in `state.db` produce `Invalid API key` failures that look like product
-  bugs and are not.
-- **The pre-commit hook runs the fast gate** (`verify:fast`) and is enabled by `npm install`
-  (the `prepare` script sets `core.hooksPath`). The e2e suite is deliberately NOT in the hook —
-  a seven-minute hook is a hook people bypass.
+- **CI runs the fast checks and both e2e lanes on every PR**; the pre-commit hook (enabled by
+  `npm install`) runs `verify:fast` on every commit. To get the same result locally before pushing:
+  `npm run verify`, `bash demo/run-mock-e2e.sh` (API lane, purges its rig first), and
+  `demo/e2e/browser-test.mjs` (browser lane — the only coverage that loads a page).
+  The e2e suite is deliberately NOT in the hook: a seven-minute hook is a hook people bypass.
+- **Two traps code cannot catch for you:** a rig recreated by hand instead of via
+  `run-mock-e2e.sh` keeps stale bot keys in `state.db`, and the resulting `Invalid API key`
+  failures look like product bugs; and a browser-lane run on a dev machine needs
+  `HOST_RESOLVER_RULES="MAP host.docker.internal 127.0.0.1"` rather than an /etc/hosts edit.
 - **Formatting is Prettier's, correctness is ESLint's.** They do not overlap: `eslint.config.mjs`
   contains zero formatting rules, and that is a property to preserve. Never add
   `tseslint.configs.stylistic`/`recommended` or a whitespace rule there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,19 +24,21 @@ it as Immich's problem. Concretely, and these are design rules not sentiments:
 - **Minimise the footprint in someone else's instance.** Every user, album, and permission this
   addon creates is a liability the operator did not ask for.
 
-**Where we currently fall short, honestly:** the sidecar still needs an all-permissions admin API
-key, so its blast radius is the whole instance — the sharpest contradiction of this ethos in the
-codebase, and worth chipping at whenever a change touches key handling. It also creates real user
-accounts in your Immich (one per remote person) that show up in every picker, because Immich has
-no service-account flag. Both are known costs, not oversights; do not make either worse without
-saying so.
+**Where this falls short today** — known costs, not oversights. Do not make either worse without
+saying so:
+
+- **An all-permissions admin API key**, so the blast radius is the whole instance. The sharpest
+  contradiction of this ethos in the codebase; worth chipping at whenever a change touches keys.
+- **Real user accounts in your Immich**, one per remote person, appearing in every picker — Immich
+  has no service-account flag.
 
 ## Golden rules
 
 - **Never touch Immich itself.** This is a sidecar: it only ever adds its own container
   and talks to Immich over the public API. Never modify Immich's source, compose
   services, database, or upload folders. Everything must fail open — Immich has to work
-  perfectly with the sidecar dead. (Design invariants: [src/ARCHITECTURE.md](./src/ARCHITECTURE.md) "Iron rules".)
+  perfectly with the sidecar dead. (Design invariants: [src/ARCHITECTURE.md](./src/ARCHITECTURE.md)
+  "Iron rules".)
 - **Keep the docs in sync — and this rule is load-bearing, not housekeeping.** `src/` carries
   Markdown docs at whatever level earns one: a folder doc where modules are small and cohesive, a
   file-level doc next to anything with dense reasoning of its own, and neither where a file needs
@@ -45,10 +47,10 @@ saying so.
   Any behaviour change updates the relevant doc(s) **in the same change**. A doc that lies is
   worse than no doc: treat drift as a bug and fix it with the code that caused it.
 
-  Explanation lives in these docs rather than in comments — naming carries the *what*, docs carry the *why* (see the naming section below). That
-  only works while they track the code, so the further an explanation sits from what it explains,
-  the more strictly this rule applies. Moving prose out of a source file and then letting it rot
-  is worse than having left it inline.
+  Explanation lives in these docs, not in comments: naming carries the *what*, docs carry the
+  *why*. That only holds while they track the code, so the further an explanation sits from what it
+  explains, the more strictly this rule applies. Moving prose out of a file and letting it rot is
+  worse than leaving it inline.
 
   Four rules for writing them:
 
@@ -71,7 +73,8 @@ saying so.
 
 ## How changes land
 
-- **Everything goes through a pull request**, gated on both e2e lanes and the fast gate below. Branch protection enforces it; merges are squash-only.
+- **Everything goes through a pull request**, gated on both e2e lanes and the fast gate below.
+  Branch protection enforces it; merges are squash-only.
 - **Conventional commits** decide the version automatically via release-please
   (`fix:` → patch, `feat:` → minor, `feat!:` → major). Don't hand-edit version numbers.
 - **Before pushing:** `npm run verify` clean (format, lint, types, runtime load, import cycles,
@@ -103,57 +106,53 @@ saying so.
 Two lanes, and the right one depends on whether Immich is involved.
 
 - **Pure logic → strict TDD.** Add the case to `src/*.test.ts`, watch it fail, then implement.
-  The loop is sub-second (`npm test`), so there is no excuse to skip it. Anything that can be a
-  pure function should be one, precisely so it can be tested this way — see `sync/invitees.ts`,
-  which was extracted from the one code path that removes a real person from a real album.
-- **Immich-facing behaviour → discover, then pin, then implement.** You cannot write a correct
-  test against an API whose behaviour you are guessing at, and guessing has caused real bugs
-  here: `GET /albums` is scoped per user, adding a user who is already the owner returns 200 and
-  is silently ignored, and album responses carry no `ownerId`. So probe the real thing on the
-  mock rig first, write the e2e assertion, then implement. The test still precedes the
-  implementation — it just follows the discovery.
+  Sub-second loop (`npm test`), so there is no excuse to skip it. Anything that can be a pure
+  function should be one, precisely so it can be tested this way — see `sync/invitees.ts`.
+- **Immich-facing behaviour → discover, then pin, then implement.** Probe the real thing on the
+  mock rig, write the e2e assertion, then implement. The test still precedes the implementation; it
+  just follows the discovery. You cannot write a correct test against an API you are guessing at,
+  and these three all caused real bugs here:
+  - `GET /albums` is scoped **per user** — the admin key sees only the admin's own albums.
+  - Adding a user who is already the owner returns **200**, silently ignored.
+  - Album responses carry **no `ownerId`** — the owner is inside `albumUsers`.
 
-**Assert invariants, not strings.** "No two users share a display name" survives every future
-rename; a test pinning one literal name has to be edited whenever behaviour changes, and a test
-edited to match new behaviour has stopped being a test. **Print real state on failure** — a
-message showing what was actually found saves a whole debugging cycle, and the e2e suite's
-`check(name, ok, detail)` takes that detail for exactly this reason.
+- **Assert invariants, not strings.** "No two users share a display name" survives every future
+  rename. A test pinning one literal name gets edited whenever behaviour changes — and a test
+  edited to match new behaviour has stopped being a test.
+- **Print real state on failure.** Showing what was actually found saves a debugging cycle; the e2e
+  `check(name, ok, detail)` takes that detail for exactly this reason.
 
 ## Store the fact, don't infer it — but only if the fact is safe to hold
 
-Nearly every sync bug in this project came from *deducing* something the code could have
-recorded. Two accounts existed for one person so that "who added this album membership" could be
-inferred from which account it was; a boolean said "we know where this person lives" instead of
-storing *where*; a mapping pointed at an account by a name-derived slug instead of its id, and
-stopped resolving the moment the account was keyed differently. Each inference was correct when
-written and wrong later.
+**Prefer a column in `state.db` over a rule in someone's head.** Nearly every sync bug here came
+from deducing what the code could have recorded — each inference correct when written, wrong later:
 
-So prefer a column in `state.db` over a rule in someone's head. **With two constraints, because
-a stored fact is also a stored liability:**
+- two accounts per person, so "who added this membership" could be inferred from which one it was
+- a boolean saying "we know where this person lives" instead of storing *where*
+- a mapping pointing at an account by a name-derived slug instead of its id — it stopped resolving
+  the moment the account was keyed differently
+
+Two constraints, because a stored fact is also a stored liability:
 
 - **Only store what is safe to hold.** `state.db` holds this household's ed25519 private key and
   the bot accounts' API keys, so anything added inherits that blast radius. (The *admin* key is
   not in there — it comes from `IMMICH_API_KEY` in the environment.) Two rules follow, neither
   about compliance:
-  - The bot password is rolled to a value nobody keeps (`ensureLocalAccountFor`), because it existed
-    only to mint one API key and has no purpose afterwards. The concrete gain is small but real:
-    a bot key deliberately lacks `apiKey.create`, so it can do its 22 things and no more, whereas
-    a password logs in interactively and can mint an unrestricted key for that account. Keeping it
-    is pure downside rather than a tradeoff — the bots are non-admin and quota-capped, so this is
-    cheap hygiene, not a critical control. The e2e asserts it.
-  - The user directory sends **names, not emails** — not because storing an email is dangerous,
-    but because an Immich email is a *login identifier*. Sending it gives a linked household, or
-    whoever later compromises it, the first half of a credential for every user here. Names are
-    all a picker needs, so nothing is given up.
-
-  Both scale with exposure: on a single-user LAN-only box they buy little, and on a public domain
-  with several linked households they matter. Default to the cautious side when it is free, and
-  say which it is rather than implying everything is critical.
-- **Order the writes so a crash fails safe.** A stored fact that is missing must lead somewhere
-  harmless. `added` records a membership BEFORE creating it, so a crash in between makes the
-  sidecar *ignore* an invitation rather than treat its own membership as a human's and share an
-  album nobody offered. Work out which way each new record fails before writing it, and say so in
-  a comment.
+  - **No retained bot password.** Rolled to a value nobody keeps (`ensureLocalAccountFor`) once the
+    API key is minted. A bot key deliberately lacks `apiKey.create`, so it can do its listed
+    actions and no more; a password logs in interactively and can mint an unrestricted key for that
+    account. Pure downside rather than a tradeoff. The e2e asserts it.
+  - **The directory sends names, not emails.** Not because an email is dangerous to store, but
+    because an Immich email is a *login identifier* — sending it hands a linked household, or
+    whoever later compromises it, the first half of a credential for every user here. A picker
+    needs only names, so nothing is given up.
+  - Both scale with exposure: little on a single-user LAN box, more on a public domain with several
+    linked households. Default to caution when it is free, and say which it is rather than
+    implying everything is critical.
+- **Order the writes so a crash fails safe.** A missing stored fact must lead somewhere harmless.
+  `added` records a membership *before* creating it, so a crash in between makes the sidecar ignore
+  an invitation rather than read its own membership as a human's. Work out which way each new
+  record fails before writing it, and say so in a one-line comment.
 
 Corollary: a fact only counts as known if something *proved* it. `Contributor.homePeer` is set
 only by a linked server's directory, never by an incoming photo — a relayed ref names the person
@@ -170,14 +169,14 @@ A single line, first line, no exceptions:
 
 Format: `path — brief description. See <doc>.md.`
 
-This is the one comment whose job cannot be done by naming, because it answers a question the code
-cannot: **where is the context for this file?** Some files have a doc of their own beside them
-(a `config.md` beside `config.ts`, once one earns it); others are covered by a folder doc under a
-different name
-(`p2p/protocol.ts` → `wire-protocol.md`). Without the pointer you would have to guess or grep.
+The one comment naming cannot replace, because it answers a question the code cannot: **where is
+the context for this file?**
 
-It also makes the link machine-followable, which matters because agents work here: open the file,
-read one line, know exactly which doc to load for context before changing anything.
+- A doc may sit beside the file (a `config.md` next to `config.ts`, once one earns it) or cover the
+  folder under a different name (`p2p/protocol.ts` → `wire-protocol.md`). Without the pointer you
+  would guess or grep.
+- It is machine-followable, which matters because agents work here: open the file, read one line,
+  load exactly the right doc before changing anything.
 
 Two rules keep it honest:
 
@@ -213,14 +212,15 @@ Two things this rule is deliberately **not**:
 **Removing a comment is a move, never a delete.** Its content goes to one of two places, and
 choosing is the whole job:
 
-- **Into the name**, when it explained *what* something is. Three that are waiting in this tree,
-  as worked examples: `mayAdd` carries a comment about revoked members — it should be
-  `reAddIfMissing`, and the comment goes with the rename. `WATCH_RUNNING` carries one about
-  stampeding the host — it should be `watchCycleInFlight`. `(cacheMaxMb * 1024 * 1024) / 10`
-  carries one about the per-item cap — the divisor should be a named constant. Renaming a
-  parameter, extracting a named constant and splitting a condition into a named boolean are all in
-  scope of the change that deleted the comment; do not stop at deletion and leave the name as it
-  was.
+- **Into the name**, when it explained *what* something is. Renaming a parameter, extracting a
+  named constant and splitting a condition into a named boolean are all in scope of the change that
+  deleted the comment. Three waiting in this tree, as worked examples:
+
+  | Today | Its comment says | Should be |
+  |---|---|---|
+  | `mayAdd` | missing members are revoked, do not re-add | `reAddIfMissing` |
+  | `WATCH_RUNNING` | overlapping cycles stampede the host | `watchCycleInFlight` |
+  | `(cacheMaxMb * 1024 * 1024) / 10` | no single item past 10% of the cap | a named divisor |
 - **Into the doc**, when it explained *why* — design reasoning, an Immich quirk, history.
 
 If neither fits and the line is a hazard at its trigger point, it stays inline as one line.
@@ -335,11 +335,10 @@ find yourself writing "this does X", the name should have said X.
 
 ## Name things so the next reader does not have to decode them
 
-Not style policing — bad names hide bugs. A `useEffect` in the accept page used `tick`, `u`, `iv`
-and `stop`, and buried in that soup was a `return () => clearInterval(iv)` inside a `.then()`,
-which is dead code: Preact only honours the value the effect itself returns, so the poll kept
-running after the page navigated away. With the pieces named for what they hold, the missing
-cleanup was obvious on sight.
+Not style policing — **bad names hide bugs.** A `useEffect` named `tick`/`u`/`iv`/`stop` concealed
+a `return () => clearInterval(iv)` inside a `.then()`: dead code, because Preact honours only the
+value the effect itself returns, so the poll outlived the page. Named for what they held, the
+missing cleanup was obvious on sight.
 
 - **Name a variable for what it holds, not its type or its position.** `signedInUser`, not `u`.
   `pollTimer`, not `iv`. `outcome`, not `d`. `minutesLeft`, not `minutes`.
@@ -363,11 +362,17 @@ debugging cycle every time it fires.
 
 These are enforced by lint or tests where possible, because each one has already caused a bug.
 
-- **Bot users live in disjoint namespaces** (`BOT_PREFIX` in `config.ts`). Invitation detection
-  reads "this bot is an album member" as a human's intent to share, which is only sound for bots
-  the sidecar *never* adds itself. Attribution contributors are the opposite — the sidecar adds
-  those. One user once served both roles, and origin and member ping-ponged mirror/withdraw every
-  poll, each offering the other a mirror of the other's album.
+- **Bot namespaces stay disjoint** — no `BOT_PREFIX` may prefix another (`invariants.test.ts`
+  asserts it).
+- **Album membership is not intent.** One account per remote person does both jobs: it owns their
+  mirrored photos *and* is what a human picks to share with them, so the sidecar adds these
+  accounts to albums itself. Two records carry the distinction instead of the namespace:
+  - `added` (`store.addedRecord`) — memberships **we** created, so only a human's reads as an
+    invitation. Record before the add.
+  - `Contributor.homePeer` — set only by a linked server's directory, which is the one thing that
+    proves where a person lives. Without it an account is attribution-only.
+
+  Getting this wrong in the unsafe direction shares an album nobody offered.
 - **Never reassign shared state arrays.** `state.mappings = state.mappings.filter(...)` discards
   whatever a concurrent loop pushed onto the old reference. Splice in place. (ESLint enforces it.)
 - **Never inline a single-source-of-truth constant** — the bot email domain, `PROTOCOL_VERSION`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,9 @@ worse without saying so**, and chip at the key one whenever a change touches key
   the suite or experiments against anyone's production Immich, and never modify a real
   user's library.
 - **No secrets in the repo.** No API keys, passwords, tokens, or personal data in commits,
-  logs, or committed files. Ever.
+  logs, or committed files. Ever. GitHub push protection blocks known credential patterns; it
+  does not recognise personal data, home-grown tokens or infrastructure details — those are on
+  you, so check the diff before every push.
 
 ## How changes land
 
@@ -81,6 +83,8 @@ worse without saying so**, and chip at the key one whenever a change touches key
   Branch protection enforces it; merges are squash-only.
 - **Conventional commits** decide the version automatically via release-please
   (`fix:` → patch, `feat:` → minor, `feat!:` → major). Don't hand-edit version numbers.
+  Squash-merge makes the **PR title** the commit release-please reads; CI rejects a
+  non-conventional title.
 - **CI runs the fast checks and both e2e lanes on every PR**; the pre-commit hook (enabled by
   `npm install`) runs `verify:fast` on every commit. To get the same result locally before pushing:
   `npm run verify`, `bash demo/run-mock-e2e.sh` (API lane, purges its rig first), and
@@ -176,8 +180,8 @@ it fires.
 | `WATCH_RUNNING` — *"overlapping cycles stampede the host"* | `watchCycleInFlight` |
 | `mayAdd` — *"missing members are revoked, do not re-add"* | `reAddIfMissing` |
 
-`mayAdd` is the instructive one: already renamed once, and still needing a comment because it says
-*permission* where the meaning is "if they are missing, put them back". Needing a comment after one
+`mayAdd` is the instructive one: a name can survive a rename and still be wrong — it says
+*permission* where the meaning is "if they are missing, put them back". Needing a comment after a
 rename means go again, not settle.
 
 How to choose the name:
@@ -261,7 +265,7 @@ instructions. Re-read every comment you touch, in full.
 Granular on purpose. Pick the nearest level that earns one:
 
 - **File-level** — one module carrying dense reasoning of its own, e.g. a `store.md` next to
-  `store.ts`. None exist yet; create one the first time a module earns it.
+  `store.ts`, created the first time a module earns it.
 - **Folder-level** (`wire-protocol.md`, `sync-loops.md`) — a concern spanning several files, where
   the useful explanation is how they fit together.
 - **Neither** — most files. A module whose names already say what it does needs no doc; it still
@@ -360,6 +364,7 @@ Enforced by lint or tests wherever that is possible.
 
 ## Layout
 
-Code is grouped by concern under `src/` (a `config`/`state`/`peers` core, then `immich/`,
-`p2p/`, `sync/`, `media/`, `web/`). See [src/ARCHITECTURE.md](./src/ARCHITECTURE.md) for the
-module map and the data flow.
+One principle: **group by concern, and let the shape evolve.** New files, new folders and
+reshaped boundaries are expected as the project grows — nothing here freezes the tree. The
+*current* module map and data flow live in [src/ARCHITECTURE.md](./src/ARCHITECTURE.md); when a
+change moves the shape, it moves that map in the same change.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"*.json\"",
     "cycles": "node scripts/check-cycles.mjs",
     "test": "docker run --rm -e IMMICH_API_KEY=test-only -v \"$PWD/src\":/app/src -w /app node:24-alpine node --test \"src/**/*.test.ts\"",
-    "verify": "npm run build:panel && npm run format:check && npm run lint && npm run typecheck && npm run check:runtime && npm run cycles && npm test",
+    "verify": "npm run verify:fast && npm run check:runtime && npm test",
     "build:panel": "node scripts/build-panel.mjs",
-    "check:runtime": "docker run --rm -v \"$PWD/src\":/app/src -v \"$PWD/scripts\":/app/scripts -w /app node:24-alpine node scripts/check-runtime.mjs"
+    "check:runtime": "docker run --rm -v \"$PWD/src\":/app/src -v \"$PWD/scripts\":/app/scripts -w /app node:24-alpine node scripts/check-runtime.mjs",
+    "verify:fast": "npm run build:panel && npm run format:check && npm run lint && npm run typecheck && npm run cycles",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -77,9 +77,14 @@ every decision.
   - Mirror albums owned by the local account standing in for the origin's album owner.
   - **One account per remote person**, keyed by their user id on their own server, so the same human
     is one account however we meet them — with their real avatar synced across.
-  - Stores a **~2 KB unique stub** per photo (or a short playable prefix for a video, so duration
-    survives) with capture date, GPS and uploader credit applied — enough for the stock app to have
-    real rows. No pixels are stored; the ledger remembers which origin asset each stub stands for.
+  - Stores a **~2 KB unique stub** per photo, with capture date, GPS and uploader credit applied —
+    enough for the stock app to have real rows. No pixels are stored; the ledger remembers which
+    origin asset each stub stands for.
+  - For a video the stub is a **playable 2 MiB prefix** of the owner's rendition
+    (`Range: bytes=0-2097151`), so the tile carries a real poster and duration.
+  - A stub whose ledger row has **no origin link** cannot be resolved to a source, so the byte
+    routes fall through to it: such proxies are excluded from relay and on-demand originals
+    (`store.ledgerWithOrigin` gates both).
   - Deletion at the source propagates, and only utility-owned assets are ever deletable. Leaving an
     album purges its stubs, mirror and ledger entirely.
 - **byte interceptors** — the app's own asset URLs (`/api/assets/:id/thumbnail`, `/original`,

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -138,19 +138,13 @@ src/
     banner/           banner.js, injected into /share/* pages
 ```
 
-Conventions for this tree:
+**Dependencies point downward.** Core (`config`/`state`/`peers`) depends on nothing else here;
+feature folders depend on core and at most on layers below them. `p2p` and `sync` reference each
+other only through runtime calls (join → reconcile, watcher → nudge), never at module load.
 
-1. **Docs sit as close to the code as they need to.** A folder doc where a concern spans several
-   files; a file-level doc beside a module carrying dense reasoning of its own; neither where the
-   names already say enough. Name it for its contents, never `README.md`.
-2. **Nest when a concern grows.** A concern starts as one file at `src/` root (like `peers.ts`) and
-   graduates to a folder with its own doc once it needs several files.
-3. **Dependencies point downward.** Core (`config`/`state`/`peers`) depends on nothing else here;
-   feature folders depend on core and at most on layers below them. `p2p` and `sync` reference each
-   other only through runtime calls (join → reconcile, watcher → nudge), never at module load.
-
-Keeping these docs accurate is a rule for every contributor, human or agent — see
-[AGENTS.md](../AGENTS.md).
+**A concern graduates.** It starts as one file at `src/` root (like `peers.ts`) and becomes a folder
+once it needs several. Where its doc then lives, and the rule that keeps these docs accurate, are in
+[AGENTS.md](../AGENTS.md) — *Where a doc lives* and *Keep the docs in sync*.
 
 ## Iron rules
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -1,20 +1,22 @@
 # Architecture
 
-> 🎬 The end-user experience this architecture produces: [video demo](https://www.youtube.com/watch?v=c3GO-YFchYo).
+> 🎬 The end-user experience this produces: [video demo](https://www.youtube.com/watch?v=c3GO-YFchYo).
 
-One zero-dependency Node process — TypeScript run natively by Node's type
-stripping (no build step), state in SQLite via the built-in node:sqlite (WAL,
-crash-safe, indexed ledgers; a legacy state.json migrates automatically on
-boot). Sync is **nudge-driven with a timed backstop**: a signed HTTP nudge — a
-lightweight webhook — makes the common case near-instant, and two timers (the
-watch loop, which ends each cycle with a reconcile pass, and the comment loop)
-are the fail-open safety net — no websockets, no dependency on any push channel
-staying up. Everything user-facing is either the stock Immich app rendering
-ordinary data we planted, or a web page we serve.
+One process, **zero runtime dependencies**:
+
+- **No build step to run it.** TypeScript is executed natively by Node's type stripping —
+  `node index.ts`, Node ≥ 23.6. The two front-end pages are Preact TSX bundled by esbuild, but the
+  bundles are **committed**, so deploying still builds nothing.
+- **State is SQLite** via the built-in `node:sqlite` — WAL, crash-safe, indexed ledgers.
+- **Sync is nudge-driven with a timed backstop.** A signed HTTP nudge makes the common case
+  near-instant; three timers are the fail-open safety net. No websockets, no push channel to keep
+  alive.
+- **Everything user-facing** is either the stock Immich app rendering ordinary data we planted, or a
+  page we serve.
 
 ```
             ┌─────────────────────────────────────────────┐
-            │                  sidecar                     │
+            │                  sidecar                    │
             │                                             │
  Immich API │  watcher ──► protocol client ──► peers      │  signed HTTPS
  (API key)  │     ▲                              │        │  to other
@@ -25,143 +27,145 @@ ordinary data we planted, or a web page we serve.
             │  state.db (SQLite): keys, peers, mappings,  │
             │        seen ledger, activity, contributors  │
             │                                             │
-            │  web: panel (/immich-shared-albums/) · banner (/share/*) │
-            │       accept page (/immich-shared-albums/accept)         │
+            │  web: panel (/immich-shared-albums/)        │
+            │       banner (/share/*) · accept page       │
             └─────────────────────────────────────────────┘
 ```
 
+## The three loops
+
+Started by `index.ts`, each guarded against overlapping itself:
+
+| Loop | Does | Cadence |
+|---|---|---|
+| `startWatchLoop` | `watchOnce` pushes local additions to peers, then **ends each cycle with `reconcileOnce`** | `POLL_MS` |
+| `startCommentLoop` | two-way comment sync, gated on a cheap activity-count statistic | fast lane |
+| `startInviteLoop` | `detectInvitesOnce` (origin side), then `pullInvitationsOnce` (member side) | own tick |
+
+A lost nudge costs nothing — the next scheduled pass catches everything. `RECONCILE_DEBUG=1` traces
+every decision.
+
 ## Components
 
-- **watcher** — runs on a timed loop over mapped albums, but gates real work
-  behind a version handshake against the album's `updatedAt` and skips
-  untouched albums entirely (an idle album costs one row read per cycle). Fresh
-  additions are pushed to peers as refs (partial-success protocol: failed
-  refs are re-offered next cycle). Everything is recorded in `seen`, keyed
-  per album mapping, and each proxy's ledger entry records the SOURCE photo's
-  checksum and origin asset — so the ledger doubles as provenance: the origin
-  relays member contributions onward to the other member households, and
-  provably never offers a household its own photos back.
-- **reconciler** — members ask the origin for the album's version
-  (`GET .../version`, one cheap read) and only pull the full manifest
-  (`GET .../manifest`) on mismatch, materialising anything missing — heals
-  refs missed at join time. The timed loop is the fail-open backstop; a nudge
-  (below) makes the common case near-instant, so eventual consistency lands in
-  seconds for family albums.
-- **comment sync** — two-way; locally-authored comments are pushed, peer
-  comments are posted via the author's utility user, and a seen-ledger keyed
-  both directions prevents echo loops.
+- **watcher** — pushes what is new here out to peers.
+  - Gates real work behind a version handshake on the album's `updatedAt`; an untouched album costs
+    one row read per cycle.
+  - Partial success: refs the peer rejected are re-offered next cycle.
+  - Records every ref in `seen`, keyed per mapping, storing the **source** checksum and origin
+    asset. The ledger therefore doubles as provenance: the origin relays member contributions on to
+    other member households, and provably never offers a household its own photos back.
+- **reconciler** — heals what the push missed.
+  - Members read `GET …/version` (one cheap read) and pull `GET …/manifest` only on mismatch.
+  - `updatedAt` alone misses cascade deletions — removing an asset from the library does not touch
+    its albums — so the asset count travels with the version.
+  - Deletion propagates: stubs whose refs leave the owner's manifest are removed, gated on a
+    consistent manifest so an indexing lag never reads as a deletion.
+- **comment sync** — the origin album is the source of truth. Local comments are pushed; peer
+  comments are posted via **the author's own local account**, and a seen-ledger keyed in both
+  directions prevents echo loops.
 - **protocol client/server** — signed ref exchange between households.
-  Key pinned at redemption (anchored on the share key, whose password and expiry are
-  both honoured). URLs are hints; identity is the key. Crucially, identity is *only*
-  identity: every mapping lookup is filtered by the calling peer, so a signature can
-  never select someone else's album. See `p2p/wire-protocol.md`.
-- **entitlement** — the answer to "may this peer read these bytes", kept separately from
-  "who is this peer". Everything advertised to a mapping (a redeem response, a manifest,
-  a ref push) is recorded in an `offered` index; the peer-facing byte routes serve only
-  what is on it, falling back to album membership (throttled) so upgrades self-heal.
-  Without this, an asset id — which manifests hand out by design — would be enough for
-  any enrolled peer to read anything the admin key can reach.
-- **materialiser** — makes shared state look like ordinary Immich data:
-  mirror albums owned by a utility user named after the origin's album owner
-  ("Jane (via shared albums)"), one utility user per contributor (with their
-  real avatar synced across). What it stores is a ~2KB unique STUB per photo
-  (a playable ~2MB prefix for videos, which carries the real poster and
-  duration) with capture date, GPS, and uploader credit applied — enough for
-  the stock app to have real rows. No pixels are stored; the ledger remembers
-  which origin asset each stub stands for. Deleting at the source propagates:
-  stubs whose refs vanish from the owner's manifest are removed (guarded so
-  only utility-owned assets are ever deletable). Leaving an album purges its
-  stubs, mirror, and ledger entirely.
-- **byte interceptors** — the app's own asset URLs (`/api/assets/:id/thumbnail`,
-  `/original`, `/video/playback`) intercepted for stub assets: the caller is
-  authorised against Immich with their own credentials, then the true bytes
-  STREAM live from the owner's server with Range passthrough (seekable video),
-  chaining through the origin for relayed photos (D <- origin <- contributor).
-  Responses carry immutable cache headers so devices cache hard. Falls through
-  to Immich for the user's own assets and on any failure — a dead sidecar can
-  only degrade shared tiles, never the local library. Streaming, never
-  buffering — Pi-friendly.
-- **membership = visibility** — mirrors are owned by utility users, so only
-  album members see them. Joins are per-user: the accept page reads the
-  visitor's own Immich session and adds exactly that account; a second user
-  joining the same link is added to the existing mirror.
-- **native invitations** — a peer household gets a local stand-in user, so adding it to an
-  album in Immich's own picker shares that album cross-server and removing it revokes. Detected
-  by listing albums *as the stand-in* (the admin key only sees its own albums, which is why
-  link-based sharing is broken for non-admins). Members **pull** invitations rather than being
-  pushed them, so a household with no inbound reachability still works. See `sync/invites.ts`.
-- **web** — the panel, the share-page join banner (shadow-DOM, fails silent),
-  the accept page, and a transparent proxy for share-page SPA assets when the
-  sidecar fronts Immich directly. All fail open.
+  - Key pinned at redemption, anchored on the share key, whose password and expiry are honoured.
+  - URLs are hints; the key is the identity.
+  - Identity is *only* identity: every mapping lookup filters on the calling peer, so a signature
+    can never select someone else's album. See [`p2p/wire-protocol.md`](./p2p/wire-protocol.md).
+- **entitlement** — "may this peer read these bytes", kept separate from "who is this peer".
+  Everything advertised to a mapping (redeem response, manifest, ref push) lands in an `offered`
+  index, and the byte routes serve only what is on it, falling back to album membership (throttled)
+  so upgrades self-heal. Without it an asset id — which manifests hand out by design — would let any
+  enrolled peer read anything the admin key can reach.
+- **materialiser** — makes shared state look like ordinary Immich data.
+  - Mirror albums owned by the local account standing in for the origin's album owner.
+  - **One account per remote person**, keyed by their user id on their own server, so the same human
+    is one account however we meet them — with their real avatar synced across.
+  - Stores a **~2 KB unique stub** per photo (or a short playable prefix for a video, so duration
+    survives) with capture date, GPS and uploader credit applied — enough for the stock app to have
+    real rows. No pixels are stored; the ledger remembers which origin asset each stub stands for.
+  - Deletion at the source propagates, and only utility-owned assets are ever deletable. Leaving an
+    album purges its stubs, mirror and ledger entirely.
+- **byte interceptors** — the app's own asset URLs (`/api/assets/:id/thumbnail`, `/original`,
+  `/video/playback`) intercepted for stub assets.
+  - The caller is authorised against Immich with **their own** credentials first.
+  - True bytes then stream live from the owner, with `Range` passthrough for seekable video,
+    chaining through the origin for relayed photos (`D ← origin ← contributor`).
+  - Immutable cache headers, so devices cache hard. Falls through to Immich for the user's own
+    assets and on any failure — a dead sidecar degrades shared tiles, never the local library.
+  - Streaming, never buffering. Pi-friendly.
+- **membership = visibility** — mirrors are owned by these accounts, so only album members see them.
+  Joins are per-user: the accept page reads the visitor's own session and adds exactly that account;
+  a second user joining the same link is added to the existing mirror.
+- **native invitations** — every person on a linked server has a local account, so adding one to an
+  album in Immich's own picker shares it with **that person**, and removing them revokes it. Sharing
+  never names a household.
+  - Detected by listing albums *as that account*, because `GET /albums` is scoped per user and the
+    admin key only ever sees the admin's own albums — which is also why link-based sharing is still
+    broken for non-admins.
+  - Members **pull** invitations rather than being pushed them, so a household with no inbound
+    reachability still works. See [`sync/sync-loops.md`](./sync/sync-loops.md).
+- **web** — the panel, the share-page join banner (shadow DOM, fails silent), the accept page, and a
+  transparent proxy for share-page assets when the sidecar fronts Immich. All fail open.
+- **nudges** — when the origin materialises a member's contribution or comment it pings the other
+  member households (a signed POST to `…/nudge`, no payload beyond the album id) so they pull
+  immediately. A latency hint, never a source of truth.
 
-- **nudges** — a lightweight webhook: when the origin materialises a member's
-  contribution or comment, it pings the other member households (a signed POST to
-  `.../nudge`, no payload beyond the album id — an ordinary event-triggered HTTP
-  request, not a websocket) so they pull immediately. The timed handshake remains
-  the fail-open safety net, so a lost nudge only delays a change to the next tick,
-  never loses it.
-
-Planned, not yet built: save-to-library — the explicit per-photo opt-in that
-stores a true original owned by the saving user (the one deliberate way a copy
-ever lands on your disk).
-
-Migration note: proxies materialised before the provenance ledger have no
-origin link — they stay as-is and are excluded from relay and on-demand
-originals; only newly synced photos participate.
+**Not built yet:** save-to-library — the explicit per-photo opt-in that stores a true original owned
+by the saving user, and the one deliberate way a copy lands on your disk.
 
 ## Code layout
 
-The process is composed from small modules grouped by concern. `index.ts` is the
-composition root (start the server + the loops); everything else is a helper.
+`index.ts` is the composition root: start the server, start the loops. Everything else is a helper.
 
 ```
 src/
-  index.ts          entry / composition root
-  config.ts         settings (CFG), the logger, string constants
-  state.ts          SQLite store, the household keypair, seen-ledger accessors
-  peers.ts          P2P transport: sign / verify / signed POST / nudge
-  store.ts          the raw SQLite layer
-  types.ts          shared types
-  immich/           the local Immich API layer   → local-immich-api.md
-  p2p/              the cross-server wire protocol → wire-protocol.md
-  sync/             the reconciliation + comment loops → sync-loops.md
-  media/            the hotlink byte path + LRU cache → hotlink-bytes.md
-  web/              HTML pages + the HTTP router → http-router.md
+  index.ts            entry / composition root
+  config.ts           settings (CFG), the logger, string constants
+  state.ts            the store instance, household keypair, seen-ledger accessors
+  store.ts            the raw SQLite layer
+  peers.ts            P2P transport: sign / verify / signed POST / nudge
+  types.ts            wire types shared by both ends
+  invariants.test.ts  pure-logic unit tests
+  immich/             the local Immich API layer        → local-immich-api.md
+  p2p/                the cross-server wire protocol    → wire-protocol.md
+  sync/               reconcile, comment + invite loops → sync-loops.md
+  media/              the hotlink byte path + LRU cache → hotlink-bytes.md
+  web/                HTTP router + pages               → http-router.md
+    panel/            admin panel  (Preact TSX → panel.bundle.js)
+    accept/           joining page (Preact TSX → accept.bundle.js)
+    banner/           banner.js, injected into /share/* pages
 ```
 
 Conventions for this tree:
 
-1. **One doc per helper folder.** Every folder under `src/` carries a single
-   Markdown file explaining what lives there and why. Name it for its contents
-   (e.g. `wire-protocol.md`), not `README.md` — the descriptive name reads better
-   in the file tree and when linked.
-2. **Nest when a concern grows.** A concern starts as one file at `src/` root
-   (like `peers.ts`); when it needs several files it graduates to a folder with
-   its own doc. Sub-folders are fine — each new folder gets its own doc.
-3. **Dependencies point downward.** Core (`config`/`state`/`peers`) depends on
-   nothing else here; feature folders depend on core and, at most, on layers
-   below them. `p2p` and `sync` reference each other only through runtime calls
-   (join → reconcile, watcher → nudge), never at module-load time.
+1. **Docs sit as close to the code as they need to.** A folder doc where a concern spans several
+   files; a file-level doc beside a module carrying dense reasoning of its own; neither where the
+   names already say enough. Name it for its contents, never `README.md`.
+2. **Nest when a concern grows.** A concern starts as one file at `src/` root (like `peers.ts`) and
+   graduates to a folder with its own doc once it needs several files.
+3. **Dependencies point downward.** Core (`config`/`state`/`peers`) depends on nothing else here;
+   feature folders depend on core and at most on layers below them. `p2p` and `sync` reference each
+   other only through runtime calls (join → reconcile, watcher → nudge), never at module load.
 
-Keeping these docs in sync with the code is a project rule for every contributor,
-human or AI agent — see [AGENTS.md](../AGENTS.md).
+Keeping these docs accurate is a rule for every contributor, human or agent — see
+[AGENTS.md](../AGENTS.md).
 
 ## Iron rules
 
-1. Stock Immich is never modified; all cleverness lives at the reverse proxy
-   or behind the public API.
-2. Every injected surface fails open — Immich must work perfectly with the
-   sidecar dead.
-3. The app only ever touches its own server's ordinary data.
-4. Ownership stays with the photo's taker: other households store nothing but
-   kilobyte placeholders — every pixel streams from its owner on demand and is
-   only ever STORED elsewhere when a user explicitly saves a photo to their
-   own library.
-5. Default-closed: no uninvited server can reach anything.
-6. **Reachability is never permission.** Every route assumes it is published to the open
-   internet. Human routes authenticate against the caller's own Immich session; peer
-   routes require a signature *and* an entitlement check. Nothing is protected by being
-   hard to find, on a private network, or behind a URL nobody has guessed.
-7. **The sidecar invents no identities and holds no logins.** The only identity that means
-   anything is an Immich one. The bot users that own the stubs get a narrowly-scoped API
-   key and no retained password, so they cannot be signed into at all.
+1. **Stock Immich is never modified.** All cleverness lives at the reverse proxy or behind the
+   public API.
+2. **Every injected surface fails open.** Immich must work perfectly with the sidecar dead.
+3. **The app only ever touches its own server's ordinary data.**
+4. **Ownership stays with the photo's taker.** Other households hold kilobyte placeholders; every
+   pixel streams from its owner on demand, and is stored elsewhere only when a user explicitly saves
+   it to their own library.
+5. **Default-closed.** No uninvited server reaches anything.
+6. **Reachability is never permission.** Every route assumes it is published to the open internet.
+   Human routes authenticate against the caller's own Immich session; peer routes require a
+   signature *and* an entitlement check. Nothing is protected by being hard to find, on a private
+   network, or behind a URL nobody has guessed.
+7. **The sidecar invents no identities and holds no logins.** The only identity that means anything
+   is an Immich one. The accounts that own stubs get a narrowly-scoped API key and no retained
+   password, so they cannot be signed into at all.
+
+**Where this falls short today:** the sidecar needs an all-permissions admin API key, so its blast
+radius is the whole instance. It also creates real user accounts — one per remote person — that
+appear in every picker, because Immich has no service-account flag. Both are known costs; do not
+make either worse without saying so.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,4 @@
-/**
- * immich-shared-albums — entry point / composition root.
- * One process: an HTTP server (protocol + panel + byte proxies) plus two sync loops.
- * State is SQLite via node:sqlite (see store.ts). TypeScript is run natively by Node's
- * type stripping — no build step. Node >= 23.6, zero dependencies.
- *
- * The code is split by concern — see each folder's .md:
- *   config.ts / state.ts / peers.ts   core: settings, persistence, P2P signing
- *   immich/                           local Immich API, refs, contributors, proxy writes
- *   p2p/                              wire protocol + join
- *   sync/                             reconcile + comment loops
- *   media/                            hotlink byte path + LRU cache
- *   web/                              HTML pages + HTTP router
- */
+/** index.ts — composition root: starts the HTTP server and the three sync loops. See ARCHITECTURE.md. */
 import { CFG, log } from './config.ts';
 import { server } from './web/server.ts';
 import { proxyUpgrade } from './web/upgrade.ts';


### PR DESCRIPTION
One PR for the conventions work. Three parts that depend on each other — AGENTS.md cites ARCHITECTURE.md's shortfall section and the `prepare` script, so they land together.

## 1. AGENTS.md — the contract (rules, no diary)

- **Boy-scout rule**: any file you touch comes up to standard — six checks in one table. Explicitly not batch migration, not a blocker on unrelated work.
- **Comments**: paired doc is the default; what survives inline is one seven-row table (single source — the duplicate lists are gone).
- **Names**: a name that needs a comment is the wrong name — any name; removing a comment is a move (into the name or the doc), never a delete. Three worked renames waiting in the tree.
- **Docs**: dense over flowing, every claim checkable, state what the code does, **no narrative** (no "used to", no retold incidents, no before/after counts), boy-scout never batch.
- **Never enforce in prose what code can enforce** — this file is for judgement calls code cannot make.
- De-duplicated throughout; three false statements fixed (a rename claimed done that wasn't, a misquoted JSDoc, two wrong list counts).

## 2. ARCHITECTURE.md — the bedrock doc, dense and verified

Every claim checked against code. Three were false: a `state.json` importer removed in #16 still described as running, **two** loops where `index.ts` starts **three** (the invite loop was absent), and "no build step" left unqualified (server: true; the two pages are esbuild-bundled with bundles committed). Two mid-clause truncations restored, the layout tree completed, doc conventions deferred to AGENTS.md instead of restated. Boy-scout on `index.ts`: 13-line header → 1.

## 3. Fast gate enforced in code, not instructions

| Gap | Fix |
|---|---|
| Hook ran only if you read the doc and set `core.hooksPath` | `prepare` script — `npm install` enables it |
| Hook duplicated `verify`'s step list in shell, and had drifted | both run the shared `verify:fast` |
| **Defect**: hook staged only `panel.bundle.js`; commits touching `accept/` shipped a stale `accept.bundle.js` | hook stages both bundles |

## Not in this PR

- #21 — the flaky e2e assertion fix (requested as its own PR; it unblocks CI for everything).
- The full comment-strip/rename sweep — preserved on `archive/comments-to-docs-full`, lands via boy-scout.

## Testing

`npm run verify` clean; hook smoke-tested. No product code changes — docs, `package.json`, the hook, and one file header.