### PR TITLE
fix: enforce the fast gate in code, not in instructions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,17 +1,11 @@
 #!/bin/sh
-# Fast gate on every commit: seconds, no containers. The e2e suite stays in CI and in
-# `bash demo/run-mock-e2e.sh` — putting a seven-minute run in a hook is how hooks get bypassed.
-#
-# Enable once per clone:  git config core.hooksPath .githooks
+# Fast gate on every commit: seconds, no containers. The e2e suite stays in CI —
+# a seven-minute hook is a hook people bypass.
+# Enabled automatically by `npm install` (the prepare script sets core.hooksPath).
 set -e
-echo "pre-commit: panel bundle, format check, lint, typecheck, cycles"
-# Rebuild the committed panel bundle, then stage it: it is generated from src/web/panel/**, and a
-# stale copy would silently ship different UI than the source says.
-npm run --silent build:panel >/dev/null || { echo "  ✗ panel build failed"; exit 1; }
-git add src/web/panel.bundle.js
-npx prettier --check "src/**/*.ts" "scripts/**/*.mjs" >/dev/null || {
-  echo "  ✗ formatting — run: npm run format"; exit 1; }
-npx eslint src || exit 1
-npx tsc --noEmit || exit 1
-node scripts/check-cycles.mjs >/dev/null || exit 1
+echo "pre-commit: verify:fast (bundles, format, lint, types, cycles)"
+npm run --silent verify:fast || exit 1
+# The bundles are generated from src/web/{panel,accept}/** — stage what the build refreshed,
+# or the commit ships UI that differs from its source.
+git add src/web/panel.bundle.js src/web/accept.bundle.js
 echo "pre-commit: ok"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"*.json\"",
     "cycles": "node scripts/check-cycles.mjs",
     "test": "docker run --rm -e IMMICH_API_KEY=test-only -v \"$PWD/src\":/app/src -w /app node:24-alpine node --test \"src/**/*.test.ts\"",
-    "verify": "npm run build:panel && npm run format:check && npm run lint && npm run typecheck && npm run check:runtime && npm run cycles && npm test",
+    "verify": "npm run verify:fast && npm run check:runtime && npm test",
     "build:panel": "node scripts/build-panel.mjs",
-    "check:runtime": "docker run --rm -v \"$PWD/src\":/app/src -v \"$PWD/scripts\":/app/scripts -w /app node:24-alpine node scripts/check-runtime.mjs"
+    "check:runtime": "docker run --rm -v \"$PWD/src\":/app/src -v \"$PWD/scripts\":/app/scripts -w /app node:24-alpine node scripts/check-runtime.mjs",
+    "verify:fast": "npm run build:panel && npm run format:check && npm run lint && npm run typecheck && npm run cycles",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",


### PR DESCRIPTION
Applies the rule that anything enforceable in code must not live as an instruction in AGENTS.md. Auditing what the doc *asks* against what code *enforces* found three gaps, one a real defect:

| Gap | Fix |
|---|---|
| The hook only runs if a contributor read AGENTS.md and ran `git config core.hooksPath .githooks` | `prepare` script — `npm install` enables it |
| The hook duplicated `verify`'s step list in shell, and had drifted from it | both now run the shared `verify:fast` script |
| **Defect:** `build:panel` compiles both bundles but the hook staged only `panel.bundle.js` — a commit touching `accept/` shipped a stale `accept.bundle.js` unless staged by hand | the hook stages both bundles |

`verify` becomes `verify:fast` + the container-based checks (`check:runtime`, `npm test`), so the hook stays seconds while CI keeps the full set.

## Testing
`npm run verify` clean; hook smoke-tested (`sh .githooks/pre-commit` → ok). No product code changed — `package.json` and the hook only.