### PR TITLE
docs: rewrite ARCHITECTURE.md dense, and correct three false claims

### DIFF
--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -77,9 +77,14 @@ every decision.
   - Mirror albums owned by the local account standing in for the origin's album owner.
   - **One account per remote person**, keyed by their user id on their own server, so the same human
     is one account however we meet them — with their real avatar synced across.
-  - Stores a **~2 KB unique stub** per photo (or a short playable prefix for a video, so duration
-    survives) with capture date, GPS and uploader credit applied — enough for the stock app to have
-    real rows. No pixels are stored; the ledger remembers which origin asset each stub stands for.
+  - Stores a **~2 KB unique stub** per photo, with capture date, GPS and uploader credit applied —
+    enough for the stock app to have real rows. No pixels are stored; the ledger remembers which
+    origin asset each stub stands for.
+  - For a video the stub is a **playable 2 MiB prefix** of the owner's rendition
+    (`Range: bytes=0-2097151`), so the tile carries a real poster and duration.
+  - A stub whose ledger row has **no origin link** cannot be resolved to a source, so the byte
+    routes fall through to it: such proxies are excluded from relay and on-demand originals
+    (`store.ledgerWithOrigin` gates both).
   - Deletion at the source propagates, and only utility-owned assets are ever deletable. Leaving an
     album purges its stubs, mirror and ledger entirely.
 - **byte interceptors** — the app's own asset URLs (`/api/assets/:id/thumbnail`, `/original`,

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -138,19 +138,13 @@ src/
     banner/           banner.js, injected into /share/* pages
 ```
 
-Conventions for this tree:
+**Dependencies point downward.** Core (`config`/`state`/`peers`) depends on nothing else here;
+feature folders depend on core and at most on layers below them. `p2p` and `sync` reference each
+other only through runtime calls (join → reconcile, watcher → nudge), never at module load.
 
-1. **Docs sit as close to the code as they need to.** A folder doc where a concern spans several
-   files; a file-level doc beside a module carrying dense reasoning of its own; neither where the
-   names already say enough. Name it for its contents, never `README.md`.
-2. **Nest when a concern grows.** A concern starts as one file at `src/` root (like `peers.ts`) and
-   graduates to a folder with its own doc once it needs several files.
-3. **Dependencies point downward.** Core (`config`/`state`/`peers`) depends on nothing else here;
-   feature folders depend on core and at most on layers below them. `p2p` and `sync` reference each
-   other only through runtime calls (join → reconcile, watcher → nudge), never at module load.
-
-Keeping these docs accurate is a rule for every contributor, human or agent — see
-[AGENTS.md](../AGENTS.md).
+**A concern graduates.** It starts as one file at `src/` root (like `peers.ts`) and becomes a folder
+once it needs several. Where its doc then lives, and the rule that keeps these docs accurate, are in
+[AGENTS.md](../AGENTS.md) — *Where a doc lives* and *Keep the docs in sync*.
 
 ## Iron rules
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -1,20 +1,22 @@
 # Architecture
 
-> 🎬 The end-user experience this architecture produces: [video demo](https://www.youtube.com/watch?v=c3GO-YFchYo).
+> 🎬 The end-user experience this produces: [video demo](https://www.youtube.com/watch?v=c3GO-YFchYo).
 
-One zero-dependency Node process — TypeScript run natively by Node's type
-stripping (no build step), state in SQLite via the built-in node:sqlite (WAL,
-crash-safe, indexed ledgers; a legacy state.json migrates automatically on
-boot). Sync is **nudge-driven with a timed backstop**: a signed HTTP nudge — a
-lightweight webhook — makes the common case near-instant, and two timers (the
-watch loop, which ends each cycle with a reconcile pass, and the comment loop)
-are the fail-open safety net — no websockets, no dependency on any push channel
-staying up. Everything user-facing is either the stock Immich app rendering
-ordinary data we planted, or a web page we serve.
+One process, **zero runtime dependencies**:
+
+- **No build step to run it.** TypeScript is executed natively by Node's type stripping —
+  `node index.ts`, Node ≥ 23.6. The two front-end pages are Preact TSX bundled by esbuild, but the
+  bundles are **committed**, so deploying still builds nothing.
+- **State is SQLite** via the built-in `node:sqlite` — WAL, crash-safe, indexed ledgers.
+- **Sync is nudge-driven with a timed backstop.** A signed HTTP nudge makes the common case
+  near-instant; three timers are the fail-open safety net. No websockets, no push channel to keep
+  alive.
+- **Everything user-facing** is either the stock Immich app rendering ordinary data we planted, or a
+  page we serve.
 
 ```
             ┌─────────────────────────────────────────────┐
-            │                  sidecar                     │
+            │                  sidecar                    │
             │                                             │
  Immich API │  watcher ──► protocol client ──► peers      │  signed HTTPS
  (API key)  │     ▲                              │        │  to other
@@ -25,143 +27,145 @@ ordinary data we planted, or a web page we serve.
             │  state.db (SQLite): keys, peers, mappings,  │
             │        seen ledger, activity, contributors  │
             │                                             │
-            │  web: panel (/immich-shared-albums/) · banner (/share/*) │
-            │       accept page (/immich-shared-albums/accept)         │
+            │  web: panel (/immich-shared-albums/)        │
+            │       banner (/share/*) · accept page       │
             └─────────────────────────────────────────────┘
 ```
 
+## The three loops
+
+Started by `index.ts`, each guarded against overlapping itself:
+
+| Loop | Does | Cadence |
+|---|---|---|
+| `startWatchLoop` | `watchOnce` pushes local additions to peers, then **ends each cycle with `reconcileOnce`** | `POLL_MS` |
+| `startCommentLoop` | two-way comment sync, gated on a cheap activity-count statistic | fast lane |
+| `startInviteLoop` | `detectInvitesOnce` (origin side), then `pullInvitationsOnce` (member side) | own tick |
+
+A lost nudge costs nothing — the next scheduled pass catches everything. `RECONCILE_DEBUG=1` traces
+every decision.
+
 ## Components
 
-- **watcher** — runs on a timed loop over mapped albums, but gates real work
-  behind a version handshake against the album's `updatedAt` and skips
-  untouched albums entirely (an idle album costs one row read per cycle). Fresh
-  additions are pushed to peers as refs (partial-success protocol: failed
-  refs are re-offered next cycle). Everything is recorded in `seen`, keyed
-  per album mapping, and each proxy's ledger entry records the SOURCE photo's
-  checksum and origin asset — so the ledger doubles as provenance: the origin
-  relays member contributions onward to the other member households, and
-  provably never offers a household its own photos back.
-- **reconciler** — members ask the origin for the album's version
-  (`GET .../version`, one cheap read) and only pull the full manifest
-  (`GET .../manifest`) on mismatch, materialising anything missing — heals
-  refs missed at join time. The timed loop is the fail-open backstop; a nudge
-  (below) makes the common case near-instant, so eventual consistency lands in
-  seconds for family albums.
-- **comment sync** — two-way; locally-authored comments are pushed, peer
-  comments are posted via the author's utility user, and a seen-ledger keyed
-  both directions prevents echo loops.
+- **watcher** — pushes what is new here out to peers.
+  - Gates real work behind a version handshake on the album's `updatedAt`; an untouched album costs
+    one row read per cycle.
+  - Partial success: refs the peer rejected are re-offered next cycle.
+  - Records every ref in `seen`, keyed per mapping, storing the **source** checksum and origin
+    asset. The ledger therefore doubles as provenance: the origin relays member contributions on to
+    other member households, and provably never offers a household its own photos back.
+- **reconciler** — heals what the push missed.
+  - Members read `GET …/version` (one cheap read) and pull `GET …/manifest` only on mismatch.
+  - `updatedAt` alone misses cascade deletions — removing an asset from the library does not touch
+    its albums — so the asset count travels with the version.
+  - Deletion propagates: stubs whose refs leave the owner's manifest are removed, gated on a
+    consistent manifest so an indexing lag never reads as a deletion.
+- **comment sync** — the origin album is the source of truth. Local comments are pushed; peer
+  comments are posted via **the author's own local account**, and a seen-ledger keyed in both
+  directions prevents echo loops.
 - **protocol client/server** — signed ref exchange between households.
-  Key pinned at redemption (anchored on the share key, whose password and expiry are
-  both honoured). URLs are hints; identity is the key. Crucially, identity is *only*
-  identity: every mapping lookup is filtered by the calling peer, so a signature can
-  never select someone else's album. See `p2p/wire-protocol.md`.
-- **entitlement** — the answer to "may this peer read these bytes", kept separately from
-  "who is this peer". Everything advertised to a mapping (a redeem response, a manifest,
-  a ref push) is recorded in an `offered` index; the peer-facing byte routes serve only
-  what is on it, falling back to album membership (throttled) so upgrades self-heal.
-  Without this, an asset id — which manifests hand out by design — would be enough for
-  any enrolled peer to read anything the admin key can reach.
-- **materialiser** — makes shared state look like ordinary Immich data:
-  mirror albums owned by a utility user named after the origin's album owner
-  ("Jane (via shared albums)"), one utility user per contributor (with their
-  real avatar synced across). What it stores is a ~2KB unique STUB per photo
-  (a playable ~2MB prefix for videos, which carries the real poster and
-  duration) with capture date, GPS, and uploader credit applied — enough for
-  the stock app to have real rows. No pixels are stored; the ledger remembers
-  which origin asset each stub stands for. Deleting at the source propagates:
-  stubs whose refs vanish from the owner's manifest are removed (guarded so
-  only utility-owned assets are ever deletable). Leaving an album purges its
-  stubs, mirror, and ledger entirely.
-- **byte interceptors** — the app's own asset URLs (`/api/assets/:id/thumbnail`,
-  `/original`, `/video/playback`) intercepted for stub assets: the caller is
-  authorised against Immich with their own credentials, then the true bytes
-  STREAM live from the owner's server with Range passthrough (seekable video),
-  chaining through the origin for relayed photos (D <- origin <- contributor).
-  Responses carry immutable cache headers so devices cache hard. Falls through
-  to Immich for the user's own assets and on any failure — a dead sidecar can
-  only degrade shared tiles, never the local library. Streaming, never
-  buffering — Pi-friendly.
-- **membership = visibility** — mirrors are owned by utility users, so only
-  album members see them. Joins are per-user: the accept page reads the
-  visitor's own Immich session and adds exactly that account; a second user
-  joining the same link is added to the existing mirror.
-- **native invitations** — a peer household gets a local stand-in user, so adding it to an
-  album in Immich's own picker shares that album cross-server and removing it revokes. Detected
-  by listing albums *as the stand-in* (the admin key only sees its own albums, which is why
-  link-based sharing is broken for non-admins). Members **pull** invitations rather than being
-  pushed them, so a household with no inbound reachability still works. See `sync/invites.ts`.
-- **web** — the panel, the share-page join banner (shadow-DOM, fails silent),
-  the accept page, and a transparent proxy for share-page SPA assets when the
-  sidecar fronts Immich directly. All fail open.
+  - Key pinned at redemption, anchored on the share key, whose password and expiry are honoured.
+  - URLs are hints; the key is the identity.
+  - Identity is *only* identity: every mapping lookup filters on the calling peer, so a signature
+    can never select someone else's album. See [`p2p/wire-protocol.md`](./p2p/wire-protocol.md).
+- **entitlement** — "may this peer read these bytes", kept separate from "who is this peer".
+  Everything advertised to a mapping (redeem response, manifest, ref push) lands in an `offered`
+  index, and the byte routes serve only what is on it, falling back to album membership (throttled)
+  so upgrades self-heal. Without it an asset id — which manifests hand out by design — would let any
+  enrolled peer read anything the admin key can reach.
+- **materialiser** — makes shared state look like ordinary Immich data.
+  - Mirror albums owned by the local account standing in for the origin's album owner.
+  - **One account per remote person**, keyed by their user id on their own server, so the same human
+    is one account however we meet them — with their real avatar synced across.
+  - Stores a **~2 KB unique stub** per photo (or a short playable prefix for a video, so duration
+    survives) with capture date, GPS and uploader credit applied — enough for the stock app to have
+    real rows. No pixels are stored; the ledger remembers which origin asset each stub stands for.
+  - Deletion at the source propagates, and only utility-owned assets are ever deletable. Leaving an
+    album purges its stubs, mirror and ledger entirely.
+- **byte interceptors** — the app's own asset URLs (`/api/assets/:id/thumbnail`, `/original`,
+  `/video/playback`) intercepted for stub assets.
+  - The caller is authorised against Immich with **their own** credentials first.
+  - True bytes then stream live from the owner, with `Range` passthrough for seekable video,
+    chaining through the origin for relayed photos (`D ← origin ← contributor`).
+  - Immutable cache headers, so devices cache hard. Falls through to Immich for the user's own
+    assets and on any failure — a dead sidecar degrades shared tiles, never the local library.
+  - Streaming, never buffering. Pi-friendly.
+- **membership = visibility** — mirrors are owned by these accounts, so only album members see them.
+  Joins are per-user: the accept page reads the visitor's own session and adds exactly that account;
+  a second user joining the same link is added to the existing mirror.
+- **native invitations** — every person on a linked server has a local account, so adding one to an
+  album in Immich's own picker shares it with **that person**, and removing them revokes it. Sharing
+  never names a household.
+  - Detected by listing albums *as that account*, because `GET /albums` is scoped per user and the
+    admin key only ever sees the admin's own albums — which is also why link-based sharing is still
+    broken for non-admins.
+  - Members **pull** invitations rather than being pushed them, so a household with no inbound
+    reachability still works. See [`sync/sync-loops.md`](./sync/sync-loops.md).
+- **web** — the panel, the share-page join banner (shadow DOM, fails silent), the accept page, and a
+  transparent proxy for share-page assets when the sidecar fronts Immich. All fail open.
+- **nudges** — when the origin materialises a member's contribution or comment it pings the other
+  member households (a signed POST to `…/nudge`, no payload beyond the album id) so they pull
+  immediately. A latency hint, never a source of truth.
 
-- **nudges** — a lightweight webhook: when the origin materialises a member's
-  contribution or comment, it pings the other member households (a signed POST to
-  `.../nudge`, no payload beyond the album id — an ordinary event-triggered HTTP
-  request, not a websocket) so they pull immediately. The timed handshake remains
-  the fail-open safety net, so a lost nudge only delays a change to the next tick,
-  never loses it.
-
-Planned, not yet built: save-to-library — the explicit per-photo opt-in that
-stores a true original owned by the saving user (the one deliberate way a copy
-ever lands on your disk).
-
-Migration note: proxies materialised before the provenance ledger have no
-origin link — they stay as-is and are excluded from relay and on-demand
-originals; only newly synced photos participate.
+**Not built yet:** save-to-library — the explicit per-photo opt-in that stores a true original owned
+by the saving user, and the one deliberate way a copy lands on your disk.
 
 ## Code layout
 
-The process is composed from small modules grouped by concern. `index.ts` is the
-composition root (start the server + the loops); everything else is a helper.
+`index.ts` is the composition root: start the server, start the loops. Everything else is a helper.
 
 ```
 src/
-  index.ts          entry / composition root
-  config.ts         settings (CFG), the logger, string constants
-  state.ts          SQLite store, the household keypair, seen-ledger accessors
-  peers.ts          P2P transport: sign / verify / signed POST / nudge
-  store.ts          the raw SQLite layer
-  types.ts          shared types
-  immich/           the local Immich API layer   → local-immich-api.md
-  p2p/              the cross-server wire protocol → wire-protocol.md
-  sync/             the reconciliation + comment loops → sync-loops.md
-  media/            the hotlink byte path + LRU cache → hotlink-bytes.md
-  web/              HTML pages + the HTTP router → http-router.md
+  index.ts            entry / composition root
+  config.ts           settings (CFG), the logger, string constants
+  state.ts            the store instance, household keypair, seen-ledger accessors
+  store.ts            the raw SQLite layer
+  peers.ts            P2P transport: sign / verify / signed POST / nudge
+  types.ts            wire types shared by both ends
+  invariants.test.ts  pure-logic unit tests
+  immich/             the local Immich API layer        → local-immich-api.md
+  p2p/                the cross-server wire protocol    → wire-protocol.md
+  sync/               reconcile, comment + invite loops → sync-loops.md
+  media/              the hotlink byte path + LRU cache → hotlink-bytes.md
+  web/                HTTP router + pages               → http-router.md
+    panel/            admin panel  (Preact TSX → panel.bundle.js)
+    accept/           joining page (Preact TSX → accept.bundle.js)
+    banner/           banner.js, injected into /share/* pages
 ```
 
 Conventions for this tree:
 
-1. **One doc per helper folder.** Every folder under `src/` carries a single
-   Markdown file explaining what lives there and why. Name it for its contents
-   (e.g. `wire-protocol.md`), not `README.md` — the descriptive name reads better
-   in the file tree and when linked.
-2. **Nest when a concern grows.** A concern starts as one file at `src/` root
-   (like `peers.ts`); when it needs several files it graduates to a folder with
-   its own doc. Sub-folders are fine — each new folder gets its own doc.
-3. **Dependencies point downward.** Core (`config`/`state`/`peers`) depends on
-   nothing else here; feature folders depend on core and, at most, on layers
-   below them. `p2p` and `sync` reference each other only through runtime calls
-   (join → reconcile, watcher → nudge), never at module-load time.
+1. **Docs sit as close to the code as they need to.** A folder doc where a concern spans several
+   files; a file-level doc beside a module carrying dense reasoning of its own; neither where the
+   names already say enough. Name it for its contents, never `README.md`.
+2. **Nest when a concern grows.** A concern starts as one file at `src/` root (like `peers.ts`) and
+   graduates to a folder with its own doc once it needs several files.
+3. **Dependencies point downward.** Core (`config`/`state`/`peers`) depends on nothing else here;
+   feature folders depend on core and at most on layers below them. `p2p` and `sync` reference each
+   other only through runtime calls (join → reconcile, watcher → nudge), never at module load.
 
-Keeping these docs in sync with the code is a project rule for every contributor,
-human or AI agent — see [AGENTS.md](../AGENTS.md).
+Keeping these docs accurate is a rule for every contributor, human or agent — see
+[AGENTS.md](../AGENTS.md).
 
 ## Iron rules
 
-1. Stock Immich is never modified; all cleverness lives at the reverse proxy
-   or behind the public API.
-2. Every injected surface fails open — Immich must work perfectly with the
-   sidecar dead.
-3. The app only ever touches its own server's ordinary data.
-4. Ownership stays with the photo's taker: other households store nothing but
-   kilobyte placeholders — every pixel streams from its owner on demand and is
-   only ever STORED elsewhere when a user explicitly saves a photo to their
-   own library.
-5. Default-closed: no uninvited server can reach anything.
-6. **Reachability is never permission.** Every route assumes it is published to the open
-   internet. Human routes authenticate against the caller's own Immich session; peer
-   routes require a signature *and* an entitlement check. Nothing is protected by being
-   hard to find, on a private network, or behind a URL nobody has guessed.
-7. **The sidecar invents no identities and holds no logins.** The only identity that means
-   anything is an Immich one. The bot users that own the stubs get a narrowly-scoped API
-   key and no retained password, so they cannot be signed into at all.
+1. **Stock Immich is never modified.** All cleverness lives at the reverse proxy or behind the
+   public API.
+2. **Every injected surface fails open.** Immich must work perfectly with the sidecar dead.
+3. **The app only ever touches its own server's ordinary data.**
+4. **Ownership stays with the photo's taker.** Other households hold kilobyte placeholders; every
+   pixel streams from its owner on demand, and is stored elsewhere only when a user explicitly saves
+   it to their own library.
+5. **Default-closed.** No uninvited server reaches anything.
+6. **Reachability is never permission.** Every route assumes it is published to the open internet.
+   Human routes authenticate against the caller's own Immich session; peer routes require a
+   signature *and* an entitlement check. Nothing is protected by being hard to find, on a private
+   network, or behind a URL nobody has guessed.
+7. **The sidecar invents no identities and holds no logins.** The only identity that means anything
+   is an Immich one. The accounts that own stubs get a narrowly-scoped API key and no retained
+   password, so they cannot be signed into at all.
+
+**Where this falls short today:** the sidecar needs an all-permissions admin API key, so its blast
+radius is the whole instance. It also creates real user accounts — one per remote person — that
+appear in every picker, because Immich has no service-account flag. Both are known costs; do not
+make either worse without saying so.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,4 @@
-/**
- * immich-shared-albums — entry point / composition root.
- * One process: an HTTP server (protocol + panel + byte proxies) plus two sync loops.
- * State is SQLite via node:sqlite (see store.ts). TypeScript is run natively by Node's
- * type stripping — no build step. Node >= 23.6, zero dependencies.
- *
- * The code is split by concern — see each folder's .md:
- *   config.ts / state.ts / peers.ts   core: settings, persistence, P2P signing
- *   immich/                           local Immich API, refs, contributors, proxy writes
- *   p2p/                              wire protocol + join
- *   sync/                             reconcile + comment loops
- *   media/                            hotlink byte path + LRU cache
- *   web/                              HTML pages + HTTP router
- */
+/** index.ts — composition root: starts the HTTP server and the three sync loops. See ARCHITECTURE.md. */
 import { CFG, log } from './config.ts';
 import { server } from './web/server.ts';
 import { proxyUpgrade } from './web/upgrade.ts';


