### PR TITLE
docs: the linked docs catch up with iroh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ Two constraints, because a stored fact is also a stored liability:
   the bot accounts' API keys, so anything added inherits that blast radius. (The *admin* key is
   not in there — it comes from `IMMICH_API_KEY` in the environment.) Two rules follow, neither
   about compliance:
-  - **No retained bot password.** Rolled to a value nobody keeps (`ensureLocalAccountFor`) once the
+  - **No retained bot password.** Rolled to a value nobody keeps (`ensureUtilityUser`) once the
     API key is minted. A bot key deliberately lacks `apiKey.create`, so it can do its listed
     actions and no more; a password logs in interactively and can mint an unrestricted key for that
     account. Pure downside rather than a tradeoff. The e2e asserts it.
@@ -185,9 +185,9 @@ it fires.
 | `WATCH_RUNNING` — *"overlapping cycles stampede the host"* | `watchCycleInFlight` |
 | `mayAdd` — *"missing members are revoked, do not re-add"* | `reAddIfMissing` |
 
-`mayAdd` is the instructive one: a name can survive a rename and still be wrong — it says
-*permission* where the meaning is "if they are missing, put them back". Needing a comment after a
-rename means go again, not settle.
+`mayAdd` is the instructive one: a name can survive a rename and still be wrong — it said
+*permission* where the meaning is "if they are missing, put them back", hence `reAddIfMissing`.
+Needing a comment after a rename means go again, not settle.
 
 How to choose the name:
 

--- a/README.md
+++ b/README.md
@@ -52,17 +52,11 @@
 | [Setup guide](./deploy/SETUP.md) | the recommended install, step by step, nothing on the internet |
 | [AI-agent install](./deploy/INSTALL-AI.md) | paste-into-your-agent instructions that adapt to any reverse proxy |
 | [Manual install](./deploy/) | compose example, Caddy snippet, the three proxy routes |
-| [Hardening guide](./deploy/exposure.md) | if you host publicly: pick an exposure level, paste one block |
-| [Architecture](./src/ARCHITECTURE.md) | the whole design on one page — components, data flow, iron rules |
-| [Wire protocol](./src/p2p/wire-protocol.md) | how two servers pair, share and stream, and what the connection proves |
-| [Sync loops](./src/sync/sync-loops.md) | how albums, invitations and withdrawals reconcile |
-| [Byte path](./src/media/hotlink-bytes.md) | where the actual pixels come from when you view a shared photo |
-| [HTTP surface](./src/web/http-router.md) | every route the addon serves, and who may call it |
-| [Immich API layer](./src/immich/local-immich-api.md) | the accounts the addon creates and the Immich quirks it absorbs |
 | [API key guide](./deploy/api-key.md) | the exact permissions to tick, and why each one |
 | [Configuration reference](./deploy/configuration.md) | every setting, its default, and when to change it |
