### PR TITLE
feat(install): IPP option, proxy choice, installer accuracy sweep

### DIFF
--- a/deploy/Caddyfile.snippet
+++ b/deploy/Caddyfile.snippet
@@ -18,7 +18,7 @@ handle /immich-shared-albums/* {
 	}
 	reverse_proxy immich-shared-albums:8300
 }
-# join banner on share pages; fallback keeps share pages working if the sidecar is down
+# join card on share pages; fallback keeps share pages working if the sidecar is down
 handle /share/* {
 	reverse_proxy immich-shared-albums:8300 immich-server:2283 {
 		lb_policy first

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -47,8 +47,12 @@ INSTALL:
    Immich docker network with env IMMICH_URL, IMMICH_API_KEY (in a chmod-600
    .env file, never in the yml), HOUSEHOLD_NAME, and a ./data
    volume for /data. Start it with docker compose up -d.
-3. Add these three routes to my reverse proxy BEFORE the catch-all Immich route,
-   then reload the proxy:
+3. If I have NO reverse proxy, skip the routes entirely: the sidecar is itself a
+   front for Immich — everything that isn't shared-album traffic passes through,
+   websockets included. Just tell me to point my Immich apps and browser at the
+   sidecar's port instead of Immich's.
+   Otherwise, add these three routes to my reverse proxy BEFORE the catch-all
+   Immich route, then reload the proxy:
      /immich-shared-albums/*                                       -> sidecar :8300
      /share/*                                         -> sidecar :8300 (fallback: immich)
      GET /api/assets/*/{thumbnail,original,video/playback} -> sidecar :8300 (fallback: immich)

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -36,9 +36,10 @@ ASK ME (only these):
    immich-public-proxy in the same compose file, with
    IMMICH_URL: http://immich-shared-albums:8300 (the addon, NOT immich-server —
    that is what makes photos shared from other servers render full quality),