### PR DESCRIPTION
Applies the conventions from #20 to the top-level architecture doc, and fixes what checking every claim against the code turned up.

## Three claims that were false

| Claim | Reality |
|---|---|
| "a legacy `state.json` migrates automatically on boot" | That importer was removed in #16. Nothing in `src/` mentions `state.json`. |
| "**two** timers (the watch loop and the comment loop)" | `index.ts` starts **three** — `startWatchLoop`, `startCommentLoop`, `startInviteLoop`. The invite loop was missing entirely, so the doc never explained how invitations reach a member. |
| "no build step" | True for the server (`node index.ts`, native type stripping). The two front-end pages are Preact TSX bundled by esbuild — the bundles are committed, so deploying still builds nothing. The doc now distinguishes the two. |

Two sentences had also lost text mid-clause and read as nonsense: `~2KB unique STUB per photo **duration)** with capture date` and `Detected by listing albums as that account **(the admin key link-based sharing is broken for non-admins)**`. Both restored from what the code does.

## Verified rather than assumed

Claims I checked and kept: `watchOnce` really does end each cycle with `reconcileOnce` ([engine.ts:88](src/sync/engine.ts#L88)), entitlement's `offered` index and its throttled membership fallback, the shadow-DOM banner, immutable cache headers on the byte routes, the playable video prefix, and `package.json` having no runtime dependencies at all.

## Density

Prose drops from 94 lines to bullets and tables. The eleven long prose bullets under *Components* become nested facts, one per line; the loops become a table.

## Also

- The code layout tree was missing `invariants.test.ts`, `web/panel/`, `web/accept/` and `web/banner/`.
- The folder-doc convention now matches `AGENTS.md` — docs sit as close to the code as they need to, rather than strictly one per folder.
- **Boy-scout on `index.ts`**, the file this doc describes: a 13-line header block that duplicated the doc and repeated two of the same stale facts, now one line.

## Testing

`npm run verify` clean. No behaviour change — one comment and one markdown file.