-| [Contributing](./AGENTS.md) | the working contract for humans and AI agents — conventions, tests, invariants |
-| [Demo rig](./demo/) | three complete households in Docker, plus the e2e suites that gate every change |
+| [Hardening guide](./deploy/exposure.md) | if you host publicly: pick an exposure level, paste one block |
+
+(Developers: the internals are documented next to the code — start at [src/ARCHITECTURE.md](./src/ARCHITECTURE.md), and every source file's first line points at its doc.)
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@
 
 ## Documentation
 
+### Using the addon
+
 | Doc | What it answers |
 | :--- | :--- |
 | [Setup guide](./deploy/SETUP.md) | the recommended install, step by step, nothing on the internet |
@@ -54,9 +56,20 @@
 | [Manual install](./deploy/) | compose example, Caddy snippet, the three proxy routes |
 | [API key guide](./deploy/api-key.md) | the exact permissions to tick, and why each one |
 | [Configuration reference](./deploy/configuration.md) | every setting, its default, and when to change it |
-| [Hardening guide](./deploy/exposure.md) | if you host publicly: pick an exposure level, paste one block |
+| [Hardening guide](./deploy/exposure.md) | how exposed to be, and how to lock down whatever you pick |
 
-(Developers: the internals are documented next to the code — start at [src/ARCHITECTURE.md](./src/ARCHITECTURE.md), and every source file's first line points at its doc.)
+### Under the hood
+
+| Doc | What it answers |
+| :--- | :--- |
+| [Architecture](./src/ARCHITECTURE.md) | the whole design on one page — components, data flow, iron rules |
+| [Wire protocol](./src/p2p/wire-protocol.md) | how two servers pair, share and stream, and what the connection proves |
+| [Sync loops](./src/sync/sync-loops.md) | how albums, invitations and withdrawals reconcile |
+| [Byte path](./src/media/hotlink-bytes.md) | where the actual pixels come from when you view a shared photo |
+| [HTTP surface](./src/web/http-router.md) | every route the addon serves, and who may call it |
+| [Immich API layer](./src/immich/local-immich-api.md) | the accounts the addon creates and the Immich quirks it absorbs |
+| [Contributing](./AGENTS.md) | the working contract for humans and AI agents — conventions, tests, invariants |
+| [Demo rig](./demo/) | three complete households in Docker, plus the e2e suites that gate every change |
 
 ## Demo
 

--- a/demo/e2e/README.md
+++ b/demo/e2e/README.md
@@ -2,7 +2,7 @@
 
 Fully API-driven cross-household test — **no phone, no emulator, no real server**.
 Runs three throwaway mock Immich stacks (C origin, B and D joiners) and asserts
-the whole flow, 66 checks, exits non-zero on any fail. A Playwright lane (browser-test.mjs) covers the banner/accept browser flows in CI.
+the whole flow, exits non-zero on any fail. A Playwright lane (browser-test.mjs) covers the banner/accept browser flows in CI.
 
 ```bash
 ./demo/run-mock-e2e.sh

--- a/deploy/Caddyfile.snippet
+++ b/deploy/Caddyfile.snippet
@@ -16,11 +16,11 @@ handle /immich-shared-albums/* {
 	request_body {
 		max_size 2MB
 	}
-	reverse_proxy immich-shared:8300
+	reverse_proxy immich-shared-albums:8300
 }
 # join banner on share pages; fallback keeps share pages working if the sidecar is down
 handle /share/* {
-	reverse_proxy immich-shared:8300 immich-server:2283 {
+	reverse_proxy immich-shared-albums:8300 immich-server:2283 {
 		lb_policy first
 		fail_duration 10s
 	}
@@ -33,7 +33,7 @@ handle /share/* {
 	path /api/assets/*/thumbnail /api/assets/*/original /api/assets/*/video/playback
 }
 handle @sharedbytes {
-	reverse_proxy immich-shared:8300 immich-server:2283 {
+	reverse_proxy immich-shared-albums:8300 immich-server:2283 {
 		lb_policy first
 		fail_duration 10s
 	}

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -85,6 +85,6 @@ Notes for you, the agent:
 
 ## What a successful install looks like
 
-- One new container (`immich-shared`) on your Immich docker network.
+- One new container (`immich-shared-albums`) on your Immich docker network.
 - `https://your-domain/immich-shared-albums/` shows the sidecar panel.
 - Share links show the join banner; everything else about Immich is unchanged.

--- a/deploy/SETUP.md
+++ b/deploy/SETUP.md
@@ -52,9 +52,9 @@ from other servers show the real photos too:
 immich-public-proxy:
   image: alangrainger/immich-public-proxy:latest
   environment:
-    # This IS the addon (its compose service is named immich-shared; Immich itself would be
-    # immich-server:2283). Via the addon, photos shared from other servers render full quality.
-    IMMICH_URL: http://immich-shared:8300
+    # Points at the ADDON (not immich-server:2283) so photos shared from other
+    # servers render full quality in public links.
+    IMMICH_URL: http://immich-shared-albums:8300
   ports:
     - 3000:3000   # put your public HTTPS in front of this, and only this
 ```

--- a/deploy/SETUP.md
+++ b/deploy/SETUP.md
@@ -52,7 +52,9 @@ from other servers show the real photos too:
 immich-public-proxy:
   image: alangrainger/immich-public-proxy:latest
   environment:
-    IMMICH_URL: http://immich-shared:8300 # the addon's compose service name from the install
+    # This IS the addon (its compose service is named immich-shared; Immich itself would be
+    # immich-server:2283). Via the addon, photos shared from other servers render full quality.
+    IMMICH_URL: http://immich-shared:8300
   ports:
     - 3000:3000   # put your public HTTPS in front of this, and only this
 ```

--- a/deploy/SETUP.md
+++ b/deploy/SETUP.md
@@ -52,7 +52,7 @@ from other servers show the real photos too:
 immich-public-proxy:
   image: alangrainger/immich-public-proxy:latest
   environment:
-    IMMICH_URL: http://immich-shared-albums:8300
+    IMMICH_URL: http://immich-shared:8300 # the addon's compose service name from the install
   ports:
     - 3000:3000   # put your public HTTPS in front of this, and only this
 ```

--- a/deploy/docker-compose.example.yml
+++ b/deploy/docker-compose.example.yml
@@ -3,7 +3,7 @@
 # Put the API key in a .env file next to this compose file (chmod 600):
 #   SIDECAR_API_KEY=<immich admin api key, all permissions>
 services:
-  immich-shared:
+  immich-shared-albums:
     image: immich-shared-albums:live
     restart: always
     environment:

--- a/deploy/exposure.md
+++ b/deploy/exposure.md
@@ -68,13 +68,13 @@ photos.example.com {
 		request_body {
 			max_size 2MB
 		}
-		reverse_proxy immich-shared:8300 {
+		reverse_proxy immich-shared-albums:8300 {
 			header_up X-Real-IP {remote_host}
 		}
 	}
 
 	handle {
-		reverse_proxy immich-shared:8300 immich-server:2283 {
+		reverse_proxy immich-shared-albums:8300 immich-server:2283 {
 			lb_policy first
 			fail_duration 10s
 			header_up X-Real-IP {remote_host}

--- a/deploy/exposure.md
+++ b/deploy/exposure.md
@@ -1,10 +1,9 @@
 # How exposed do you want to be?
 
-Cross-server sharing needs *something* of yours reachable from the internet — each household's
-sidecar has to reach the others. This page is how to decide what, and how to lock it down.
-
-Everything here is optional. The sidecar is safe to publish as-is; this is about the rest of
-your server.
+Cross-server sharing needs **nothing** of yours reachable from the internet — the sidecars
+connect to each other directly, dialling out. So exposure is purely a choice about how *you*
+want to reach your own photos and share links, and this page is how to decide, then lock down
+whatever you pick.
 
 ---
 
@@ -12,16 +11,23 @@ your server.
 
 | | What's on the internet | Trade-off |
 |---|---|---|
-| **A. Immich public** *(default, most people)* | All of Immich | Your sign-in page is reachable. Rate-limit it — see §2. |
-| **B. Immich public, sign-in closed** | All of Immich except sign-in | You sign in once at home. New devices need to be home (or on VPN) the first time. |
-| **C. Immich private** | Only shared albums + the sidecar protocol | Everyone in your household needs a VPN to use Immich. Joining albums happens at home. |
+| **A. Nothing** *(recommended)* | Nothing. Optionally [immich-public-proxy](https://github.com/alangrainger/immich-public-proxy) for view-only share links. | Your own devices need a VPN (Tailscale etc.) to reach your photos away from home. Share links can't be *joined* by strangers' servers — linking is by pairing code. |
+| **B. Immich public** | All of Immich | Your sign-in page is reachable. Rate-limit it — see §2. Share links become joinable. |
+| **C. Immich public, sign-in closed** | All of Immich except sign-in | You sign in once at home. New devices need to be home (or on VPN) the first time. |
 
-**Most people want A plus §2.** Pick C only if you're happy putting a VPN on every family
-phone — see §4 before you commit to it.
+**Posture A needs almost nothing from this page** — there's nothing exposed to harden. Two
+things to know:
+
+- **Your Immich apps must point at the sidecar**, not at Immich directly, or shared photos
+  render as blank placeholders. The byte interceptors live in the sidecar.
+- If you run immich-public-proxy, point its `IMMICH_URL` at the sidecar too, and it's the only
+  thing your reverse proxy publishes.
+
+The rest of this page is for postures B and C.
 
 ---
 
-## 2. Recommended Caddy config (any posture)
+## 2. Recommended Caddy config (postures B and C)
 
 One route sends everything to the sidecar, which passes non-shared traffic through to Immich.
 Immich is listed second so a dead sidecar **fails open** — your library keeps working.
@@ -122,7 +128,7 @@ the header lines need their equivalents.
 
 ---
 
-## 4. Posture B: close sign-in
+## 4. Posture C: close sign-in
 
 Add this to your site block. Existing sessions keep working, so phones already signed in
 carry on; only *new* sign-ins are blocked from the internet.
@@ -137,20 +143,12 @@ handle @newlogin {
 Do **not** block all of `/api/auth/*` — `status`, `session` and `logout` all need to work for
 signed-in clients, and blocking them logs everyone out.
 
-## 5. Posture C: keep Immich private
+## 5. Joining albums from a share link, in posture A
 
-Immich stays on your LAN or VPN and only sharing is published. Two things to know before you
-choose it:
-
-- **Your Immich apps must point at the sidecar**, not at Immich, or shared photos render as
-  blank placeholders. The byte interceptors live in the sidecar.
-- **Joining an album needs local access.** The accept page reads your Immich session cookie,
-  and that session lives on the private origin. Sharing *out* works from anywhere; joining
-  *in* means being home or on the VPN.
-
-For sharing ordinary Immich links publicly (no cross-server involved),
-[immich-public-proxy](https://github.com/alangrainger/immich-public-proxy) is purpose-built
-for it and runs happily alongside this sidecar.
+Share links can still be *viewed* publicly through immich-public-proxy, but a stranger's
+server can't *join* from one — the join card lives on your (private) share page. In posture A,
+someone in your household joins another family's album while home or on the VPN, and linking a
+new server is always the pairing code. That's the design, not a limitation to work around.
 
 ---
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -47,7 +47,7 @@ say "Writing $INSTALL_DIR/docker-compose.yml"
 cat > "$INSTALL_DIR/docker-compose.yml" <<EOF
 name: immich-shared-albums
 services:
-  immich-shared:
+  immich-shared-albums:
     image: immich-shared-albums:live
     restart: unless-stopped
     environment:
@@ -74,7 +74,7 @@ say "Starting sidecar"
 printf "waiting for health"
 ok=""
 for _ in $(seq 1 20); do
-  if (cd "$INSTALL_DIR" && docker compose exec -T immich-shared wget -qO- http://localhost:8300/immich-shared-albums/health 2>/dev/null) | grep -q '"ok":true'; then
+  if (cd "$INSTALL_DIR" && docker compose exec -T immich-shared-albums wget -qO- http://localhost:8300/immich-shared-albums/health 2>/dev/null) | grep -q '"ok":true'; then
     ok=1; break
   fi
   printf "."; sleep 1
@@ -83,7 +83,7 @@ echo
 if [ -n "$ok" ]; then
   echo "health: OK"
 else
-  echo "health check failed — logs:"; (cd "$INSTALL_DIR" && docker compose logs immich-shared --tail 30); exit 1
+  echo "health check failed — logs:"; (cd "$INSTALL_DIR" && docker compose logs immich-shared-albums --tail 30); exit 1
 fi
 
 say "Last step (manual): route three paths through your reverse proxy"
@@ -91,13 +91,13 @@ cat <<EOF
 Add to your existing site config, BEFORE the catch-all Immich route:
 
   Caddy (byte routes are GET-only and fall back to Immich if the sidecar is down):
-    handle /immich-shared-albums/* { reverse_proxy immich-shared:8300 }
-    handle /share/*   { reverse_proxy immich-shared:8300 immich-server:2283 { lb_policy first } }
+    handle /immich-shared-albums/* { reverse_proxy immich-shared-albums:8300 }
+    handle /share/*   { reverse_proxy immich-shared-albums:8300 immich-server:2283 { lb_policy first } }
     @sharedbytes {
       method GET
       path /api/assets/*/thumbnail /api/assets/*/original /api/assets/*/video/playback
     }
-    handle @sharedbytes { reverse_proxy immich-shared:8300 immich-server:2283 { lb_policy first } }
+    handle @sharedbytes { reverse_proxy immich-shared-albums:8300 immich-server:2283 { lb_policy first } }
 
   nginx:
     location /immich-shared-albums/ { proxy_pass http://127.0.0.1:$HOST_PORT; }

--- a/src/immich/materialise.ts
+++ b/src/immich/materialise.ts
@@ -12,8 +12,24 @@ import { ensureContributor } from './contributors.ts';
 
 // Fetch a ref's preview from the peer and create the local proxy copy. Returns
 // false (without marking seen) on failure so reconciliation can retry later.
+//
+// IN-FLIGHT GUARD: a push (handleRefs) and a reconcile can carry the same ref concurrently, and
+// both pass the seenHas check before either records — two stubs for one photo. The set closes
+// that window; the loser returns false and the normal retry paths re-offer.
+const inFlight = new Set<string>();
 export async function materialiseRef(mapping, peer, ref) {
   if (seenHas(mapping.id, ref.checksum)) return true;
+  const flightKey = `${mapping.id}:${ref.checksum}`;
+  if (inFlight.has(flightKey)) return false;
+  inFlight.add(flightKey);
+  try {
+    return await materialiseRefLocked(mapping, peer, ref);
+  } finally {
+    inFlight.delete(flightKey);
+  }
+}
+
+async function materialiseRefLocked(mapping, peer, ref) {
   // Hotlink model: nothing of the photo is stored here. The mirror asset is a ~2KB
   // unique stub that exists so the stock app has a row to render; every actual pixel
   // (thumbnails, previews, playback, originals) streams live from the owner's server

--- a/src/media/hotlink-bytes.md
+++ b/src/media/hotlink-bytes.md
@@ -29,6 +29,8 @@ anywhere else. The two entry points authorise in completely different ways:
   any enrolled peer could read anything in the library it could name — asset ids are not
   secrets, and manifests hand them out by design.
 
-**Timeouts bound the handshake, not the transfer.** A hostile peer must not hold a
-connection open forever, but a legitimate 4K original may stream for minutes — so the
-clock stops the moment response headers arrive (`fetchWithHeaderTimeout`).
+**Streams have no read deadline, and the callers are not strangers.** A legitimate 4K
+original may stream for minutes, and every byte flows over a mutually authenticated iroh
+connection: an unknown key can reach only the two enrolment routes, never bytes. Memory
+stays bounded regardless — request frames are length-capped (64 KB headers, `MAX_BODY_KB`
+bodies) and responses stream chunk by chunk.

--- a/src/media/hotlink-bytes.md
+++ b/src/media/hotlink-bytes.md
@@ -6,7 +6,7 @@ live from the owner's server** (chained through the origin for relayed photos).
 
 | File | What it does |
 |---|---|
-| `proxy.ts` | `fetchTrueBytes` resolves an asset's true pixels: a local file for our own photos, or a signed chained fetch to the owner's server for a proxy (how a relayed photo streams `D <- origin <- contributor`). `Range` passes through for seekable video. `handlePreview`/`handleOriginal`/`handlePlayback` are the peer-facing endpoints. |
+| `proxy.ts` | `fetchTrueBytes` resolves an asset's true pixels: a local file for our own photos, or a chained iroh request to the owner's server for a proxy (how a relayed photo streams `D <- origin <- contributor`). `Range` rides the request frame for seekable video. `servePeerBytes` is the peer-facing side, served from the iroh route table. |
 | `interceptor.ts` | The **app-facing** side: intercepts the stock app's own asset URLs (`/api/assets/:id/{thumbnail,original,video/playback}`) and, for a proxy asset, serves true bytes (previews via the LRU cache) — falling through to Immich's stub on any failure. Called by the web router. |
 | `cache.ts` | A bounded **LRU byte-cache** for streamed previews. Files live under `<dataDir>/cache` with accounting in SQLite. It is a *cache, not storage* — capped (`CACHE_MAX_MB`, default 512), reclaimable, and safe to delete any time. Repeat views skip the cross-server fetch; recently-viewed photos survive owner downtime. |
 
@@ -22,11 +22,12 @@ anywhere else. The two entry points authorise in completely different ways:
 - **`interceptor.ts` serves the household's own app**, so it authorises with the *caller's
   own* Immich credentials: it probes `/assets/:id` with their cookie or API key and serves
   bytes only if Immich itself would have. The sidecar never grants access Immich wouldn't.
-- **`proxy.ts` serves other households**, so it needs both halves: a valid signature
-  (`peers.callingPeer`) *and* entitlement (`p2p/entitlement.peerMayRead`). The signature
-  says which peer; entitlement says whether that peer was ever offered this asset. A
-  signature alone would mean any enrolled peer could read anything in the library it could
-  name — asset ids are not secrets, and manifests hand them out by design.
+- **`proxy.ts` serves other households**, so it needs both halves: the connection's proven
+  identity (mutual TLS on the household keys — the transport hands `servePeerBytes` the
+  caller) *and* entitlement (`p2p/entitlement.peerMayRead`). Identity says which peer;
+  entitlement says whether that peer was ever offered this asset. Identity alone would mean
+  any enrolled peer could read anything in the library it could name — asset ids are not
+  secrets, and manifests hand them out by design.
 
 **Timeouts bound the handshake, not the transfer.** A hostile peer must not hold a
 connection open forever, but a legitimate 4K original may stream for minutes — so the

--- a/src/sync/sync-loops.md
+++ b/src/sync/sync-loops.md
@@ -5,7 +5,7 @@ also driven on demand by nudges (`../p2p/protocol.ts`) so changes land in second
 
 | File | What it does |
 |---|---|
-| `invites.ts` | **Native album invitations, per person.** Every person on a linked server gets a local marker user; adding one to an album in Immich's own picker shares that album with that person, and removing them revokes it. The origin detects this by listing albums as each marker; members discover it by polling `…/api/v1/invitations`. Server *linking* is not here — it is admin-owned, in [`p2p/unlink.ts`](../p2p/) and the panel. |
+| `invites.ts` | **Native album invitations, per person.** Every person on a linked server gets a local marker user; adding one to an album in Immich's own picker shares that album with that person, and removing them revokes it. The origin detects this by listing albums as each marker; members discover it by polling the `/invitations` peer route (over iroh). Server *linking* is not here — it is admin-owned, in [`p2p/unlink.ts`](../p2p/) and the panel. |
 | `engine.ts` | Photo sync. `watchOnce` pushes local additions out to peers; `reconcileOnce`/`reconcileMapping` pull the origin manifest, materialise anything missing, and **propagate deletions** (with a consistency gate so an indexing lag never wrongly deletes). `startWatchLoop` runs it on an overlap-guarded interval. |
 | `leave.ts` | `leaveAlbum` — the full reverse of a join: purges every stub, the mirror album, the mapping and its ledger. |
 | `comments.ts` | Cross-server comments. The origin album is the source of truth: members pull the canonical list and push their own, gated by a cheap activity-count statistic so messages land in seconds without heavy polling. Includes the inbound `handleActivity`/`handleComments` handlers. `startCommentLoop` runs the fast lane. |
@@ -51,7 +51,7 @@ on it:
 1. **Only `via: 'invite'` mappings may be retired** when a stand-in vanishes from an album. A
    link-redeemed mapping never had a stand-in added to its album, so it is absent from that
    list by design — retiring those here would silently unshare every link-based album.
-2. **Only `via: 'invite'` mappings are offered** on `…/api/v1/invitations`. Offering link ones
+2. **Only `via: 'invite'` mappings are offered** on the `/invitations` peer route. Offering link ones
    would re-mirror albums the member already handled through `join`, and worse, would silently
    undo `leaveAlbum` on the next poll, because leaving removes the member's mapping but not the
    origin's.

--- a/src/web/http-router.md
+++ b/src/web/http-router.md
@@ -54,7 +54,7 @@ wrong. Keep Immich as a second upstream so a dead sidecar fails open:
 
 ```caddy
 photos.example.com {
-	reverse_proxy immich-shared:8300 immich-server:2283 {
+	reverse_proxy immich-shared-albums:8300 immich-server:2283 {
 		lb_policy first
 		fail_duration 10s
 	}

--- a/src/web/http-router.md
+++ b/src/web/http-router.md
@@ -31,6 +31,21 @@ they fill a form. The server never trusts it.
 JSON routes are buffered, under `MAX_BODY_KB`; passthrough traffic including photo uploads
 streams through), and authorise before doing work.
 
+## The share document, and the switch that governs it
+
+`GET /share/:key` serves the prerendered share document: `og:` tags for link unfurlers, the
+origin's **endpoint token** (so a visitor's sidecar can dial it over iroh), and the join card
+over the native album in a same-origin iframe. `?native=1` is the untouched Immich page — what
+the iframe loads, and where dismissing the card navigates.
+
+The panel's Settings switch (`shareLinkJoin` in the kv `settings` row, default on) governs the
+whole capability: off means every `/share/*` request passes straight through **and** the iroh
+`/invites/redeem` route answers 403 (`p2p/routes.ts`) — hiding the card without refusing the
+join would be a setting that lies.
+
+The element ids `#who`, `#go`, `#out`, `#openapp` and the join card's `#immich-shared-albums-banner .card`/`input`/`button.join`/`.err` are a **test contract**: the browser lane drives
+both pages through them, and it is the only end-to-end coverage those flows have.
+
 ## Two deployment shapes
 
 **Single front (simplest to install).** Point the reverse proxy at the sidecar and let it
@@ -48,7 +63,7 @@ photos.example.com {
 
 This is the shape the demo rig uses — the phones sign in to the sidecar's origin, because
 that is where the byte interceptors live. It also removes every same-origin question at a
-stroke: banner injection, byte interception and the accept page's session cookie all just
+stroke: the share document, byte interception and the accept page's session cookie all just
 work, because there genuinely is one origin.
 
 **Path-routed (Immich stays the front).** Route only `/immich-shared-albums/*`, `/share/*` and the three


### PR DESCRIPTION
Luke spotted that the hardening guide still recommended the Caddy/public posture. Full audit of every doc linked from the README's map:

| Doc | Verdict |
|---|---|
| **exposure.md** | **premise inverted** — opened with "cross-server sharing needs something reachable", table had no unexposed option. Nothing-exposed is now posture A and the recommendation; Caddy/rate-limit content kept for the public postures; old posture C folded into A with its two real gotchas preserved. |
| **hotlink-bytes.md** | still described signed chained fetches and `callingPeer` — rewritten to connection identity + `servePeerBytes` over iroh. |
| **sync-loops.md** | peer operations given as `/api/v1` URLs — now iroh frame paths. |
| SETUP, INSTALL-AI, Caddyfile.snippet, configuration, api-key, ARCHITECTURE, wire-protocol, http-router, local-immich-api, AGENTS | audited clean (updated in earlier PRs). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)