-   and tell me the two follow-ups: put my public HTTPS in front of only the
-   proxy's port, and set Immich's Administration -> Settings -> Server ->
-   External domain to that public address.
+   and tell me the two follow-ups: make only the proxy's port publicly
+   reachable (my choice how — its own README covers the common setups), and set
+   Immich's Administration -> Settings -> Server -> External domain to that
+   public address.
 
 INSTALL:
 1. git clone https://github.com/lukeet332/immich-shared-albums

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -25,12 +25,20 @@ DISCOVER (do this yourself, don't ask me):
 3. Confirm docker and git are available.
 
 ASK ME (only these):
-1. My public Immich URL (e.g. https://photos.example.com).
-2. A household name to show to peers (e.g. "The Smith household").
-3. An Immich admin API key with ALL permissions — I create it in
-   Immich web -> Account Settings -> API Keys -> New API Key -> tick everything.
-   (If password login is disabled on my server because I use OAuth, warn me the
-   sidecar will briefly toggle it during utility-user provisioning.)
+1. A household name to show to peers (e.g. "The Smith household").
+2. An Immich admin API key. I create it in Immich web -> Account Settings ->
+   API Keys -> New API Key, ticking exactly the permissions listed in
+   deploy/api-key.md of the repo (read it; 'all' also works but is broader than
+   needed). The addon verifies the key at startup and logs anything missing.
+   (If password login is disabled on my server because I use OAuth, tell me the
+   scoped list needs systemConfig.read+update added, and why.)
+3. Whether I want PUBLIC view-only share links. If yes, also install
+   immich-public-proxy in the same compose file, with
+   IMMICH_URL: http://immich-shared-albums:8300 (the addon, NOT immich-server —
+   that is what makes photos shared from other servers render full quality),
+   and tell me the two follow-ups: put my public HTTPS in front of only the
+   proxy's port, and set Immich's Administration -> Settings -> Server ->
+   External domain to that public address.
 
 INSTALL:
 1. git clone https://github.com/lukeet332/immich-shared-albums
@@ -49,20 +57,23 @@ INSTALL:
    Show me the exact diff before applying it.
 
 VERIFY (all three, report results):
-1. GET <public-url>/immich-shared-albums/health returns {"ok":true,...}.
-2. Any Immich share link opened in a browser shows the
-   "Join shared album with your server?" banner over the working share page.
-3. The share page itself still fully loads (photos render behind the banner).
+1. GET <immich-address>/immich-shared-albums/health returns {"ok":true,...}
+   (use whatever address serves my Immich — LAN is fine; nothing needs to be public).
+2. Any Immich share link opened in a browser shows the "Join shared album with
+   your server?" card, with the album visible behind it.
+3. <immich-address>/immich-shared-albums/ (signed in as an Immich admin) shows
+   the panel with a "Create pairing link" button.
 
 ROLLBACK (if anything fails): docker compose down the sidecar, revert the proxy
 diff, reload the proxy — Immich itself is untouched throughout.
 
-4. If my Immich is reachable from the public internet, set REQUIRE_SHARE_PASSWORD=true
-   and ALLOW_PRIVATE_PEERS=false in the sidecar env, and tell me what each one
-   changes. Skip both if I am only reachable over a LAN or a tailnet.
-5. Read deploy/exposure.md and offer me the hardening from section 2 (access log,
-   rate limiting, security headers) as a diff I can approve. Do not apply it
-   without showing me first.
+AFTER INSTALL:
+1. If my Immich is reachable from the public internet, set
+   REQUIRE_SHARE_PASSWORD=true in the sidecar env and tell me what it changes;
+   then read deploy/exposure.md and offer me its posture-C hardening (access
+   log, rate limiting, security headers) as a diff I can approve. Do not apply
+   anything without showing me first. If nothing of mine is public, say so and
+   skip this.
 
 Notes for you, the agent:
 - The sidecar is additive and fail-open: if it dies, only the banner and

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -76,7 +76,7 @@ AFTER INSTALL:
    skip this.
 
 Notes for you, the agent:
-- The sidecar is additive and fail-open: if it dies, only the banner and
+- The sidecar is additive and fail-open: if it dies, only the share-page join card and
   cross-server sync stop; Immich keeps working. Never modify Immich's own
   compose services, database, or upload folders.
 - State lives in the ./data volume (state.db: household keypair, peers, album

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -74,11 +74,11 @@ diff, reload the proxy — Immich itself is untouched throughout.
 
 AFTER INSTALL:
 1. If my Immich is reachable from the public internet, set
-   REQUIRE_SHARE_PASSWORD=true in the sidecar env and tell me what it changes;
-   then read deploy/exposure.md and offer me its posture-C hardening (access
-   log, rate limiting, security headers) as a diff I can approve. Do not apply
-   anything without showing me first. If nothing of mine is public, say so and
-   skip this.
+   REQUIRE_SHARE_PASSWORD=true in the sidecar env and tell me what it changes,
+   and point me at Immich's own hardening guidance — hosting is theirs to
+   document, and the sidecar adds no public surface beyond its own routes
+   (deploy/exposure.md has the details). If nothing of mine is public, say so
+   and skip this.
 
 Notes for you, the agent:
 - The sidecar is additive and fail-open: if it dies, only the share-page join card and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,46 @@
+# Installing the addon
+
+Three ways in, easiest first:
+
+- **AI agent** — point Claude Code, Cursor or similar at [INSTALL-AI.md](./INSTALL-AI.md). It
+  inspects your actual setup and adapts, including your reverse proxy config.
+- **Script** — `bash deploy/install.sh` from a clone of this repo. It detects your Immich,
+  asks a handful of questions and starts the addon. It can also set up
+  [immich-public-proxy](https://github.com/alangrainger/immich-public-proxy) for public
+  share links, and a Caddy front if you don't run a reverse proxy yet.
+- **By hand** — the rest of this page.
+
+Whichever route you take, the step-by-step walkthrough with screenshots-level detail is
+[SETUP.md](./SETUP.md), and nothing needs to be reachable from the internet.
+
+## Manual install
+
+1. **Build the image** from a clone of this repo:
+
+   ```sh
+   docker build -t immich-shared-albums:live .
+   ```
+
+2. **Create the API key.** In Immich web, signed in as an admin: *Account Settings → API Keys
+   → New API Key*, ticking the permissions in [api-key.md](./api-key.md) (`all` also works but
+   is broader than needed). The addon verifies the key at startup and logs anything missing.
+
+3. **Start the container** with [docker-compose.example.yml](./docker-compose.example.yml) —
+   it joins your Immich docker network and holds the key in a `.env` file. Every setting is
+   documented in [configuration.md](./configuration.md).
+
+4. **Put it in front of Immich** so the stock apps see shared photos. Two shapes:
+
+   - **Single front (simplest):** point your apps — or your reverse proxy — at the addon's
+     port instead of Immich's. It passes everything that isn't shared-album traffic straight
+     through, websockets included, and Immich stays reachable directly as an escape hatch.
+     The Caddy version of this is in [exposure.md §2](./exposure.md).
+   - **Three routes:** keep your proxy pointed at Immich and add the routes in
+     [Caddyfile.snippet](./Caddyfile.snippet) (they translate 1:1 to nginx/Traefik/NPM).
+
+5. **Verify.** In a web browser, signed in to Immich as an admin, open
+   `https://<your-immich>/immich-shared-albums/` — the admin panel with *Create pairing link*
+   means everything works.
+
+Uninstalling is `docker compose down` plus removing whatever proxy lines you added — the
+addon never modifies Immich itself.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,7 +7,7 @@ Three ways in, easiest first:
 - **Script** — `bash deploy/install.sh` from a clone of this repo. It detects your Immich,
   asks a handful of questions and starts the addon. It can also set up
   [immich-public-proxy](https://github.com/alangrainger/immich-public-proxy) for public
-  share links, and a Caddy front if you don't run a reverse proxy yet.
+  share links.
 - **By hand** — the rest of this page.
 
 Whichever route you take, the step-by-step walkthrough with screenshots-level detail is

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,7 +34,8 @@ Whichever route you take, the step-by-step walkthrough with screenshots-level de
    - **Single front (simplest):** point your apps — or your reverse proxy — at the addon's
      port instead of Immich's. It passes everything that isn't shared-album traffic straight
      through, websockets included, and Immich stays reachable directly as an escape hatch.
-     The Caddy version of this is in [exposure.md §2](./exposure.md).
+     Any Immich hosting guide applies as written — just use the addon's port where it says
+     Immich's ([exposure.md](./exposure.md) has the full story).
    - **Three routes:** keep your proxy pointed at Immich and add the routes in
      [Caddyfile.snippet](./Caddyfile.snippet) (they translate 1:1 to nginx/Traefik/NPM).
 

--- a/deploy/SETUP.md
+++ b/deploy/SETUP.md
@@ -41,7 +41,8 @@ account. Remove them from the album to unshare; unlink the server in the panel t
 
 ## 4. Optional: view-only links for people without a server
 
-Grandma doesn't run Immich — she just wants to *look*. Add
+Grandma doesn't run Immich — she just wants to *look*. The install script offers to set this
+up for you (answer **y** when it asks about share links); by hand, add
 [immich-public-proxy](https://github.com/alangrainger/immich-public-proxy) as the one small public
 piece. It shows Immich share links as a read-only gallery and exposes nothing else.
 

--- a/deploy/docker-compose.example.yml
+++ b/deploy/docker-compose.example.yml
@@ -1,7 +1,7 @@
 # Build the image first, from a clone of this repo:
 #   docker build -t immich-shared-albums:live .
 # Put the API key in a .env file next to this compose file (chmod 600):
-#   SIDECAR_API_KEY=<immich admin api key, all permissions>
+#   SIDECAR_API_KEY=<immich admin api key — permissions in api-key.md>
 services:
   immich-shared-albums:
     image: immich-shared-albums:live
@@ -10,18 +10,24 @@ services:
       IMMICH_URL: http://immich-server:2283
       IMMICH_API_KEY: ${SIDECAR_API_KEY}
       HOUSEHOLD_NAME: "The Example household"
-      # optional: PORT (8300), DATA_DIR (/data), POLL_MS (20000), ALBUM_TEMPLATE ("{name}")
-      # optional: CACHE_MAX_MB (512), MAX_BODY_KB (1024)
+      # Every other setting has a working default — the full list with explanations
+      # is in configuration.md. The ones worth knowing about:
       #
       # Recommended when this server is reachable from the public internet:
       #   REQUIRE_SHARE_PASSWORD: "true"   # refuse to enrol a peer from a link with no
       #                                    # password set. Without it, whoever holds a
       #                                    # forwarded link can introduce their server.
-      #                                    # resolve to a private range. Leave this alone
-      #                                    # (default true) for LAN or tailnet setups.
       #   UTILITY_QUOTA_MB: "2048"         # storage cap on the bot users that own the
       #                                    # stubs. They store ~2KB/photo and ~2MB/video,
       #                                    # so size it well above your shared volume —
       #                                    # too low and syncing silently starts failing.
     volumes:
       - ./sidecar-data:/data
+    networks: [immich]
+
+# Join the docker network your Immich runs on, so IMMICH_URL resolves.
+# Find its name with:  docker inspect immich_server --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}'
+networks:
+  immich:
+    external: true
+    name: immich_default

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -31,7 +31,7 @@ docker network inspect "$IMMICH_NETWORK" >/dev/null 2>&1 || {
 
 IMMICH_URL=$(ask "Immich server URL as reachable from that network [http://immich-server:2283]:" http://immich-server:2283)
 HOUSEHOLD_NAME=$(ask "Household name shown to peers [My household]:" "My household")
-HOST_PORT=$(ask "Host port to expose the sidecar on (your reverse proxy points here) [8300]:" 8300)
+HOST_PORT=$(ask "Host port to expose the sidecar on (your apps or proxy will point here) [8300]:" 8300)
 echo "API key: create it in Immich web -> Account Settings -> API Keys -> New API Key,"
 echo "ticking the permissions listed in deploy/api-key.md (the addon verifies at startup"
 echo "and logs anything missing; 'all' also works but is broader than needed)."

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -36,6 +36,10 @@ printf 'Immich admin API key (input hidden): '
 read -rs SIDECAR_API_KEY; echo
 [ -n "$SIDECAR_API_KEY" ] || { echo "API key is required"; exit 1; }
 
+WANT_IPP=$(ask "Also set up public view-only share links via immich-public-proxy? [y/N]:" "n")
+case "$WANT_IPP" in y|Y|yes|YES) WANT_IPP=1;; *) WANT_IPP="";; esac
+[ -n "$WANT_IPP" ] && IPP_PORT=$(ask "Host port for immich-public-proxy [3000]:" 3000)
+
 INSTALL_DIR=$(ask "Install directory [./immich-shared-albums-live]:" ./immich-shared-albums-live)
 mkdir -p "$INSTALL_DIR/data"
 INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd)"
@@ -59,6 +63,21 @@ services:
     ports:
       - $HOST_PORT:8300
     networks: [immich]
+EOF
+if [ -n "$WANT_IPP" ]; then
+cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
+  immich-public-proxy:
+    image: alangrainger/immich-public-proxy:latest
+    restart: unless-stopped
+    environment:
+      # points at the ADDON, so photos shared from other servers render full quality in links
+      IMMICH_URL: http://immich-shared-albums:8300
+    ports:
+      - $IPP_PORT:3000
+    networks: [immich]
+EOF
+fi
+cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
 networks:
   immich:
     external: true
@@ -113,3 +132,19 @@ Then reload the proxy and open any Immich share link — you should see the
 
 To uninstall: cd $INSTALL_DIR && docker compose down && remove the proxy lines.
 EOF
+
+if [ -n "$WANT_IPP" ]; then
+cat <<EOF
+
+immich-public-proxy is running on port $IPP_PORT. Two follow-ups it can't do for you:
+
+  1. Put your public HTTPS in front of it — and ONLY it, if you're keeping Immich private:
+       share.example.com { reverse_proxy immich-public-proxy:$IPP_PORT }
+  2. In Immich: Administration -> Settings -> Server -> External domain
+     -> set it to that public address, so the share links Immich creates point at the proxy.
+
+Optional but recommended with this setup: in the addon's panel, switch
+"Allow other Immich users to join albums via shared links" OFF — links stay
+view-only, and other servers link to yours by pairing code alone.
+EOF
+fi

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -161,8 +161,10 @@ cat <<EOF
 
 immich-public-proxy is running on port $IPP_PORT. Two follow-ups it can't do for you:
 
-  1. Put your public HTTPS in front of it — and ONLY it, if you're keeping Immich private:
-       share.example.com { reverse_proxy immich-public-proxy:$IPP_PORT }
+  1. Make port $IPP_PORT reachable at your public address — and ONLY that port, if
+     you're keeping Immich private. However you host things is up to you; the
+     proxy's own docs cover the common setups:
+       https://github.com/alangrainger/immich-public-proxy
   2. In Immich: Administration -> Settings -> Server -> External domain
      -> set it to that public address, so the share links Immich creates point at the proxy.
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -15,8 +15,8 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 command -v docker >/dev/null || { echo "docker is required — install Docker first"; exit 1; }
 
 say "immich-shared-albums installer"
-echo "You'll need an Immich admin API key with all permissions:"
-echo "  Immich web -> Account Settings -> API Keys -> New API Key -> tick everything."
+echo "You'll need an Immich admin API key — see deploy/api-key.md for the exact"
+echo "permissions to tick (a short list; 'all' also works but is broader than needed)."
 
 # auto-detect the network the Immich server container is on, to pre-fill the prompt
 DEFAULT_NET=immich_default
@@ -30,11 +30,30 @@ docker network inspect "$IMMICH_NETWORK" >/dev/null 2>&1 || {
   echo "network '$IMMICH_NETWORK' not found. Existing networks:"; docker network ls --format '  {{.Name}}'; exit 1; }
 
 IMMICH_URL=$(ask "Immich server URL as reachable from that network [http://immich-server:2283]:" http://immich-server:2283)
+IMMICH_UPSTREAM_HOST=$(echo "$IMMICH_URL" | sed 's|https\?://||')
 HOUSEHOLD_NAME=$(ask "Household name shown to peers [My household]:" "My household")
 HOST_PORT=$(ask "Host port to expose the sidecar on (your reverse proxy points here) [8300]:" 8300)
+echo "API key: create it in Immich web -> Account Settings -> API Keys -> New API Key,"
+echo "ticking the permissions listed in deploy/api-key.md (the addon verifies at startup"
+echo "and logs anything missing; 'all' also works but is broader than needed)."
 printf 'Immich admin API key (input hidden): '
 read -rs SIDECAR_API_KEY; echo
 [ -n "$SIDECAR_API_KEY" ] || { echo "API key is required"; exit 1; }
+
+echo "How should your Immich apps reach the addon?"
+echo "  1) I already run a reverse proxy (Caddy/nginx/Traefik/NPM) — print the routes for me to add"
+echo "  2) No proxy — the addon itself becomes the front; I'll point my apps at its port"
+echo "  3) Set up a new Caddy container for me, fronting everything"
+PROXY_MODE=$(ask "Pick 1, 2 or 3 [2]:" "2")
+case "$PROXY_MODE" in 1|2|3) ;; *) PROXY_MODE=2;; esac
+if [ "$PROXY_MODE" = "3" ]; then
+  CADDY_SITE=$(ask "Domain for HTTPS (blank = plain HTTP on a port, fine for LAN):" "")
+  if [ -n "$CADDY_SITE" ]; then CADDY_PORTS="80:80
+      - 443:443"; else
+    CADDY_HTTP_PORT=$(ask "Host port for Caddy [8080]:" 8080)
+    CADDY_PORTS="$CADDY_HTTP_PORT:80"
+  fi
+fi
 
 WANT_IPP=$(ask "Also set up public view-only share links via immich-public-proxy? [y/N]:" "n")
 case "$WANT_IPP" in y|Y|yes|YES) WANT_IPP=1;; *) WANT_IPP="";; esac
@@ -64,6 +83,30 @@ services:
       - $HOST_PORT:8300
     networks: [immich]
 EOF
+if [ "$PROXY_MODE" = "3" ]; then
+cat > "$INSTALL_DIR/Caddyfile" <<EOF
+${CADDY_SITE:-:80} {
+	# single front: the addon passes everything that isn't shared-album traffic to Immich,
+	# and Immich is the fallback so a dead addon fails open
+	reverse_proxy immich-shared-albums:8300 $IMMICH_UPSTREAM_HOST {
+		lb_policy first
+		fail_duration 10s
+	}
+}
+EOF
+cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+    ports:
+      - $CADDY_PORTS
+    networks: [immich]
+EOF
+NEED_CADDY_VOLUME=1
+fi
 if [ -n "$WANT_IPP" ]; then
 cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
   immich-public-proxy:
@@ -83,6 +126,12 @@ networks:
     external: true
     name: $IMMICH_NETWORK
 EOF
+if [ -n "${NEED_CADDY_VOLUME:-}" ]; then
+cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
+volumes:
+  caddy-data:
+EOF
+fi
 # key lives in an env file next to the compose, chmod 600, never in the yml
 umask 177
 echo "SIDECAR_API_KEY=$SIDECAR_API_KEY" > "$INSTALL_DIR/.env"
@@ -105,6 +154,33 @@ else
   echo "health check failed — logs:"; (cd "$INSTALL_DIR" && docker compose logs immich-shared-albums --tail 30); exit 1
 fi
 
+if [ "$PROXY_MODE" = "2" ]; then
+say "Done — the addon IS your front"
+cat <<EOF
+Point your Immich apps and browser at:  http://<this-host>:$HOST_PORT
+Everything that isn't shared-album traffic passes straight through to Immich,
+websockets included, and if the addon is ever down you can point apps back at
+Immich directly — your library is never behind it hostage.
+
+Verify the panel (signed in to Immich as an admin):
+  http://<this-host>:$HOST_PORT/immich-shared-albums/
+
+To uninstall: cd $INSTALL_DIR && docker compose down.
+EOF
+elif [ "$PROXY_MODE" = "3" ]; then
+say "Done — Caddy is fronting everything"
+cat <<EOF
+Point your Immich apps and browser at:  ${CADDY_SITE:-http://<this-host>:${CADDY_HTTP_PORT:-8080}}
+(Caddy -> addon -> Immich, with Immich as fallback so a dead addon fails open.
+If you gave a domain, Caddy fetches its own HTTPS certificate — make sure the
+domain's DNS points here and ports 80/443 reach this machine.)
+
+Verify the panel (signed in to Immich as an admin):
+  ${CADDY_SITE:-http://<this-host>:${CADDY_HTTP_PORT:-8080}}/immich-shared-albums/
+
+To uninstall: cd $INSTALL_DIR && docker compose down.
+EOF
+else
 say "Last step (manual): route three paths through your reverse proxy"
 cat <<EOF
 Add to your existing site config, BEFORE the catch-all Immich route:
@@ -132,6 +208,7 @@ Then reload the proxy and open any Immich share link — you should see the
 
 To uninstall: cd $INSTALL_DIR && docker compose down && remove the proxy lines.
 EOF
+fi
 
 if [ -n "$WANT_IPP" ]; then
 cat <<EOF

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -30,7 +30,6 @@ docker network inspect "$IMMICH_NETWORK" >/dev/null 2>&1 || {
   echo "network '$IMMICH_NETWORK' not found. Existing networks:"; docker network ls --format '  {{.Name}}'; exit 1; }
 
 IMMICH_URL=$(ask "Immich server URL as reachable from that network [http://immich-server:2283]:" http://immich-server:2283)
-IMMICH_UPSTREAM_HOST=$(echo "$IMMICH_URL" | sed 's|https\?://||')
 HOUSEHOLD_NAME=$(ask "Household name shown to peers [My household]:" "My household")
 HOST_PORT=$(ask "Host port to expose the sidecar on (your reverse proxy points here) [8300]:" 8300)
 echo "API key: create it in Immich web -> Account Settings -> API Keys -> New API Key,"
@@ -40,20 +39,10 @@ printf 'Immich admin API key (input hidden): '
 read -rs SIDECAR_API_KEY; echo
 [ -n "$SIDECAR_API_KEY" ] || { echo "API key is required"; exit 1; }
 
-echo "How should your Immich apps reach the addon?"
-echo "  1) I already run a reverse proxy (Caddy/nginx/Traefik/NPM) — print the routes for me to add"
-echo "  2) No proxy — the addon itself becomes the front; I'll point my apps at its port"
-echo "  3) Set up a new Caddy container for me, fronting everything"
-PROXY_MODE=$(ask "Pick 1, 2 or 3 [2]:" "2")
-case "$PROXY_MODE" in 1|2|3) ;; *) PROXY_MODE=2;; esac
-if [ "$PROXY_MODE" = "3" ]; then
-  CADDY_SITE=$(ask "Domain for HTTPS (blank = plain HTTP on a port, fine for LAN):" "")
-  if [ -n "$CADDY_SITE" ]; then CADDY_PORTS="80:80
-      - 443:443"; else
-    CADDY_HTTP_PORT=$(ask "Host port for Caddy [8080]:" 8080)
-    CADDY_PORTS="$CADDY_HTTP_PORT:80"
-  fi
-fi
+# No proxy is the default and needs nothing extra: the addon itself is the front,
+# passing everything that isn't shared-album traffic through to Immich.
+HAVE_PROXY=$(ask "Do you already run a reverse proxy in front of Immich (Caddy/nginx/Traefik/NPM)? [y/N]:" "n")
+case "$HAVE_PROXY" in y|Y|yes|YES) PROXY_MODE=1;; *) PROXY_MODE=2;; esac
 
 WANT_IPP=$(ask "Also set up public view-only share links via immich-public-proxy? [y/N]:" "n")
 case "$WANT_IPP" in y|Y|yes|YES) WANT_IPP=1;; *) WANT_IPP="";; esac
