### PR TITLE
fix: e2e flakes — duplicate-stub race, unlink-survivor miscount

### DIFF
--- a/demo/e2e/e2e-test.mjs
+++ b/demo/e2e/e2e-test.mjs
@@ -1115,9 +1115,11 @@ console.log('— stage: panel manages server links (unlink)');
     // Their photos leave with them. Everything these accounts owned was a proxy whose bytes
     // streamed from the peer, so once the link is gone the assets are unreachable and keeping
     // them would only scatter broken thumbnails through albums here.
-    check('no account for that server survives the unlink',
-          afterUsers.every(u => !/\(via /.test(u.name || '')),
-          afterUsers.map(u => u.name).join(', ') || '(none)');
+    // Scoped to the unlinked server: B may hold other live links (it pairs with D two stages
+    // up), and their people are allowed to appear here whenever the directory poll ticks.
+    const survivors = afterUsers.filter(u => (u.name || '').includes(`(via ${target.name}`));
+    check('no account for that server survives the unlink', survivors.length === 0,
+          survivors.map(u => u.name).join(', ') || '(none)');
     // SECURITY: deleting the accounts takes their album memberships with them, and nothing may be
     // left behind for a later re-link to misread as a fresh invitation.
     const leftBehind = [];

--- a/src/immich/materialise.ts
+++ b/src/immich/materialise.ts
@@ -12,8 +12,24 @@ import { ensureContributor } from './contributors.ts';
 
 // Fetch a ref's preview from the peer and create the local proxy copy. Returns
 // false (without marking seen) on failure so reconciliation can retry later.
+//
+// IN-FLIGHT GUARD: a push (handleRefs) and a reconcile can carry the same ref concurrently, and
+// both pass the seenHas check before either records — two stubs for one photo. The set closes
+// that window; the loser returns false and the normal retry paths re-offer.
+const inFlight = new Set<string>();
 export async function materialiseRef(mapping, peer, ref) {
   if (seenHas(mapping.id, ref.checksum)) return true;
+  const flightKey = `${mapping.id}:${ref.checksum}`;
+  if (inFlight.has(flightKey)) return false;
+  inFlight.add(flightKey);
+  try {
+    return await materialiseRefLocked(mapping, peer, ref);
+  } finally {
+    inFlight.delete(flightKey);
+  }
+}
+
+async function materialiseRefLocked(mapping, peer, ref) {
   // Hotlink model: nothing of the photo is stored here. The mirror asset is a ~2KB
   // unique stub that exists so the stock app has a row to render; every actual pixel
   // (thumbnails, previews, playback, originals) streams live from the owner's server


### PR DESCRIPTION
Two independent e2e flakes, both root-caused:

## 1. Duplicate-stub race (code fix)
A push notification and the reconcile poll could materialise the same ref twice: `handleRefs` runs outside the `RECONCILING` mutex, so both paths passed the `seenHas` check before either recorded the checksum. Signature was the mirror count sitting one high (10 want 9) and ping-ponging. Fixed with an in-flight set keyed on `mapping.id:checksum` — the second caller backs off and the next reconcile pass settles it. Struck ~50% of runs before; hasn't reproduced since.

## 2. Unlink-survivor miscount (test fix)
The unlink stage unlinks C, then asserted **no** `(via ...)` account survives — but B legitimately still holds its link to D from the pairing stage two blocks up. Whenever D's directory poll ticked before the check, D's people appeared (correctly) and were miscounted as C-unlink survivors. The check is now scoped to accounts from the server actually unlinked. Struck ~1 in 3 soaks.

## Verification
- 3× consecutive full-suite soaks with both fixes: 148/148 each.
- One additional clean pre-commit soak of fix 1 alone before fix 2 existed.
- CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)