@@ -83,30 +72,6 @@ services:
       - $HOST_PORT:8300
     networks: [immich]
 EOF
-if [ "$PROXY_MODE" = "3" ]; then
-cat > "$INSTALL_DIR/Caddyfile" <<EOF
-${CADDY_SITE:-:80} {
-	# single front: the addon passes everything that isn't shared-album traffic to Immich,
-	# and Immich is the fallback so a dead addon fails open
-	reverse_proxy immich-shared-albums:8300 $IMMICH_UPSTREAM_HOST {
-		lb_policy first
-		fail_duration 10s
-	}
-}
-EOF
-cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
-  caddy:
-    image: caddy:2
-    restart: unless-stopped
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy-data:/data
-    ports:
-      - $CADDY_PORTS
-    networks: [immich]
-EOF
-NEED_CADDY_VOLUME=1
-fi
 if [ -n "$WANT_IPP" ]; then
 cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
   immich-public-proxy:
@@ -126,12 +91,6 @@ networks:
     external: true
     name: $IMMICH_NETWORK
 EOF
-if [ -n "${NEED_CADDY_VOLUME:-}" ]; then
-cat >> "$INSTALL_DIR/docker-compose.yml" <<EOF
-volumes:
-  caddy-data:
-EOF
-fi
 # key lives in an env file next to the compose, chmod 600, never in the yml
 umask 177
 echo "SIDECAR_API_KEY=$SIDECAR_API_KEY" > "$INSTALL_DIR/.env"
@@ -164,19 +123,6 @@ Immich directly — your library is never behind it hostage.
 
 Verify the panel (signed in to Immich as an admin):
   http://<this-host>:$HOST_PORT/immich-shared-albums/
-
-To uninstall: cd $INSTALL_DIR && docker compose down.
-EOF
-elif [ "$PROXY_MODE" = "3" ]; then
-say "Done — Caddy is fronting everything"
-cat <<EOF
-Point your Immich apps and browser at:  ${CADDY_SITE:-http://<this-host>:${CADDY_HTTP_PORT:-8080}}
-(Caddy -> addon -> Immich, with Immich as fallback so a dead addon fails open.
-If you gave a domain, Caddy fetches its own HTTPS certificate — make sure the
-domain's DNS points here and ports 80/443 reach this machine.)
-
-Verify the panel (signed in to Immich as an admin):
-  ${CADDY_SITE:-http://<this-host>:${CADDY_HTTP_PORT:-8080}}/immich-shared-albums/
 
 To uninstall: cd $INSTALL_DIR && docker compose down.
 EOF


### PR DESCRIPTION
Brings all three install paths up to date and gives each a real answer to "how do apps reach the addon".

## install.sh
- **Proxy question, y/n.** Already run a reverse proxy? **y** → prints the three routes to add (previous behaviour). **n** (default) → nothing extra is installed, because the addon *is* the front: everything that isn't shared-album traffic passes through to Immich, websockets included — the closing message says to point apps at the addon's port. Both modes smoke-tested end-to-end.
- **New: IPP option.** Optional immich-public-proxy service pointed at the addon (`IMMICH_URL: http://immich-shared-albums:8300`), with printed follow-ups (public HTTPS in front of only its port, Immich's External domain setting, suggest turning off link-joining). Smoke-tested: both containers healthy.
- Key prompts now point at the scoped permission list in deploy/api-key.md instead of "tick everything".

An interim commit added a "set up Caddy for me" third option; removed again before merge — post-iroh nothing needs public hosting, and on a LAN it only duplicated what the addon already does.

## INSTALL-AI.md
Accuracy rewrite — it still described the pre-iroh world: asked for a public URL, an ALL-permissions key, and set a deleted env var. Now: no URL ask, scoped key, IPP as an optional question, verify steps for the unexposed default, and a no-proxy case (single front) instead of assuming a proxy exists.

## Manual install
- deploy/ gets a README so the "Manual install" link lands on instructions instead of a file listing (build → key → compose → single-front or three-routes → verify).
- docker-compose.example.yml: drops the "all permissions" ask, removes an orphaned comment fragment from a deleted setting, and gains the external-network block without which it couldn't reach Immich at all.
- Caddyfile.snippet: "join banner" → "join card".

🤖 Generated with [Claude Code](https://claude.com/claude-code)