### PR TITLE
feat(config)!: the ISA_ env contract — one namespace, strict parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 # TypeScript runs natively via Node's type stripping, no build step. index.ts is the entry.
 COPY src/ ./
+# /data holds the identity key and every bot API key — created here so the node user owns it
+# even when the volume is anonymous. Bind-mount installs must be writable by uid 1000.
+RUN mkdir -p /data && chown node:node /data
+USER node
 VOLUME /data
 EXPOSE 8300
+# Lets `depends_on: condition: service_healthy` work for anything composed in front of the addon.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s \
+  CMD wget -qO- "http://127.0.0.1:${ISA_PORT:-8300}/immich-shared-albums/health" || exit 1
 CMD ["node", "index.ts"]

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Two settings matter when you install; everything else has a working default (ful
 
 | Variable | What to put there |
 |---|---|
-| `IMMICH_API_KEY` | **Required.** An API key from an admin account, created with the permissions below. |
-| `HOUSEHOLD_NAME` | The name the other family sees, e.g. `The Smiths`. |
+| `ISA_IMMICH_API_KEY` | **Required.** An API key from an admin account, created with the permissions below. |
+| `ISA_HOUSEHOLD_NAME` | The name the other family sees, e.g. `The Smiths`. |
 
 ### The API key
 

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -33,14 +33,17 @@ services:
 
   sidecar-b:
     image: immich-shared-albums:demo
+    # rig-only: the suite reads state.db from the host and purges via docker exec,
+    # so the test sidecars keep running as root instead of the image's node user
+    user: "0:0"
     # LAN address when testing from a phone.
     extra_hosts:
       - host.docker.internal:host-gateway
     environment:
-      IMMICH_URL: http://immich-b:2283
-      IMMICH_API_KEY: ${B_SIDECAR_API_KEY:-${B_API_KEY}}
-      HOUSEHOLD_NAME: "Demo household (B)"
-      POLL_MS: "15000"
+      ISA_IMMICH_URL: http://immich-b:2283
+      ISA_IMMICH_API_KEY: ${B_SIDECAR_API_KEY:-${B_API_KEY}}
+      ISA_HOUSEHOLD_NAME: "Demo household (B)"
+      ISA_SYNC_POLL_MS: "15000"
     networks:
       - default
       - isa-demo

--- a/demo/household-c/docker-compose.yml
+++ b/demo/household-c/docker-compose.yml
@@ -30,14 +30,17 @@ services:
     restart: unless-stopped
   sidecar-c:
     image: immich-shared-albums:demo
+    # rig-only: the suite reads state.db from the host and purges via docker exec,
+    # so the test sidecars keep running as root instead of the image's node user
+    user: "0:0"
     # LAN address when testing from a phone.
     extra_hosts:
       - host.docker.internal:host-gateway
     environment:
-      IMMICH_URL: http://immich-c:2283
-      IMMICH_API_KEY: ${C_SIDECAR_API_KEY:-${C_API_KEY}}
-      HOUSEHOLD_NAME: "Mock household (C)"
-      POLL_MS: "8000"
+      ISA_IMMICH_URL: http://immich-c:2283
+      ISA_IMMICH_API_KEY: ${C_SIDECAR_API_KEY:-${C_API_KEY}}
+      ISA_HOUSEHOLD_NAME: "Mock household (C)"
+      ISA_SYNC_POLL_MS: "8000"
     networks:
       - default
       - isa-demo

--- a/demo/household-d/docker-compose.yml
+++ b/demo/household-d/docker-compose.yml
@@ -31,13 +31,16 @@ services:
     restart: unless-stopped
   sidecar-d:
     image: immich-shared-albums:demo
+    # rig-only: the suite reads state.db from the host and purges via docker exec,
+    # so the test sidecars keep running as root instead of the image's node user
+    user: "0:0"
     extra_hosts:
       - host.docker.internal:host-gateway
     environment:
-      IMMICH_URL: http://immich-d:2283
-      IMMICH_API_KEY: ${D_SIDECAR_API_KEY:-${D_API_KEY}}
-      HOUSEHOLD_NAME: "Mock household (D)"
-      POLL_MS: "8000"
+      ISA_IMMICH_URL: http://immich-d:2283
+      ISA_IMMICH_API_KEY: ${D_SIDECAR_API_KEY:-${D_API_KEY}}
+      ISA_HOUSEHOLD_NAME: "Mock household (D)"
+      ISA_SYNC_POLL_MS: "8000"
     networks:
       - default
       - isa-demo

--- a/deploy/INSTALL-AI.md
+++ b/deploy/INSTALL-AI.md
@@ -45,7 +45,7 @@ INSTALL:
 1. git clone https://github.com/lukeet332/immich-shared-albums
 2. Either run `bash deploy/install.sh` interactively with me, or replicate what
    it does: build the image, write a compose file joining the sidecar to the
-   Immich docker network with env IMMICH_URL, IMMICH_API_KEY (in a chmod-600
+   Immich docker network with env ISA_IMMICH_URL, ISA_IMMICH_API_KEY (in a chmod-600
    .env file, never in the yml), HOUSEHOLD_NAME, and a ./data
    volume for /data. Start it with docker compose up -d.
 3. If I have NO reverse proxy, skip the routes entirely: the sidecar is itself a
@@ -74,7 +74,7 @@ diff, reload the proxy — Immich itself is untouched throughout.
 
 AFTER INSTALL:
 1. If my Immich is reachable from the public internet, set
-   REQUIRE_SHARE_PASSWORD=true in the sidecar env and tell me what it changes,
+   ISA_LINK_JOIN_REQUIRES_PASSWORD=true in the sidecar env and tell me what it changes,
    and point me at Immich's own hardening guidance — hosting is theirs to
    document, and the sidecar adds no public surface beyond its own routes
    (deploy/exposure.md has the details). If nothing of mine is public, say so

--- a/deploy/api-key.md
+++ b/deploy/api-key.md
@@ -31,5 +31,5 @@ by promise.
 
 ## Where to put it
 
-In the `.env` file next to the addon's `docker-compose.yml`, as `IMMICH_API_KEY`. Never in the
+In the `.env` file next to the addon's `docker-compose.yml`, as `ISA_IMMICH_API_KEY`. Never in the
 compose file itself.

--- a/deploy/configuration.md
+++ b/deploy/configuration.md
@@ -1,22 +1,26 @@
 # Configuration reference
 
-Only `IMMICH_API_KEY` is required. Everything else has a working default — set these only if you
-need to. For the key's permission list, see [api-key.md](./api-key.md).
+Only `ISA_IMMICH_API_KEY` is required. Everything else has a working default — set these only
+if you need to. For the key's permission list, see [api-key.md](./api-key.md).
+
+Every setting is `ISA_`-prefixed so the addon can never collide with Immich's own variables
+(or anything else's) in a shared env file. Booleans accept `true`/`false` (also `1`/`0`,
+`yes`/`no`, `on`/`off`) — anything else refuses to start rather than silently picking a side.
 
 | Variable | Default | What it does |
 |---|---|---|
-| `IMMICH_API_KEY` | — | **Required.** A key on an admin account, created with the permission list in [api-key.md](./api-key.md). The addon checks the key when it starts and tells you if something is missing. `all` works too. |
-| `HOUSEHOLD_NAME` | `Unnamed household` | The name other servers see. |
-| `IMMICH_URL` | `http://immich-server:2283` | Your Immich, from inside the container. |
-| `PORT` | `8300` | Port the addon listens on. |
-| `DATA_DIR` | `/data` | Where `state.db` lives. Back this up; it holds your signing key. |
-| `REQUIRE_SHARE_PASSWORD` | `false` | Refuse share-link joins when the link has no password. Worth setting if your Immich is public. |
-| `SHARE_USER_DIRECTORY` | `true` | Share your users' names (never emails) with linked servers so they can be picked in the share menu. `false` keeps your user list private and disables that, leaving share links. |
-| `RELAY` | on | If two servers can't connect directly (roughly 1 network in 10), traffic falls back through a public relay run by [n0](https://n0.computer). The relay only ever sees encrypted bytes. `off` means direct connections only. |
-| `ALBUM_TEMPLATE` | `{name}` | Naming for shared albums on your side, e.g. `{name} (shared)`. |
-| `CACHE_MAX_MB` | `512` | Cache for recently viewed shared photos. `0` disables it. Safe to delete any time. |
-| `UTILITY_QUOTA_MB` | `0` (none) | Storage cap for the addon's bot accounts. |
-| `MAX_BODY_KB` | `1024` | Cap on request bodies the addon buffers. |
-| `POLL_MS` | `20000` | How often it checks linked servers for changes. |
-| `COMMENT_POLL_MS` | `5000` | How often the comment sync checks for new activity. |
-| `RECONCILE_DEBUG` | off | Set `1` to log every sync decision. Turn this on first if an album looks wrong. |
+| `ISA_IMMICH_API_KEY` | — | **Required.** A key on an admin account, created with the permission list in [api-key.md](./api-key.md). The addon checks the key when it starts and tells you if something is missing. `all` works too. |
+| `ISA_HOUSEHOLD_NAME` | `Unnamed household` | The name other servers see. |
+| `ISA_IMMICH_URL` | `http://immich-server:2283` | Your Immich, from inside the container. |
+| `ISA_PORT` | `8300` | Port the addon listens on inside the container (map any host port onto it). |
+| `ISA_DATA_DIR` | `/data` | Where `state.db` lives. Back this up; it holds this server's identity key — and copy the whole directory, not just `state.db` (its WAL sidecar files carry recent writes). |
+| `ISA_LINK_JOIN_REQUIRES_PASSWORD` | `false` | Refuse to let another *server* join from a share link that has no password. A gate on joining, not viewing — a link's own password and expiry are always enforced. Worth setting if your Immich is public. |
+| `ISA_PUBLISH_USER_DIRECTORY` | `true` | Publish your users' names (never emails) to linked servers so they can be picked in the share menu. `false` keeps your user list private and disables native invitations from those servers, leaving share links. |
+| `ISA_RELAY` | `true` | If two servers can't connect directly (roughly 1 network in 10), traffic falls back through a public relay run by [n0](https://n0.computer). The relay only ever sees encrypted bytes. `false` means direct connections only. |
+| `ISA_MIRROR_ALBUM_TEMPLATE` | `{name}` | Naming for mirror albums created on this side. Tokens: `{name}` = the album's name, `{peer}` = the sending household — e.g. `{name} (from {peer})`. |
+| `ISA_CACHE_MAX_MB` | `512` | Cache for recently viewed shared photos. `0` disables it. Safe to delete any time. |
+| `ISA_BOT_QUOTA_MB` | `0` (none) | Storage cap for the addon's bot accounts. They store ~2KB per photo and ~2MB per video, so size it well above your shared volume — too low and syncing silently starts failing. |
+| `ISA_MAX_BODY_KB` | `1024` | Cap on request bodies the addon buffers. |
+| `ISA_SYNC_POLL_MS` | `20000` | How often it checks linked servers for changes. |
+| `ISA_COMMENT_POLL_MS` | `5000` | How often the comment sync checks for new activity. |
+| `ISA_RECONCILE_DEBUG` | `false` | Log every sync decision. Turn this on first if an album looks wrong. |

--- a/deploy/docker-compose.example.yml
+++ b/deploy/docker-compose.example.yml
@@ -1,28 +1,30 @@
 # Build the image first, from a clone of this repo:
 #   docker build -t immich-shared-albums:live .
 # Put the API key in a .env file next to this compose file (chmod 600):
-#   SIDECAR_API_KEY=<immich admin api key — permissions in api-key.md>
+#   ISA_IMMICH_API_KEY=<immich admin api key — permissions in api-key.md>
 services:
   immich-shared-albums:
     image: immich-shared-albums:live
     restart: always
     environment:
-      IMMICH_URL: http://immich-server:2283
-      IMMICH_API_KEY: ${SIDECAR_API_KEY}
-      HOUSEHOLD_NAME: "The Example household"
+      ISA_IMMICH_URL: http://immich-server:2283
+      ISA_IMMICH_API_KEY: ${ISA_IMMICH_API_KEY}
+      ISA_HOUSEHOLD_NAME: "The Example household"
       # Every other setting has a working default — the full list with explanations
       # is in configuration.md. The ones worth knowing about:
       #
       # Recommended when this server is reachable from the public internet:
-      #   REQUIRE_SHARE_PASSWORD: "true"   # refuse to enrol a peer from a link with no
+      #   ISA_LINK_JOIN_REQUIRES_PASSWORD: "true"   # refuse to enrol a peer from a link with no
       #                                    # password set. Without it, whoever holds a
       #                                    # forwarded link can introduce their server.
-      #   UTILITY_QUOTA_MB: "2048"         # storage cap on the bot users that own the
+      #   ISA_BOT_QUOTA_MB: "2048"         # storage cap on the bot users that own the
       #                                    # stubs. They store ~2KB/photo and ~2MB/video,
       #                                    # so size it well above your shared volume —
       #                                    # too low and syncing silently starts failing.
     volumes:
-      - ./sidecar-data:/data
+      # a named volume, owned by the container's non-root user. The identity key lives
+      # here: `docker compose down -v` would delete it and orphan every pairing.
+      - isa-data:/data
     networks: [immich]
 
 # Join the docker network your Immich runs on, so IMMICH_URL resolves.
@@ -31,3 +33,5 @@ networks:
   immich:
     external: true
     name: immich_default
+volumes:
+  isa-data:

--- a/deploy/exposure.md
+++ b/deploy/exposure.md
@@ -46,7 +46,7 @@ Addon-specific settings worth flipping per posture:
 - **Posture B:** in the panel, switch *"Allow other Immich users to join albums via shared
   links"* **off** — links stay strictly view-only, and servers link to yours by pairing code
   alone.
-- **Posture C:** set `REQUIRE_SHARE_PASSWORD: "true"` on the addon, so a forwarded share link
+- **Posture C:** set `ISA_LINK_JOIN_REQUIRES_PASSWORD: "true"` on the addon, so a forwarded share link
   with no password can't be used to introduce a stranger's server.
 - **Any posture:** `chmod 600` the `.env` holding the API key. If a non-root user needs
   `docker compose`, use `chown root:docker` + `chmod 640` instead — the docker group is

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -36,8 +36,8 @@ echo "API key: create it in Immich web -> Account Settings -> API Keys -> New AP
 echo "ticking the permissions listed in deploy/api-key.md (the addon verifies at startup"
 echo "and logs anything missing; 'all' also works but is broader than needed)."
 printf 'Immich admin API key (input hidden): '
-read -rs SIDECAR_API_KEY; echo
-[ -n "$SIDECAR_API_KEY" ] || { echo "API key is required"; exit 1; }
+read -rs ISA_API_KEY; echo
+[ -n "$ISA_API_KEY" ] || { echo "API key is required"; exit 1; }
 
 # No proxy is the default and needs nothing extra: the addon itself is the front,
 # passing everything that isn't shared-album traffic through to Immich.
@@ -49,7 +49,7 @@ case "$WANT_IPP" in y|Y|yes|YES) WANT_IPP=1;; *) WANT_IPP="";; esac
 [ -n "$WANT_IPP" ] && IPP_PORT=$(ask "Host port for immich-public-proxy [3000]:" 3000)
 
 INSTALL_DIR=$(ask "Install directory [./immich-shared-albums-live]:" ./immich-shared-albums-live)
-mkdir -p "$INSTALL_DIR/data"
+mkdir -p "$INSTALL_DIR"
 INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd)"
 
 say "Building image from source"
@@ -63,11 +63,13 @@ services:
     image: immich-shared-albums:live
     restart: unless-stopped
     environment:
-      IMMICH_URL: $IMMICH_URL
-      IMMICH_API_KEY: \${SIDECAR_API_KEY}
-      HOUSEHOLD_NAME: "$HOUSEHOLD_NAME"
+      ISA_IMMICH_URL: $IMMICH_URL
+      ISA_IMMICH_API_KEY: \${ISA_IMMICH_API_KEY}
+      ISA_HOUSEHOLD_NAME: "$HOUSEHOLD_NAME"
     volumes:
-      - ./data:/data
+      # a named volume, so the container's own (non-root) user owns it. The identity key
+      # lives here: docker compose down -v would delete it and orphan every pairing.
+      - isa-data:/data
     ports:
       - $HOST_PORT:8300
     networks: [immich]
@@ -90,10 +92,12 @@ networks:
   immich:
     external: true
     name: $IMMICH_NETWORK
+volumes:
+  isa-data:
 EOF
 # key lives in an env file next to the compose, chmod 600, never in the yml
 umask 177
-echo "SIDECAR_API_KEY=$SIDECAR_API_KEY" > "$INSTALL_DIR/.env"
+echo "ISA_IMMICH_API_KEY=$ISA_API_KEY" > "$INSTALL_DIR/.env"
 umask 022
 
 say "Starting sidecar"
@@ -124,7 +128,7 @@ Immich directly — your library is never behind it hostage.
 Verify the panel (signed in to Immich as an admin):
   http://<this-host>:$HOST_PORT/immich-shared-albums/
 
-To uninstall: cd $INSTALL_DIR && docker compose down.
+To uninstall: cd $INSTALL_DIR && docker compose down (add -v to also delete\nthis server's identity — other servers would need a fresh pairing link).
 EOF
 else
 say "Last step (manual): route three paths through your reverse proxy"

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/luke/Documents/immich-shared-albums/node_modules

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "format": "prettier --write \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"*.json\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"*.json\"",
     "cycles": "node scripts/check-cycles.mjs",
-    "test": "docker run --rm -e IMMICH_API_KEY=test-only -v \"$PWD/src\":/app/src -v \"$PWD/scripts\":/app/scripts -v \"$PWD/package.json\":/app/package.json -v \"$PWD/package-lock.json\":/app/package-lock.json -v isa-node-modules:/app/node_modules -w /app node:24-alpine sh -c 'npm ci --omit=dev --ignore-scripts --no-audit --no-fund >/dev/null 2>&1; node --test \"src/**/*.test.ts\"'",
+    "test": "docker run --rm -e ISA_IMMICH_API_KEY=test-only -v \"$PWD/src\":/app/src -v \"$PWD/scripts\":/app/scripts -v \"$PWD/package.json\":/app/package.json -v \"$PWD/package-lock.json\":/app/package-lock.json -v isa-node-modules:/app/node_modules -w /app node:24-alpine sh -c 'npm ci --omit=dev --ignore-scripts --no-audit --no-fund >/dev/null 2>&1; node --test \"src/**/*.test.ts\"'",
     "verify": "npm run verify:fast && npm run check:runtime && npm test",
-    "check:runtime": "docker run --rm -e IMMICH_API_KEY=test-only -v \"$PWD/src\":/app/src -v \"$PWD/scripts\":/app/scripts -v \"$PWD/package.json\":/app/package.json -v \"$PWD/package-lock.json\":/app/package-lock.json -v isa-node-modules:/app/node_modules -w /app node:24-alpine sh -c 'npm ci --omit=dev --ignore-scripts --no-audit --no-fund >/dev/null 2>&1; node scripts/check-runtime.mjs'",
+    "check:runtime": "docker run --rm -e ISA_IMMICH_API_KEY=test-only -v \"$PWD/src\":/app/src -v \"$PWD/scripts\":/app/scripts -v \"$PWD/package.json\":/app/package.json -v \"$PWD/package-lock.json\":/app/package-lock.json -v isa-node-modules:/app/node_modules -w /app node:24-alpine sh -c 'npm ci --omit=dev --ignore-scripts --no-audit --no-fund >/dev/null 2>&1; node scripts/check-runtime.mjs'",
     "verify:fast": "npm run build:web && npm run format:check && npm run lint && npm run typecheck && npm run cycles",
     "prepare": "git config core.hooksPath .githooks",
     "build:web": "node scripts/build-web.mjs"

--- a/scripts/check-runtime.mjs
+++ b/scripts/check-runtime.mjs
@@ -17,7 +17,7 @@ import { readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-process.env.IMMICH_API_KEY ||= 'check-runtime-only';
+process.env.ISA_IMMICH_API_KEY ||= 'check-runtime-only';
 process.env.DATA_DIR ||= '/tmp/check-runtime';
 
 const root = join(import.meta.dirname, '..', 'src');

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -37,13 +37,13 @@ transport — lockfile-pinned, installed by the Dockerfile):
 
 Started by `index.ts`, each guarded against overlapping itself:
 
-| Loop | Does | Cadence |
-|---|---|---|
-| `startWatchLoop` | `watchOnce` pushes local additions to peers, then **ends each cycle with `reconcileOnce`** | `POLL_MS` |
-| `startCommentLoop` | two-way comment sync, gated on a cheap activity-count statistic | fast lane |
-| `startInviteLoop` | `detectInvitesOnce` (origin side), then `pullInvitationsOnce` (member side) | own tick |
+| Loop               | Does                                                                                       | Cadence            |
+| ------------------ | ------------------------------------------------------------------------------------------ | ------------------ |
+| `startWatchLoop`   | `watchOnce` pushes local additions to peers, then **ends each cycle with `reconcileOnce`** | `ISA_SYNC_POLL_MS` |
+| `startCommentLoop` | two-way comment sync, gated on a cheap activity-count statistic                            | fast lane          |
+| `startInviteLoop`  | `detectInvitesOnce` (origin side), then `pullInvitationsOnce` (member side)                | own tick           |
 
-A lost nudge costs nothing — the next scheduled pass catches everything. `RECONCILE_DEBUG=1` traces
+A lost nudge costs nothing — the next scheduled pass catches everything. `ISA_RECONCILE_DEBUG=1` traces
 every decision.
 
 ## Components
@@ -68,7 +68,7 @@ every decision.
   QUIC dialing the household's key itself.
   - The key IS the address; relay/address hints refresh themselves after every dial.
   - Enrolment is proven by the connection (pairing ticket or share key names the grant).
-  - Identity is *only* identity: every mapping lookup filters on the calling peer, so a valid
+  - Identity is _only_ identity: every mapping lookup filters on the calling peer, so a valid
     connection can never select someone else's album. See [`p2p/wire-protocol.md`](./p2p/wire-protocol.md).
 - **entitlement** — "may this peer read these bytes", kept separate from "who is this peer".
   Everything advertised to a mapping (redeem response, manifest, ref push) lands in an `offered`
@@ -104,7 +104,7 @@ every decision.
 - **native invitations** — every person on a linked server has a local account, so adding one to an
   album in Immich's own picker shares it with **that person**, and removing them revokes it. Sharing
   never names a household.
-  - Detected by listing albums *as that account*, because `GET /albums` is scoped per user and the
+  - Detected by listing albums _as that account_, because `GET /albums` is scoped per user and the
     admin key only ever sees the admin's own albums — which is also why link-based sharing is still
     broken for non-admins.
   - Members **pull** invitations rather than being pushed them, so a household with no inbound
@@ -148,7 +148,7 @@ other only through runtime calls (join → reconcile, watcher → nudge), never 
 
 **A concern graduates.** It starts as one file at `src/` root (like `peers.ts`) and becomes a folder
 once it needs several. Where its doc then lives, and the rule that keeps these docs accurate, are in
-[AGENTS.md](../AGENTS.md) — *Where a doc lives* and *Keep the docs in sync*.
+[AGENTS.md](../AGENTS.md) — _Where a doc lives_ and _Keep the docs in sync_.
 
 ## Iron rules
 
@@ -162,7 +162,7 @@ once it needs several. Where its doc then lives, and the rule that keeps these d
 5. **Default-closed.** No uninvited server reaches anything.
 6. **Reachability is never permission.** Every route assumes it is published to the open internet.
    Human routes authenticate against the caller's own Immich session; peer routes require the
-   mutual-TLS connection's identity *and* an entitlement check. Nothing is protected by being hard to find, on a private
+   mutual-TLS connection's identity _and_ an entitlement check. Nothing is protected by being hard to find, on a private
    network, or behind a URL nobody has guessed.
 7. **The sidecar invents no identities and holds no logins.** The only identity that means anything
    is an Immich one. The accounts that own stubs get a narrowly-scoped API key and no retained

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,45 +1,87 @@
 /**
  * config.ts — process configuration, the shared logger, and small string constants.
  * The single source of truth for env-derived settings; every other module reads CFG here.
+ *
+ * Every variable is ISA_-prefixed: the addon shares compose files with Immich itself (which
+ * owns IMMICH_*) and with anything else on the stack (PORT, DATA_DIR are claimed by half the
+ * container ecosystem), so an unprefixed name is a collision waiting for a shared env_file.
+ *
+ * Parsing is strict and fails LOUDLY at boot. A typo'd boolean must never fail open —
+ * `ISA_RELAY=flase` refusing to start beats it silently keeping the relay on, and
+ * `ISA_SYNC_POLL_MS=20s` becoming NaN would make setInterval fire every tick.
  */
 
 export const SIDECAR_VERSION = '0.5.0'; // x-release-please-version
+
+const die = (msg: string): never => {
+  console.error(msg);
+  process.exit(1);
+};
+
+const envBool = (name: string, dflt: boolean): boolean => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return dflt;
+  const v = raw.trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(v)) return true;
+  if (['false', '0', 'no', 'off'].includes(v)) return false;
+  return die(`${name}=${raw} is not a boolean — use true/false (or 1/0, yes/no, on/off)`);
+};
+
+const envInt = (name: string, dflt: number, min = 0): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return dflt;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < min)
+    return die(`${name}=${raw} is not a whole number >= ${min}`);
+  return n;
+};
+
 // Read and check this first: the process cannot run without it, so proving that here once
 // means `CFG.apiKey` is a plain `string` everywhere instead of `string | undefined`.
-const apiKey = process.env.IMMICH_API_KEY;
-if (!apiKey) {
-  console.error('IMMICH_API_KEY required');
-  process.exit(1);
-}
+const apiKey = process.env.ISA_IMMICH_API_KEY;
+if (!apiKey) die('ISA_IMMICH_API_KEY required');
 
 export const CFG = {
-  immichUrl: process.env.IMMICH_URL || 'http://immich-server:2283',
-  apiKey,
-  name: process.env.HOUSEHOLD_NAME || 'Unnamed household',
-  port: Number(process.env.PORT || 8300),
-  dataDir: process.env.DATA_DIR || '/data',
-  pollMs: Number(process.env.POLL_MS || 20000),
-  template: process.env.ALBUM_TEMPLATE || '{name}',
+  immichUrl: process.env.ISA_IMMICH_URL || 'http://immich-server:2283',
+  apiKey: apiKey as string,
+  name: process.env.ISA_HOUSEHOLD_NAME || 'Unnamed household',
+  port: envInt('ISA_PORT', 8300, 1),
+  dataDir: process.env.ISA_DATA_DIR || '/data',
+  // The album/asset watch cadence. Invite detection rides the same tick today; if the two
+  // ever want different cadences, mint ISA_INVITE_POLL_MS rather than overloading this one.
+  syncPollMs: envInt('ISA_SYNC_POLL_MS', 20000, 1000),
+  commentPollMs: envInt('ISA_COMMENT_POLL_MS', 5000, 500),
+  // Naming for mirror albums created on this side. Tokens: {name} = the album's name at the
+  // origin, {peer} = the sending household's name. The vocabulary is declared here so adding
+  // a token later can never change the meaning of an existing template.
+  mirrorAlbumTemplate: process.env.ISA_MIRROR_ALBUM_TEMPLATE || '{name}',
   // bounded LRU byte-cache for streamed previews (0 disables). A cache, not storage:
   // capped, reclaimable, invisible to libraries — delete the folder any time.
-  cacheMaxMb: Number(process.env.CACHE_MAX_MB ?? 512),
+  cacheMaxMb: envInt('ISA_CACHE_MAX_MB', 512),
   // Hard cap on any request body we will buffer. The router reads bodies before it can
   // know who is calling, so this is the one limit that must not depend on auth.
-  maxBodyKb: Number(process.env.MAX_BODY_KB ?? 1024),
-  // Refuse to enrol a peer from a share link that carries no password. Recommended
-  // whenever the sidecar is reachable from the public internet: without it, possession
-  // of a link is the whole credential. A link's own password and expiry are ALWAYS
-  // enforced regardless of this setting.
-  requireSharePassword: process.env.REQUIRE_SHARE_PASSWORD === 'true',
-  // Optional storage cap on the bot users that own the stubs (0 = no quota). They only
-  // ever store ~2KB per photo and ~2MB per video, so a cap bounds what a stolen utility
+  maxBodyKb: envInt('ISA_MAX_BODY_KB', 1024, 1),
+  // Refuse to enrol a peer SERVER from a share link that carries no password — a gate on
+  // JOINING, not on viewing. Recommended whenever the share page is reachable from the
+  // public internet: without it, possession of a link is the whole credential. A link's own
+  // password and expiry are ALWAYS enforced regardless of this setting.
+  linkJoinRequiresPassword: envBool('ISA_LINK_JOIN_REQUIRES_PASSWORD', false),
+  // Optional storage cap on the bot accounts that own the stubs (0 = no quota). They only
+  // ever store ~2KB per photo and ~2MB per video, so a cap bounds what a stolen bot
   // key could write — but set it too low and materialisation silently starts failing.
-  utilityQuotaMb: Number(process.env.UTILITY_QUOTA_MB ?? 0),
-  // Share the names of local (human) users with linked servers, so they can invite a specific
-  // person to an album. Names only — never emails. Set false to keep your user list private;
-  // because sharing is per person, that disables native invitations from that server entirely
+  botQuotaMb: envInt('ISA_BOT_QUOTA_MB', 0),
+  // PUBLISH the names of local (human) users to linked servers, so they can invite a
+  // specific person to an album. Names only — never emails; outbound only (it does not
+  // affect consuming a peer's directory). Set false to keep your user list private; because
+  // sharing is per person, that disables native invitations from that server entirely
   // (there is nobody to name) and leaves share links as the way in.
-  shareUserDirectory: process.env.SHARE_USER_DIRECTORY !== 'false',
+  publishUserDirectory: envBool('ISA_PUBLISH_USER_DIRECTORY', true),
+  // Relays assist hole-punching and carry end-to-end-encrypted traffic when a direct path
+  // fails — the one disclosed third party, and only ever a fallback. false runs dark.
+  // Strictly parsed BECAUSE this is the privacy setting: a typo must halt, never fail open.
+  relay: envBool('ISA_RELAY', true),
+  // Log every sync decision — turn on first when an album looks wrong.
+  reconcileDebug: envBool('ISA_RECONCILE_DEBUG', false),
 };
 export const log = (...a) => console.log(new Date().toISOString(), ...a);
 export const UTILITY_SUFFIX = ' (via shared albums)';
@@ -105,7 +147,8 @@ export const BOT_PREFIX = {
  * carried a server name: the decorated name travelled as the "true" contributor, the receiver
  * appended its own suffix, and the decoration accumulated one layer per relay hop
  * ("Nan (via B server) (via shared albums)"). Greedy on purpose, so a doubled name collapses back
- * to the person in one pass.
+ * to the person in one pass. Callers must gate on the account being a BOT (`utility` flag /
+ * isUtilityEmail) — a human genuinely named with a trailing "(via …)" must travel as written.
  */
 export const personName = (name?: string) => (name || '').replace(/\s*\(via .*\)\s*$/, '').trim();
 
@@ -122,6 +165,7 @@ export const isUtilityEmail = (email?: string) => !!email && email.endsWith(`@${
  * "sidecar" was a generic term staking a claim another Immich addon could reasonably want, so
  * it moved to a name specific to this project. There is deliberately no compatibility shim for
  * the old prefix: the install base was small enough that a clean break beat carrying a second
- * route surface forever. Both peers must run a version that agrees on this.
+ * route surface forever. Both peers must run a version that agrees on this — a member's share
+ * page probes the ORIGIN's prefix, so it could never be per-install configuration.
  */
 export const ROUTE_PREFIX = '/immich-shared-albums';

--- a/src/immich/client.ts
+++ b/src/immich/client.ts
@@ -28,7 +28,6 @@ export const jsonBody = obj => ({
   body: JSON.stringify(obj),
 });
 
-export const UTILITY_SUFFIX = ' (via shared albums)';
 export let USERS = {};
 let USERS_AT = 0;
 export async function usersById(maxAgeMs = 60000) {

--- a/src/immich/contributors.ts
+++ b/src/immich/contributors.ts
@@ -180,10 +180,10 @@ export async function ensureUtilityUser(
   } catch (e) {
     log(`WARNING: could not retire the login password for ${email}: ${e.message}`);
   }
-  if (CFG.utilityQuotaMb > 0) {
+  if (CFG.botQuotaMb > 0) {
     try {
       await immichJson(`/admin/users/${user.id}`, {
-        ...jsonBody({ quotaSizeInBytes: CFG.utilityQuotaMb * 1024 * 1024 }),
+        ...jsonBody({ quotaSizeInBytes: CFG.botQuotaMb * 1024 * 1024 }),
         method: 'PUT',
       });
     } catch (e) {

--- a/src/immich/local-immich-api.md
+++ b/src/immich/local-immich-api.md
@@ -4,12 +4,12 @@ Everything that reads from or writes to **this household's own Immich** lives he
 Nothing in this folder knows about peers or the wire protocol — it only speaks the
 Immich REST API. Higher layers (`p2p/`, `sync/`) compose these functions.
 
-| File | What it does |
-|---|---|
-| `client.ts` | The Immich REST client: the `fetch` wrapper (`immich`/`immichJson`), the 60s-cached users map, album/asset getters (v3 uses `search/metadata`, not embedded album assets), asset upload, metadata apply, and the 1×1 `STUB_JPEG` placeholder. |
-| `refs.ts` | The on-the-wire shape of a shared photo (`AssetRef`). `assetToRef` describes a local asset for a peer; `offerableAssets` is the full set an album may advertise (what manifests use); `shareableAssets` is that minus what a mapping has already sent (the push queue); `buildManifest` renders the offer set. |
+| File              | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client.ts`       | The Immich REST client: the `fetch` wrapper (`immich`/`immichJson`), the 60s-cached users map, album/asset getters (v3 uses `search/metadata`, not embedded album assets), asset upload, metadata apply, and the 1×1 `STUB_JPEG` placeholder.                                                                                                                                                                                                                                            |
+| `refs.ts`         | The on-the-wire shape of a shared photo (`AssetRef`). `assetToRef` describes a local asset for a peer; `offerableAssets` is the full set an album may advertise (what manifests use); `shareableAssets` is that minus what a mapping has already sent (the push queue); `buildManifest` renders the offer set.                                                                                                                                                                           |
 | `contributors.ts` | Per-contributor **utility users** (`person-<their user id on their own server>@immich-shared-albums.invalid` — one account per remote person, never keyed by display name). Foreign photos are owned by these bot users so they stay out of the local timeline while keeping attribution. Provisions/heals them, mints their API keys (toggling password-login if the instance is OAuth-only), and syncs avatars. See the note below — these are the sidecar's most sensitive artefacts. |
-| `materialise.ts` | Writing and un-writing **proxy assets**. `materialiseRef` pulls a ~2 KB stub (or a playable video prefix) and files it under the right contributor; `deleteProxyAsset` removes one — hard-guarded so only utility-owned proxies are ever deletable. Human photos are untouchable. |
+| `materialise.ts`  | Writing and un-writing **proxy assets**. `materialiseRef` pulls a ~2 KB stub (or a playable video prefix) and files it under the right contributor; `deleteProxyAsset` removes one — hard-guarded so only utility-owned proxies are ever deletable. Human photos are untouchable.                                                                                                                                                                                                        |
 
 **Key idea — the hotlink model:** a materialised asset is only a placeholder stub. The
 real pixels never live here; they stream from the owner's server on demand (see `media/`).
@@ -30,5 +30,5 @@ sensitive thing the sidecar writes, and three properties keep them contained:
   only credential in `state.db` is a scoped key. If the roll fails the password is kept so
   a retry can resume, and the failure is logged.
 
-`UTILITY_QUOTA_MB` optionally caps their storage. Size it well above the shared volume:
+`ISA_BOT_QUOTA_MB` optionally caps their storage. Size it well above the shared volume:
 too low and materialisation starts failing silently.

--- a/src/media/cache.ts
+++ b/src/media/cache.ts
@@ -1,7 +1,7 @@
 /**
  * media/cache.ts — a bounded LRU byte-cache for streamed previews. Files live under
  * <dataDir>/cache with accounting in SQLite; a cache, not storage (capped, reclaimable,
- * safe to delete). Disabled when CACHE_MAX_MB=0.
+ * safe to delete). Disabled when ISA_CACHE_MAX_MB=0.
  */
 import fs from 'node:fs';
 import crypto from 'node:crypto';

--- a/src/media/hotlink-bytes.md
+++ b/src/media/hotlink-bytes.md
@@ -4,11 +4,11 @@ Where the actual pixels come from. Mirrors store only kilobyte stubs; when a dev
 asks for a thumbnail, preview, original or video, these modules fetch the **real bytes
 live from the owner's server** (chained through the origin for relayed photos).
 
-| File | What it does |
-|---|---|
-| `proxy.ts` | `fetchTrueBytes` resolves an asset's true pixels: a local file for our own photos, or a chained iroh request to the owner's server for a proxy (how a relayed photo streams `D <- origin <- contributor`). `Range` rides the request frame for seekable video. `servePeerBytes` is the peer-facing side, served from the iroh route table. |
-| `interceptor.ts` | The **app-facing** side: intercepts the stock app's own asset URLs (`/api/assets/:id/{thumbnail,original,video/playback}`) and, for a proxy asset, serves true bytes (previews via the LRU cache) — falling through to Immich's stub on any failure. Called by the web router. |
-| `cache.ts` | A bounded **LRU byte-cache** for streamed previews. Files live under `<dataDir>/cache` with accounting in SQLite. It is a *cache, not storage* — capped (`CACHE_MAX_MB`, default 512), reclaimable, and safe to delete any time. Repeat views skip the cross-server fetch; recently-viewed photos survive owner downtime. |
+| File             | What it does                                                                                                                                                                                                                                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `proxy.ts`       | `fetchTrueBytes` resolves an asset's true pixels: a local file for our own photos, or a chained iroh request to the owner's server for a proxy (how a relayed photo streams `D <- origin <- contributor`). `Range` rides the request frame for seekable video. `servePeerBytes` is the peer-facing side, served from the iroh route table. |
+| `interceptor.ts` | The **app-facing** side: intercepts the stock app's own asset URLs (`/api/assets/:id/{thumbnail,original,video/playback}`) and, for a proxy asset, serves true bytes (previews via the LRU cache) — falling through to Immich's stub on any failure. Called by the web router.                                                             |
+| `cache.ts`       | A bounded **LRU byte-cache** for streamed previews. Files live under `<dataDir>/cache` with accounting in SQLite. It is a _cache, not storage_ — capped (`ISA_CACHE_MAX_MB`, default 512), reclaimable, and safe to delete any time. Repeat views skip the cross-server fetch; recently-viewed photos survive owner downtime.              |
 
 **Fail-open:** if the owner's server is unreachable and nothing is cached, the interceptor
 falls back to the local stub (a placeholder tile) rather than erroring — the app keeps working.
@@ -19,12 +19,12 @@ These are the only routes that hand out real pixels, and the local branch of
 `fetchTrueBytes` reads with the admin key — so who is asking matters more here than
 anywhere else. The two entry points authorise in completely different ways:
 
-- **`interceptor.ts` serves the household's own app**, so it authorises with the *caller's
-  own* Immich credentials: it probes `/assets/:id` with their cookie or API key and serves
+- **`interceptor.ts` serves the household's own app**, so it authorises with the _caller's
+  own_ Immich credentials: it probes `/assets/:id` with their cookie or API key and serves
   bytes only if Immich itself would have. The sidecar never grants access Immich wouldn't.
 - **`proxy.ts` serves other households**, so it needs both halves: the connection's proven
   identity (mutual TLS on the household keys — the transport hands `servePeerBytes` the
-  caller) *and* entitlement (`p2p/entitlement.peerMayRead`). Identity says which peer;
+  caller) _and_ entitlement (`p2p/entitlement.peerMayRead`). Identity says which peer;
   entitlement says whether that peer was ever offered this asset. Identity alone would mean
   any enrolled peer could read anything in the library it could name — asset ids are not
   secrets, and manifests hand them out by design.
@@ -32,5 +32,5 @@ anywhere else. The two entry points authorise in completely different ways:
 **Streams have no read deadline, and the callers are not strangers.** A legitimate 4K
 original may stream for minutes, and every byte flows over a mutually authenticated iroh
 connection: an unknown key can reach only the two enrolment routes, never bytes. Memory
-stays bounded regardless — request frames are length-capped (64 KB headers, `MAX_BODY_KB`
+stays bounded regardless — request frames are length-capped (64 KB headers, `ISA_MAX_BODY_KB`
 bodies) and responses stream chunk by chunk.

--- a/src/p2p/mirror.ts
+++ b/src/p2p/mirror.ts
@@ -87,7 +87,9 @@ export async function ensureMirror(req: MirrorRequest): Promise<{ mapping: Mappi
     try {
       mirror = await immichJson(
         '/albums',
-        jsonBody({ albumName: CFG.template.replace('{name}', album.name) }),
+        jsonBody({
+          albumName: CFG.mirrorAlbumTemplate.replaceAll('{name}', album.name).replaceAll('{peer}', peer.name),
+        }),
         host.apiKey
       );
       break;

--- a/src/p2p/protocol.ts
+++ b/src/p2p/protocol.ts
@@ -56,8 +56,8 @@ export async function handleRedeem(callerPub: string, body: string) {
       log(`redeem refused: wrong album password from "${household.name}"`);
       return [403, { error: 'incorrect album password' }];
     }
-  } else if (CFG.requireSharePassword) {
-    log('redeem refused: REQUIRE_SHARE_PASSWORD is set and this link has no password');
+  } else if (CFG.linkJoinRequiresPassword) {
+    log('redeem refused: ISA_LINK_JOIN_REQUIRES_PASSWORD is set and this link has no password');
     return [403, { error: 'this server only shares albums whose link has a password set' }];
   }
   const album = await getAlbum(link.album.id);

--- a/src/p2p/transport.ts
+++ b/src/p2p/transport.ts
@@ -53,8 +53,8 @@ export async function startTransport(handler: PeerHandler): Promise<void> {
   const builder = Endpoint.builder();
   presetMinimal(builder);
   // Relays assist hole-punching and carry end-to-end-encrypted traffic when a direct path
-  // fails — the one disclosed third party, and only ever a fallback. RELAY=off runs dark.
-  if (process.env.RELAY !== 'off') builder.relayMode(RelayMode.defaultMode());
+  // fails — the one disclosed third party, and only ever a fallback. ISA_RELAY=off runs dark.
+  if (CFG.relay) builder.relayMode(RelayMode.defaultMode());
   builder.alpns([PROTOCOL_ALPN]);
   builder.secretKey(secretSeed());
   endpoint = await builder.bind();

--- a/src/p2p/wire-protocol.md
+++ b/src/p2p/wire-protocol.md
@@ -20,21 +20,21 @@ certificates, and no listening HTTP surface for peers at all.
   **Discovery is never enabled** — tickets and tokens carry the address, so no registry learns a
   server exists.
 
-| File | What it does |
-|---|---|
-| `transport.ts` | The iroh endpoint: lifecycle (the endpoint secret IS the household key's seed), dial-by-key with self-refreshing hints, the frame codec, `peerRequest`/`peerByteRequest`. |
-| `routes.ts` | The peer route table, served from the accept loop — the only place peer operations exist. Gates `/invites/redeem` on the panel's `shareLinkJoin` setting. |
-| `protocol.ts` | Inbound handlers, mostly owner-side. `handleRedeem` turns a share key into a pinned peer + mapping and returns the manifest; `handleRefs` accepts pushed photos; `handleVersion`/`handleManifest` answer the cheap handshake and the full offer set; `handleNudge` reacts to "something moved, pull now". Each returns `[status, jsonBody]` for `routes.ts` to frame. |
-| `pair.ts` | Linking two servers as its own act. Mints an `isa2-…` ticket — this endpoint's key + dial hints + a single-use, 15-minute, 32-byte secret — and `handlePair` burns the secret **before** answering, so a replay finds nothing. The redeeming side dials the ticket's key, and the dial only succeeds if the far end holds it: identity is verified by connecting. Pairing conveys **no album access** — what the two servers may see of each other is decided afterwards, per person, in Immich's own picker. |
-| `join.ts` | The **member side** of joining. Dials the endpoint carried by the invite, redeems the share key, pins the peer (refusing an origin that answers with a different identity than the invite named), creates the local mirror, and kicks off the first reconcile. Idempotent — re-joining adds the user to the existing mirror. |
-| `mirror.ts` | Creating the local mirror of a remote album — the account-owner, local members as editors, the mapping, and the background fill. Shared by `join.ts` (share link) and `sync/invites.ts` (native invitation): two ways to acquire an album, one way to mirror it. |
-| `entitlement.ts` | What a peer may **read**, as distinct from who it is. Records every asset advertised to a mapping, and answers the byte routes' "is this peer allowed this asset". |
-| `unlink.ts` | Cutting a server link, from the panel. Tears down mirrors held from that peer (via `sync/leave.ts`, so their stubs go too), drops the mappings and entitlement for albums shared *to* them, and deletes that peer's per-person accounts with `force: true` — **assets leave with their owner**. Unlinking is destructive by design, and the panel confirms it. |
+| File             | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `transport.ts`   | The iroh endpoint: lifecycle (the endpoint secret IS the household key's seed), dial-by-key with self-refreshing hints, the frame codec, `peerRequest`/`peerByteRequest`.                                                                                                                                                                                                                                                                                                                                     |
+| `routes.ts`      | The peer route table, served from the accept loop — the only place peer operations exist. Gates `/invites/redeem` on the panel's `shareLinkJoin` setting.                                                                                                                                                                                                                                                                                                                                                     |
+| `protocol.ts`    | Inbound handlers, mostly owner-side. `handleRedeem` turns a share key into a pinned peer + mapping and returns the manifest; `handleRefs` accepts pushed photos; `handleVersion`/`handleManifest` answer the cheap handshake and the full offer set; `handleNudge` reacts to "something moved, pull now". Each returns `[status, jsonBody]` for `routes.ts` to frame.                                                                                                                                         |
+| `pair.ts`        | Linking two servers as its own act. Mints an `isa2-…` ticket — this endpoint's key + dial hints + a single-use, 15-minute, 32-byte secret — and `handlePair` burns the secret **before** answering, so a replay finds nothing. The redeeming side dials the ticket's key, and the dial only succeeds if the far end holds it: identity is verified by connecting. Pairing conveys **no album access** — what the two servers may see of each other is decided afterwards, per person, in Immich's own picker. |
+| `join.ts`        | The **member side** of joining. Dials the endpoint carried by the invite, redeems the share key, pins the peer (refusing an origin that answers with a different identity than the invite named), creates the local mirror, and kicks off the first reconcile. Idempotent — re-joining adds the user to the existing mirror.                                                                                                                                                                                  |
+| `mirror.ts`      | Creating the local mirror of a remote album — the account-owner, local members as editors, the mapping, and the background fill. Shared by `join.ts` (share link) and `sync/invites.ts` (native invitation): two ways to acquire an album, one way to mirror it.                                                                                                                                                                                                                                              |
+| `entitlement.ts` | What a peer may **read**, as distinct from who it is. Records every asset advertised to a mapping, and answers the byte routes' "is this peer allowed this asset".                                                                                                                                                                                                                                                                                                                                            |
+| `unlink.ts`      | Cutting a server link, from the panel. Tears down mirrors held from that peer (via `sync/leave.ts`, so their stubs go too), drops the mappings and entitlement for albums shared _to_ them, and deletes that peer's per-person accounts with `force: true` — **assets leave with their owner**. Unlinking is destructive by design, and the panel confirms it.                                                                                                                                                |
 
 **The share-link handshake, end to end:** the origin's share page embeds its endpoint token → the
 join card forwards it in the v2 invite fragment (never a server log) → the visitor's own sidecar
 dials the origin and redeems → the origin pins the caller's proven key and returns the manifest →
-the joiner materialises it via `sync/`. The origin's HTTPS exists for the *page*; the protocol leg
+the joiner materialises it via `sync/`. The origin's HTTPS exists for the _page_; the protocol leg
 needs no exposed surface anywhere.
 
 ## What the connection does and does not prove
@@ -44,7 +44,7 @@ forward-secret. On its own it says nothing about what that peer may touch, and t
 the same thing is how a peer-to-peer protocol turns into an open door. Two rules follow, and every
 inbound handler keeps them:
 
-1. **Look mappings up *with* the caller.** `peers.mappingFor` always filters on
+1. **Look mappings up _with_ the caller.** `peers.mappingFor` always filters on
    `m.peer === peerPub`. Without that term a mapping id alone selects an album, and any enrolled
    peer can act on a relationship belonging to a different household.
 2. **A nudge is a hint, never a source.** `handleNudge` reconciles against the mapping's own
@@ -60,7 +60,7 @@ inbound handler keeps them:
   get wrong.
 - **A grant an admin or owner actually made**: a pairing secret (single-use, burned before the
   answer) or a share key, whose own rules — expiry, password (constant-time compared),
-  `REQUIRE_SHARE_PASSWORD` — are honoured exactly as Immich's share page honours them.
+  `ISA_LINK_JOIN_REQUIRES_PASSWORD` — are honoured exactly as Immich's share page honours them.
 - **Idempotency.** Re-redeeming reuses the existing mapping rather than minting another, so a
   valid grant is not an unbounded state-growth lever.
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -9,6 +9,19 @@ import { CFG } from './config.ts';
 
 // 0700: this directory holds the identity key and every bot account's API key.
 fs.mkdirSync(CFG.dataDir, { recursive: true, mode: 0o700 });
+// The identity key IS this server's identity: lose the volume and every pairing dies with it.
+// A data dir on the container's own filesystem (or an anonymous volume) survives restarts but
+// not recreation — loud warning rather than silent data loss on the next `down`.
+try {
+  const { dev: dataDev } = fs.statSync(CFG.dataDir);
+  const { dev: rootDev } = fs.statSync('/');
+  if (dataDev === rootDev)
+    console.error(
+      `WARNING: ${CFG.dataDir} is not a mounted volume — this server's identity will be lost when the container is recreated. Bind-mount it (see deploy/docker-compose.example.yml).`
+    );
+} catch {
+  /* stat quirks on exotic filesystems must not stop boot */
+}
 export const store = new Store(CFG.dataDir);
 export const state = store.state;
 /**

--- a/src/sync/comments.ts
+++ b/src/sync/comments.ts
@@ -172,8 +172,5 @@ export async function pullCanonicalComments(mapping, peer) {
 // comments ride a fast lane: the count statistic is one indexed query, so seconds-level
 // cadence stays cheap even on low-power hosts; the full activity fetch only runs on change
 export function startCommentLoop() {
-  setInterval(
-    () => syncComments().catch(e => log('comment loop:', e.message)),
-    Number(process.env.COMMENT_POLL_MS || 5000)
-  );
+  setInterval(() => syncComments().catch(e => log('comment loop:', e.message)), CFG.commentPollMs);
 }

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -134,7 +134,7 @@ export async function reconcileMapping(mapping: Mapping, peer: Peer) {
     // where the two agree — dirty reads retry next cycle instead of poisoning the cursor.
     const expectedCount = version ? Number(String(version).split('|')[1]) : NaN;
     const consistent = !Number.isFinite(expectedCount) || manifest.length === expectedCount;
-    if (process.env.RECONCILE_DEBUG)
+    if (CFG.reconcileDebug)
       log(
         `DBG reconcile "${mapping.albumName}": version=${version} cursor=${mapping.remoteVersion} manifest=${manifest.length} expected=${expectedCount} consistent=${consistent} ledger=${store.seenForMapping(mapping.id).length}`
       );
@@ -144,7 +144,7 @@ export async function reconcileMapping(mapping: Mapping, peer: Peer) {
     if (version && consistent) {
       const offered = new Set(manifest.map(x => x.checksum));
       for (const entry of store.seenForMapping(mapping.id)) {
-        if (process.env.RECONCILE_DEBUG)
+        if (CFG.reconcileDebug)
           log(
             `DBG entry c=${entry.checksum.slice(0, 8)} o=${!!entry.originAsset} offered=${offered.has(entry.checksum)}`
           );
@@ -188,5 +188,5 @@ export function startWatchLoop() {
       .finally(() => {
         WATCH_RUNNING = false;
       });
-  }, CFG.pollMs);
+  }, CFG.syncPollMs);
 }

--- a/src/sync/invites.ts
+++ b/src/sync/invites.ts
@@ -37,11 +37,11 @@ import crypto from 'node:crypto';
 /**
  * Our own human users, as offered to a paired household so they can invite one of us
  * specifically. NAMES ONLY — never emails, and never the bot users. Off entirely when
- * SHARE_USER_DIRECTORY=false, which disables native invitations with that peer altogether —
+ * ISA_PUBLISH_USER_DIRECTORY=false, which disables native invitations with that peer altogether —
  * sharing is per person, so with no directory there is nobody to name. Share links still work.
  */
 export async function localDirectory() {
-  if (!CFG.shareUserDirectory) return [];
+  if (!CFG.publishUserDirectory) return [];
   const users = await immichJson('/admin/users');
   return (users || [])
     .filter(u => !isUtilityEmail(u.email) && !u.deletedAt)
@@ -156,7 +156,7 @@ export async function detectInvitesOnce() {
     // given album: inviting two people from the same household to one album must mirror for both.
     // Abort the peer on ANY read failure — a partial view is indistinguishable from a withdrawal.
     const targets = inviteTargetsFor(peer.pub);
-    if (!targets.length) continue; // directory not shared yet, or SHARE_USER_DIRECTORY=false
+    if (!targets.length) continue; // directory not shared yet, or ISA_PUBLISH_USER_DIRECTORY=false
     const seen: Seen = { invited: new Map(), visible: new Set() };
     const invitees = new Map<string, Set<string>>();
     let readFailed = false;
@@ -453,5 +453,5 @@ export function startInviteLoop() {
     })().finally(() => {
       INVITES_RUNNING = false;
     });
-  }, CFG.pollMs);
+  }, CFG.syncPollMs);
 }

--- a/src/sync/sync-loops.md
+++ b/src/sync/sync-loops.md
@@ -3,22 +3,22 @@
 The background engine that keeps mirrors up to date in both directions. Runs on timers;
 also driven on demand by nudges (`../p2p/protocol.ts`) so changes land in seconds.
 
-| File | What it does |
-|---|---|
-| `invites.ts` | **Native album invitations, per person.** Every person on a linked server gets a local marker user; adding one to an album in Immich's own picker shares that album with that person, and removing them revokes it. The origin detects this by listing albums as each marker; members discover it by polling the `/invitations` peer route (over iroh). Server *linking* is not here — it is admin-owned, in [`p2p/unlink.ts`](../p2p/) and the panel. |
-| `engine.ts` | Photo sync. `watchOnce` pushes local additions out to peers; `reconcileOnce`/`reconcileMapping` pull the origin manifest, materialise anything missing, and **propagate deletions** (with a consistency gate so an indexing lag never wrongly deletes). `startWatchLoop` runs it on an overlap-guarded interval. |
-| `leave.ts` | `leaveAlbum` — the full reverse of a join: purges every stub, the mirror album, the mapping and its ledger. |
-| `comments.ts` | Cross-server comments. The origin album is the source of truth: members pull the canonical list and push their own, gated by a cheap activity-count statistic so messages land in seconds without heavy polling. Includes the inbound `handleActivity`/`handleComments` handlers. `startCommentLoop` runs the fast lane. |
+| File          | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `invites.ts`  | **Native album invitations, per person.** Every person on a linked server gets a local marker user; adding one to an album in Immich's own picker shares that album with that person, and removing them revokes it. The origin detects this by listing albums as each marker; members discover it by polling the `/invitations` peer route (over iroh). Server _linking_ is not here — it is admin-owned, in [`p2p/unlink.ts`](../p2p/) and the panel. |
+| `engine.ts`   | Photo sync. `watchOnce` pushes local additions out to peers; `reconcileOnce`/`reconcileMapping` pull the origin manifest, materialise anything missing, and **propagate deletions** (with a consistency gate so an indexing lag never wrongly deletes). `startWatchLoop` runs it on an overlap-guarded interval.                                                                                                                                       |
+| `leave.ts`    | `leaveAlbum` — the full reverse of a join: purges every stub, the mirror album, the mapping and its ledger.                                                                                                                                                                                                                                                                                                                                            |
+| `comments.ts` | Cross-server comments. The origin album is the source of truth: members pull the canonical list and push their own, gated by a cheap activity-count statistic so messages land in seconds without heavy polling. Includes the inbound `handleActivity`/`handleComments` handlers. `startCommentLoop` runs the fast lane.                                                                                                                               |
 
 **Why loops and not just webhooks:** nudges make the common case instant, but the timed
 sweep is the safety net — a lost nudge costs nothing because the next scheduled handshake
-catches everything (fail-open by design). `RECONCILE_DEBUG=1` traces every decision.
+catches everything (fail-open by design). `ISA_RECONCILE_DEBUG=1` traces every decision.
 
 ## Why sharing is per person, and links are not shareable objects
 
 Sharing names a **person**, never a whole server. A server link is not a person, so it gets no
 marker user and never appears in Immich's people picker; it is created by redeeming a share link
-and destroyed from the panel (`…/unlink`). This also means `SHARE_USER_DIRECTORY=false` disables
+and destroyed from the panel (`…/unlink`). This also means `ISA_PUBLISH_USER_DIRECTORY=false` disables
 native invitations with that peer — with no directory there is nobody to name — and share links
 remain the way in.
 
@@ -31,14 +31,14 @@ one person would appear to work and silently do nothing.
 
 `GET /albums` is scoped per user, so the admin key only ever sees the admin's own albums —
 which is exactly why a non-admin cannot share cross-server through a share link today. Asking
-*as the stand-in* sidesteps it: it does not matter who owns the album, only that the stand-in
+_as the stand-in_ sidesteps it: it does not matter who owns the album, only that the stand-in
 was invited to it.
 
 Three Immich behaviours this has to allow for:
 
 - the album **owner** appears inside `albumUsers` with `role: 'owner'`, and `GET /albums`
   returns no `ownerId` at all — so the owner is only discoverable there;
-- a stand-in that *owns* an album is a mirror we created for inbound content, not an
+- a stand-in that _owns_ an album is a mirror we created for inbound content, not an
   invitation, so those are skipped;
 - adding a user who is already the owner returns **200 and is silently ignored**, so a 200 is
   never proof an invitation took. Read `albumUsers` back.

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -1,14 +1,14 @@
 /** web/assets.ts — serves the committed dist/ artifacts and fills their %%TOKENS%%, escaped. See http-router.md. */
 import fs from 'node:fs';
 import path from 'node:path';
-import { CFG, ROUTE_PREFIX } from '../config.ts';
+import { CFG } from '../config.ts';
 
 const read = (name: string) => {
   const file = path.join(import.meta.dirname, 'dist', name);
   try {
-    // dist hardcodes the default prefix so it stays valid standalone; rewriting here keeps
-    // config.ROUTE_PREFIX the single source of truth.
-    return fs.readFileSync(file, 'utf8').replaceAll('/immich-shared-albums/', `${ROUTE_PREFIX}/`);
+    // The prefix is FIXED (see config.ROUTE_PREFIX: a member's share page probes the origin's
+    // prefix, so it could never vary per install) — dist hardcodes it and is served verbatim.
+    return fs.readFileSync(file, 'utf8');
   } catch {
     console.error(`asset missing at ${file} — run: npm run build:web`);
     return '';

--- a/src/web/http-router.md
+++ b/src/web/http-router.md
@@ -2,33 +2,32 @@
 
 The single process's one HTTP entry point and the HTML it serves — for humans and the stock app only; peer traffic rides iroh (`p2p/`).
 
-| File | What it does |
-|---|---|
-| `server.ts` | The router: a thin dispatch table mapping each path to a handler. Exports `server`; `index.ts` calls `.listen()`. |
-| `passthrough.ts` | The transparent fall-through proxy to Immich for anything that isn't a sidecar route (SPA bundles, `/api`, `?native=1` share pages). Pure stream both directions — it buffers and rewrites nothing; uploads must never be buffered here. |
-| `upgrade.ts` | Websockets and any other protocol upgrade, piped at the socket level. Separate from `passthrough.ts` because `fetch()` cannot carry an upgrade at all: these never reach the router, arriving on the server's `upgrade` event instead. Two transports, two files. |
-| `assets.ts` | Reads the committed `dist/` artifacts once, rewrites the route prefix, and fills each document's `%%TOKENS%%` with escaped per-request values (household name, og tags, the sign-in reason). The only server-side code that touches HTML, and it contains none. |
-| `ui/` | The whole front-end, one Preact workspace: `lib/Document.tsx` (the single document every page prerenders into), `lib/theme.ts`, and `pages/{panel,accept,share,sign-in}` — each page is TSX components plus a real `.css` file. `scripts/build-web.mjs` bundles and prerenders it into `dist/`. |
-| `dist/` | Committed build output — `<page>.js`, `<page>.css`, prerendered `<page>.html`. Committed so the Dockerfile stays seven lines with no build step; the pre-commit hook rebuilds and stages it, and CI fails on drift. |
-| `auth.ts` | Who is calling a human-facing route. Forwards the caller's own Immich credentials (session cookie or API key) to Immich's `/users/me` and believes the answer. The sidecar has no accounts of its own and must never invent any. |
-
+| File             | What it does                                                                                                                                                                                                                                                                                    |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server.ts`      | The router: a thin dispatch table mapping each path to a handler. Exports `server`; `index.ts` calls `.listen()`.                                                                                                                                                                               |
+| `passthrough.ts` | The transparent fall-through proxy to Immich for anything that isn't a sidecar route (SPA bundles, `/api`, `?native=1` share pages). Pure stream both directions — it buffers and rewrites nothing; uploads must never be buffered here.                                                        |
+| `upgrade.ts`     | Websockets and any other protocol upgrade, piped at the socket level. Separate from `passthrough.ts` because `fetch()` cannot carry an upgrade at all: these never reach the router, arriving on the server's `upgrade` event instead. Two transports, two files.                               |
+| `assets.ts`      | Reads the committed `dist/` artifacts once, rewrites the route prefix, and fills each document's `%%TOKENS%%` with escaped per-request values (household name, og tags, the sign-in reason). The only server-side code that touches HTML, and it contains none.                                 |
+| `ui/`            | The whole front-end, one Preact workspace: `lib/Document.tsx` (the single document every page prerenders into), `lib/theme.ts`, and `pages/{panel,accept,share,sign-in}` — each page is TSX components plus a real `.css` file. `scripts/build-web.mjs` bundles and prerenders it into `dist/`. |
+| `dist/`          | Committed build output — `<page>.js`, `<page>.css`, prerendered `<page>.html`. Committed so the Dockerfile stays seven lines with no build step; the pre-commit hook rebuilds and stages it, and CI fails on drift.                                                                             |
+| `auth.ts`        | Who is calling a human-facing route. Forwards the caller's own Immich credentials (session cookie or API key) to Immich's `/users/me` and believes the answer. The sidecar has no accounts of its own and must never invent any.                                                                |
 
 ## Who may call what
 
 Every route here can be published to the internet, so reachability is never permission.
 There are three tiers, and each is enforced server-side:
 
-| Tier | Routes | Gate |
-|---|---|---|
-| Public | `/immich-shared-albums/health`, `/immich-shared-albums/accept`, `/immich-shared-albums/assets/*`, `/share/:key` (the join document; `?native=1` passes through) | none — liveness, static pages and their assets. `health` returns `{ok:true}` and nothing else, because the join card probes it cross-origin to discover a sidecar. |
-| Signed-in human | `/immich-shared-albums/join`, `/leave`, `/peers`, `/pairings`, `/pairings/revoke`, `/pair`, `/settings`, `/unlink`, the panel | `auth.ts` against the caller's Immich session. `join` takes the account from the **session**, not the request body; naming a different user requires admin. Everything else here requires admin — server links and settings are admin-owned objects. |
-| Peers | **nothing** — peer operations left HTTP entirely and ride mutually authenticated iroh QUIC; see [`../p2p/wire-protocol.md`](../p2p/wire-protocol.md). The router serves humans and the app, full stop. |
+| Tier            | Routes                                                                                                                                                                                                 | Gate                                                                                                                                                                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public          | `/immich-shared-albums/health`, `/immich-shared-albums/accept`, `/immich-shared-albums/assets/*`, `/share/:key` (the join document; `?native=1` passes through)                                        | none — liveness, static pages and their assets. `health` returns `{ok:true}` and nothing else, because the join card probes it cross-origin to discover a sidecar.                                                                                   |
+| Signed-in human | `/immich-shared-albums/join`, `/leave`, `/peers`, `/pairings`, `/pairings/revoke`, `/pair`, `/settings`, `/unlink`, the panel                                                                          | `auth.ts` against the caller's Immich session. `join` takes the account from the **session**, not the request body; naming a different user requires admin. Everything else here requires admin — server links and settings are admin-owned objects. |
+| Peers           | **nothing** — peer operations left HTTP entirely and ride mutually authenticated iroh QUIC; see [`../p2p/wire-protocol.md`](../p2p/wire-protocol.md). The router serves humans and the app, full stop. |
 
 The accept page's client-side `whoami` is UX only — it tells someone to sign in before
 they fill a form. The server never trusts it.
 
 **Two ordering rules in `server.ts`:** route before reading a body (only the sidecar's own
-JSON routes are buffered, under `MAX_BODY_KB`; passthrough traffic including photo uploads
+JSON routes are buffered, under `ISA_MAX_BODY_KB`; passthrough traffic including photo uploads
 streams through), and authorise before doing work.
 
 ## The share document, and the switch that governs it

--- a/src/web/share.bundle.js
+++ b/src/web/share.bundle.js
@@ -1,4 +1,750 @@
-var B,f,pe,ze,E,se,fe,he,J,F,D,de,G,K,Y,$e,$={},W=[],We=/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,O=Array.isArray;function C(t,e){for(var n in e)t[n]=e[n];return t}function Q(t){t&&t.parentNode&&t.parentNode.removeChild(t)}function Le(t,e,n){var i,_,o,s={};for(o in e)o=="key"?i=e[o]:o=="ref"?_=e[o]:s[o]=e[o];if(arguments.length>2&&(s.children=arguments.length>3?B.call(arguments,2):n),typeof t=="function"&&t.defaultProps!=null)for(o in t.defaultProps)s[o]===void 0&&(s[o]=t.defaultProps[o]);return R(t,s,i,_,null)}function R(t,e,n,i,_){var o={type:t,props:e,key:n,ref:i,__k:null,__:null,__b:0,__e:null,__c:null,constructor:void 0,__v:_??++pe,__i:-1,__u:0};return _==null&&f.vnode!=null&&f.vnode(o),o}function A(t){return t.children}function z(t,e){this.props=t,this.context=e}function P(t,e){if(e==null)return t.__?P(t.__,t.__i+1):null;for(var n;e<t.__k.length;e++)if((n=t.__k[e])!=null&&n.__e!=null)return n.__e;return typeof t.type=="function"?P(t):null}function Be(t){if(t.__P&&t.__d){var e=t.__v,n=e.__e,i=[],_=[],o=C({},e);o.__v=e.__v+1,f.vnode&&f.vnode(o),X(t.__P,o,e,t.__n,t.__P.namespaceURI,32&e.__u?[n]:null,i,n??P(e),!!(32&e.__u),_),o.__v=e.__v,o.__.__k[o.__i]=o,ye(i,o,_),e.__e=e.__=null,o.__e!=n&&me(o)}}function me(t){if((t=t.__)!=null&&t.__c!=null)return t.__e=t.__c.base=null,t.__k.some(function(e){if(e!=null&&e.__e!=null)return t.__e=t.__c.base=e.__e}),me(t)}function le(t){(!t.__d&&(t.__d=!0)&&E.push(t)&&!L.__r++||se!=f.debounceRendering)&&((se=f.debounceRendering)||fe)(L)}function L(){try{for(var t,e=1;E.length;)E.length>e&&E.sort(he),t=E.shift(),e=E.length,Be(t)}finally{E.length=L.__r=0}}function be(t,e,n,i,_,o,s,l,u,a,p){var d,r,c,m,k,x,y=i&&i.__k||W,h=e.length;for(u=Oe(n,e,y,u,h),d=0;d<h;d++)(c=n.__k[d])!=null&&(r=c.__i!=-1&&y[c.__i]||$,c.__i=d,x=X(t,c,r,_,o,s,l,u,a,p),m=c.__e,c.ref&&r.ref!=c.ref&&(r.ref&&Z(r.ref,null,c),p.push(c.ref,c.__c||m,c)),k==null&&m!=null&&(k=m),4&c.__u?(u=ve(c,u,t),r.__e&&(r.__e=null)):typeof c.type=="function"&&x!==void 0?u=x:m&&(u=m.nextSibling),c.__u&=-7);return n.__e=k,u}function Oe(t,e,n,i,_){var o,s,l,u,a,p=n.length,d=p,r=0;for(t.__k=new Array(_),o=0;o<_;o++)(s=e[o])!=null&&typeof s!="boolean"&&typeof s!="function"?(typeof s=="string"||typeof s=="number"||typeof s=="bigint"||s.constructor==String?s=t.__k[o]=R(null,s,null,null,null):O(s)?s=t.__k[o]=R(A,{children:s},null,null,null):s.constructor===void 0&&s.__b>0?s=t.__k[o]=R(s.type,s.props,s.key,s.ref?s.ref:null,s.__v):t.__k[o]=s,u=o+r,s.__=t,s.__b=t.__b+1,l=null,(a=s.__i=Ve(s,n,u,d))!=-1&&(d--,(l=n[a])&&(l.__u|=2)),l==null||l.__v==null?(a==-1&&(_>p?r--:_<p&&r++),typeof s.type!="function"&&(s.__u|=4)):a!=u&&(a==u-1?r--:a==u+1?r++:(a>u?r--:r++,s.__u|=4))):t.__k[o]=null;if(d)for(o=0;o<p;o++)(l=n[o])!=null&&(2&l.__u)==0&&(l.__e==i&&(i=P(l)),ke(l,l));return i}function ve(t,e,n){var i,_;if(typeof t.type=="function"){for(i=t.__k,_=0;i&&_<i.length;_++)i[_]&&(i[_].__=t,e=ve(i[_],e,n));return e}t.__e!=e&&(e&&t.type&&!e.parentNode&&(e=P(t)),e=n.insertBefore(t.__e,e||null));do e=e&&e.nextSibling;while(e!=null&&e.nodeType==8);return e}function Ve(t,e,n,i){var _,o,s,l=t.key,u=t.type,a=e[n],p=a!=null&&(2&a.__u)==0;if(a===null&&l==null||p&&l==a.key&&u==a.type)return n;if(i>(p?1:0)){for(_=n-1,o=n+1;_>=0||o<e.length;)if((a=e[s=_>=0?_--:o++])!=null&&(2&a.__u)==0&&l==a.key&&u==a.type)return s}return-1}function ce(t,e,n){e[0]=="-"?t.setProperty(e,n??""):t[e]=n==null?"":typeof n!="number"||We.test(e)?n:n+"px"}function j(t,e,n,i,_){var o,s;e:if(e=="style")if(typeof n=="string")t.style.cssText=n;else{if(typeof i=="string"&&(t.style.cssText=i=""),i)for(e in i)n&&e in n||ce(t.style,e,"");if(n)for(e in n)i&&n[e]==i[e]||ce(t.style,e,n[e])}else if(e[0]=="o"&&e[1]=="n")o=e!=(e=e.replace(de,"$1")),s=e.toLowerCase(),e=s in t||e=="onFocusOut"||e=="onFocusIn"?s.slice(2):e.slice(2),t.l||(t.l={}),t.l[e+o]=n,n?i?n[D]=i[D]:(n[D]=G,t.addEventListener(e,o?Y:K,o)):t.removeEventListener(e,o?Y:K,o);else{if(_=="http://www.w3.org/2000/svg")e=e.replace(/xlink(H|:h)/,"h").replace(/sName$/,"s");else if(e!="width"&&e!="height"&&e!="href"&&e!="list"&&e!="form"&&e!="tabIndex"&&e!="download"&&e!="rowSpan"&&e!="colSpan"&&e!="role"&&e!="popover"&&e in t)try{t[e]=n??"";break e}catch{}typeof n=="function"||(n==null||n===!1&&e[4]!="-"?t.removeAttribute(e):t.setAttribute(e,e=="popover"&&n==1?"":n))}}function ue(t){return function(e){if(this.l){var n=this.l[e.type+t];if(e[F]==null)e[F]=G++;else if(e[F]<n[D])return;return n(f.event?f.event(e):e)}}}function X(t,e,n,i,_,o,s,l,u,a){var p,d,r,c,m,k,x,y,h,w,M,H,U,ae,N,q,S=e.type;if(e.constructor!==void 0)return null;128&n.__u&&(u=!!(32&n.__u),o=[l=e.__e=n.__e]),(p=f.__b)&&p(e);e:if(typeof S=="function"){d=s.length;try{if(h=e.props,w=S.prototype&&S.prototype.render,M=(p=S.contextType)&&i[p.__c],H=p?M?M.props.value:p.__:i,n.__c?y=(r=e.__c=n.__c).__=r.__E:(w?e.__c=r=new S(h,H):(e.__c=r=new z(h,H),r.constructor=S,r.render=Je),M&&M.sub(r),r.state||(r.state={}),r.__n=i,c=r.__d=!0,r.__h=[],r._sb=[]),w&&r.__s==null&&(r.__s=r.state),w&&S.getDerivedStateFromProps!=null&&(r.__s==r.state&&(r.__s=C({},r.__s)),C(r.__s,S.getDerivedStateFromProps(h,r.__s))),m=r.props,k=r.state,r.__v=e,c)w&&S.getDerivedStateFromProps==null&&r.componentWillMount!=null&&r.componentWillMount(),w&&r.componentDidMount!=null&&r.__h.push(r.componentDidMount);else{if(w&&S.getDerivedStateFromProps==null&&h!==m&&r.componentWillReceiveProps!=null&&r.componentWillReceiveProps(h,H),e.__v==n.__v||!r.__e&&r.shouldComponentUpdate!=null&&r.shouldComponentUpdate(h,r.__s,H)===!1){e.__v!=n.__v&&(r.props=h,r.state=r.__s,r.__d=!1),e.__e=n.__e,e.__k=n.__k,e.__k.some(function(T){T&&(T.__=e)}),W.push.apply(r.__h,r._sb),r._sb=[],r.__h.length&&s.push(r),l=P(n);break e}r.componentWillUpdate!=null&&r.componentWillUpdate(h,r.__s,H),w&&r.componentDidUpdate!=null&&r.__h.push(function(){r.componentDidUpdate(m,k,x)})}if(r.context=H,r.props=h,r.__P=t,r.__e=!1,U=f.__r,ae=0,w)r.state=r.__s,r.__d=!1,U&&U(e),p=r.render(r.props,r.state,r.context),W.push.apply(r.__h,r._sb),r._sb=[];else do r.__d=!1,U&&U(e),p=r.render(r.props,r.state,r.context),r.state=r.__s;while(r.__d&&++ae<25);r.state=r.__s,r.getChildContext!=null&&(i=C(C({},i),r.getChildContext())),w&&!c&&r.getSnapshotBeforeUpdate!=null&&(x=r.getSnapshotBeforeUpdate(m,k)),N=p!=null&&p.type===A&&p.key==null?xe(p.props.children):p,l=be(t,O(N)?N:[N],e,n,i,_,o,s,l,u,a),r.base=e.__e,e.__u&=-161,r.__h.length&&s.push(r),y&&(r.__E=r.__=null)}catch(T){if(s.length=d,e.__v=null,u||o!=null){if(T.then){for(e.__u|=u?160:128;l&&l.nodeType==8&&l.nextSibling;)l=l.nextSibling;o!=null&&(o[o.indexOf(l)]=null),e.__e=l}else if(o!=null)for(q=o.length;q--;)Q(o[q])}else e.__e=n.__e;e.__k==null&&(e.__k=n.__k||[]),T.then||ge(e),f.__e(T,e,n)}}else o==null&&e.__v==n.__v?(e.__k=n.__k,e.__e=n.__e):l=e.__e=qe(n.__e,e,n,i,_,o,s,u,a);return(p=f.diffed)&&p(e),128&e.__u?void 0:l}function ge(t){t&&(t.__c&&(t.__c.__e=!0),t.__k&&t.__k.some(ge))}function ye(t,e,n){for(var i=0;i<n.length;i++)Z(n[i],n[++i],n[++i]);f.__c&&f.__c(e,t),t.some(function(_){try{t=_.__h,_.__h=[],t.some(function(o){o.call(_)})}catch(o){f.__e(o,_.__v)}})}function xe(t){return typeof t!="object"||t==null||t.__b>0?t:O(t)?t.map(xe):t.constructor!==void 0?null:C({},t)}function qe(t,e,n,i,_,o,s,l,u){var a,p,d,r,c,m,k,x=n.props||$,y=e.props,h=e.type;if(h=="svg"?_="http://www.w3.org/2000/svg":h=="math"?_="http://www.w3.org/1998/Math/MathML":_||(_="http://www.w3.org/1999/xhtml"),o!=null){for(a=0;a<o.length;a++)if((c=o[a])&&"setAttribute"in c==!!h&&(h?c.localName==h:c.nodeType==3)){t=c,o[a]=null;break}}if(t==null){if(h==null)return document.createTextNode(y);t=document.createElementNS(_,h,y.is&&y),l&&(f.__m&&f.__m(e,o),l=!1),o=null}if(h==null)x===y||l&&t.data==y||(t.data=y);else{if(o=h=="textarea"&&y.defaultValue!=null?null:o&&B.call(t.childNodes),!l&&o!=null)for(x={},a=0;a<t.attributes.length;a++)x[(c=t.attributes[a]).name]=c.value;for(a in x)c=x[a],a=="dangerouslySetInnerHTML"?d=c:a=="children"||a in y||a=="value"&&"defaultValue"in y||a=="checked"&&"defaultChecked"in y||j(t,a,null,c,_);for(a in y)c=y[a],a=="children"?r=c:a=="dangerouslySetInnerHTML"?p=c:a=="value"?m=c:a=="checked"?k=c:l&&typeof c!="function"||x[a]===c||j(t,a,c,x[a],_);if(p)l||d&&(p.__html==d.__html||p.__html==t.innerHTML)||(t.innerHTML=p.__html),e.__k=[];else if(d&&(t.innerHTML=""),be(e.type=="template"?t.content:t,O(r)?r:[r],e,n,i,h=="foreignObject"?"http://www.w3.org/1999/xhtml":_,o,s,o?o[0]:n.__k&&P(n,0),l,u),o!=null)for(a=o.length;a--;)Q(o[a]);l&&h!="textarea"||(a="value",h=="progress"&&m==null?t.removeAttribute("value"):m!=null&&(m!==t[a]||h=="progress"&&!m||h=="option"&&m!=x[a])&&j(t,a,m,x[a],_),a="checked",k!=null&&k!=t[a]&&j(t,a,k,x[a],_))}return t}function Z(t,e,n){try{if(typeof t=="function"){var i=typeof t.__u=="function";i&&t.__u(),i&&e==null||(t.__u=t(e))}else t.current=e}catch(_){f.__e(_,n)}}function ke(t,e,n){var i,_;if(f.unmount&&f.unmount(t),(i=t.ref)&&(i.current&&i.current!=t.__e||Z(i,null,e)),(i=t.__c)!=null){if(i.componentWillUnmount)try{i.componentWillUnmount()}catch(o){f.__e(o,e)}i.base=i.__P=i.__n=null}if(i=t.__k)for(_=0;_<i.length;_++)i[_]&&ke(i[_],e,n||typeof t.type!="function");n||Q(t.__e),t.__c=t.__=t.__e=void 0}function Je(t,e,n){return this.constructor(t,n)}function we(t,e,n){var i,_,o,s;e==document&&(e=document.documentElement),f.__&&f.__(t,e),_=(i=typeof n=="function")?null:n&&n.__k||e.__k,o=[],s=[],X(e,t=(!i&&n||e).__k=Le(A,null,[t]),_||$,$,e.namespaceURI,!i&&n?[n]:_?null:e.firstChild?B.call(e.childNodes):null,o,!i&&n?n:_?_.__e:e.firstChild,i,s),ye(o,t,s),t.props.children=null}B=W.slice,f={__e:function(t,e,n,i){for(var _,o,s;e=e.__;)if((_=e.__c)&&!_.__)try{if((o=_.constructor)&&o.getDerivedStateFromError!=null&&(_.setState(o.getDerivedStateFromError(t)),s=_.__d),_.componentDidCatch!=null&&(_.componentDidCatch(t,i||{}),s=_.__d),s)return _.__E=_}catch(l){t=l}throw t}},pe=0,ze=function(t){return t!=null&&t.constructor===void 0},z.prototype.setState=function(t,e){var n;n=this.__s!=null&&this.__s!=this.state?this.__s:this.__s=C({},this.state),typeof t=="function"&&(t=t(C({},n),this.props)),t&&C(n,t),t!=null&&this.__v&&(e&&this._sb.push(e),le(this))},z.prototype.forceUpdate=function(t){this.__v&&(this.__e=!0,t&&this.__h.push(t),le(this))},z.prototype.render=A,E=[],fe=typeof Promise=="function"?Promise.prototype.then.bind(Promise.resolve()):setTimeout,he=function(t,e){return t.__v.__b-e.__v.__b},L.__r=0,J=Math.random().toString(8),F="__d"+J,D="__a"+J,de=/(PointerCapture)$|Capture$/i,G=0,K=ue(!1),Y=ue(!0),$e=0;var te,v,ee,Se,ne=0,Ue=[],g=f,Ce=g.__b,Ee=g.__r,Ae=g.diffed,He=g.__c,Pe=g.unmount,Te=g.__;function Ke(t,e){g.__h&&g.__h(v,t,ne||e),ne=0;var n=v.__H||(v.__H={__:[],__h:[]});return t>=n.__.length&&n.__.push({}),n.__[t]}function I(t){return ne=1,Ye(De,t)}function Ye(t,e,n){var i=Ke(te++,2);if(i.t=t,!i.__c&&(i.__=[n?n(e):De(void 0,e),function(l){var u=i.__N?i.__N[0]:i.__[0],a=i.t(u,l);u!==a&&(i.__N=[a,i.__[1]],i.__c.setState({}))}],i.__c=v,!v.__f)){var _=function(l,u,a){if(!i.__c.__H)return!0;var p=!1,d=i.__c.props!==l;if(i.__c.__H.__.some(function(c){if(c.__N){p=!0;var m=c.__[0];c.__=c.__N,c.__N=void 0,m!==c.__[0]&&(d=!0)}}),o){var r=o.call(this,l,u,a);return p?r||d:r}return!p||d};v.__f=!0;var o=v.shouldComponentUpdate,s=v.componentWillUpdate;v.componentWillUpdate=function(l,u,a){if(this.__e){var p=o;o=void 0,_(l,u,a),o=p}s&&s.call(this,l,u,a)},v.shouldComponentUpdate=_}return i.__N||i.__}function Ge(){for(var t;t=Ue.shift();){var e=t.__H;if(t.__P&&e)try{e.__h.some(V),e.__h.some(re),e.__h=[]}catch(n){e.__h=[],g.__e(n,t.__v)}}}g.__b=function(t){v=null,Ce&&Ce(t)},g.__=function(t,e){t&&e.__k&&e.__k.__m&&(t.__m=e.__k.__m),Te&&Te(t,e)},g.__r=function(t){Ee&&Ee(t),te=0;var e=(v=t.__c).__H;e&&(ee===v?(e.__h=[],v.__h=[],e.__.some(function(n){n.__N&&(n.__=n.__N),n.u=n.__N=void 0})):(e.__h.some(V),e.__h.some(re),e.__h=[],te=0)),ee=v},g.diffed=function(t){Ae&&Ae(t);var e=t.__c;e&&e.__H&&(e.__H.__h.length&&(Ue.push(e)!==1&&Se===g.requestAnimationFrame||((Se=g.requestAnimationFrame)||Qe)(Ge)),e.__H.__.some(function(n){n.u&&(n.__H=n.u,n.u=void 0)})),ee=v=null},g.__c=function(t,e){e.some(function(n){try{n.__h.some(V),n.__h=n.__h.filter(function(i){return!i.__||re(i)})}catch(i){e.some(function(_){_.__h&&(_.__h=[])}),e=[],g.__e(i,n.__v)}}),He&&He(t,e)},g.unmount=function(t){Pe&&Pe(t);var e,n=t.__c;n&&n.__H&&(n.__H.__.some(function(i){try{V(i)}catch(_){e=_}}),n.__H=void 0,e&&g.__e(e,n.__v))};var Me=typeof requestAnimationFrame=="function";function Qe(t){var e,n=function(){clearTimeout(i),Me&&cancelAnimationFrame(e),setTimeout(t)},i=setTimeout(n,35);Me&&(e=requestAnimationFrame(n))}function V(t){var e=v,n=t.__c;typeof n=="function"&&(t.__c=void 0,n()),v=e}function re(t){var e=v;t.__c=t.__(),v=e}function De(t,e){return typeof e=="function"?e(t):e}var Ie=(t,...e)=>String.raw({raw:t},...e);var Ne=Ie`
+var B,
+  f,
+  pe,
+  ze,
+  E,
+  se,
+  fe,
+  he,
+  J,
+  F,
+  D,
+  de,
+  G,
+  K,
+  Y,
+  $e,
+  $ = {},
+  W = [],
+  We = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,
+  O = Array.isArray;
+function C(t, e) {
+  for (var n in e) t[n] = e[n];
+  return t;
+}
+function Q(t) {
+  t && t.parentNode && t.parentNode.removeChild(t);
+}
+function Le(t, e, n) {
+  var i,
+    _,
+    o,
+    s = {};
+  for (o in e) o == 'key' ? (i = e[o]) : o == 'ref' ? (_ = e[o]) : (s[o] = e[o]);
+  if (
+    (arguments.length > 2 && (s.children = arguments.length > 3 ? B.call(arguments, 2) : n),
+    typeof t == 'function' && t.defaultProps != null)
+  )
+    for (o in t.defaultProps) s[o] === void 0 && (s[o] = t.defaultProps[o]);
+  return R(t, s, i, _, null);
+}
+function R(t, e, n, i, _) {
+  var o = {
+    type: t,
+    props: e,
+    key: n,
+    ref: i,
+    __k: null,
+    __: null,
+    __b: 0,
+    __e: null,
+    __c: null,
+    constructor: void 0,
+    __v: _ ?? ++pe,
+    __i: -1,
+    __u: 0,
+  };
+  return (_ == null && f.vnode != null && f.vnode(o), o);
+}
+function A(t) {
+  return t.children;
+}
+function z(t, e) {
+  ((this.props = t), (this.context = e));
+}
+function P(t, e) {
+  if (e == null) return t.__ ? P(t.__, t.__i + 1) : null;
+  for (var n; e < t.__k.length; e++) if ((n = t.__k[e]) != null && n.__e != null) return n.__e;
+  return typeof t.type == 'function' ? P(t) : null;
+}
+function Be(t) {
+  if (t.__P && t.__d) {
+    var e = t.__v,
+      n = e.__e,
+      i = [],
+      _ = [],
+      o = C({}, e);
+    ((o.__v = e.__v + 1),
+      f.vnode && f.vnode(o),
+      X(t.__P, o, e, t.__n, t.__P.namespaceURI, 32 & e.__u ? [n] : null, i, n ?? P(e), !!(32 & e.__u), _),
+      (o.__v = e.__v),
+      (o.__.__k[o.__i] = o),
+      ye(i, o, _),
+      (e.__e = e.__ = null),
+      o.__e != n && me(o));
+  }
+}
+function me(t) {
+  if ((t = t.__) != null && t.__c != null)
+    return (
+      (t.__e = t.__c.base = null),
+      t.__k.some(function (e) {
+        if (e != null && e.__e != null) return (t.__e = t.__c.base = e.__e);
+      }),
+      me(t)
+    );
+}
+function le(t) {
+  ((!t.__d && (t.__d = !0) && E.push(t) && !L.__r++) || se != f.debounceRendering) &&
+    ((se = f.debounceRendering) || fe)(L);
+}
+function L() {
+  try {
+    for (var t, e = 1; E.length;) (E.length > e && E.sort(he), (t = E.shift()), (e = E.length), Be(t));
+  } finally {
+    E.length = L.__r = 0;
+  }
+}
+function be(t, e, n, i, _, o, s, l, u, a, p) {
+  var d,
+    r,
+    c,
+    m,
+    k,
+    x,
+    y = (i && i.__k) || W,
+    h = e.length;
+  for (u = Oe(n, e, y, u, h), d = 0; d < h; d++)
+    (c = n.__k[d]) != null &&
+      ((r = (c.__i != -1 && y[c.__i]) || $),
+      (c.__i = d),
+      (x = X(t, c, r, _, o, s, l, u, a, p)),
+      (m = c.__e),
+      c.ref && r.ref != c.ref && (r.ref && Z(r.ref, null, c), p.push(c.ref, c.__c || m, c)),
+      k == null && m != null && (k = m),
+      4 & c.__u
+        ? ((u = ve(c, u, t)), r.__e && (r.__e = null))
+        : typeof c.type == 'function' && x !== void 0
+          ? (u = x)
+          : m && (u = m.nextSibling),
+      (c.__u &= -7));
+  return ((n.__e = k), u);
+}
+function Oe(t, e, n, i, _) {
+  var o,
+    s,
+    l,
+    u,
+    a,
+    p = n.length,
+    d = p,
+    r = 0;
+  for (t.__k = new Array(_), o = 0; o < _; o++)
+    (s = e[o]) != null && typeof s != 'boolean' && typeof s != 'function'
+      ? (typeof s == 'string' || typeof s == 'number' || typeof s == 'bigint' || s.constructor == String
+          ? (s = t.__k[o] = R(null, s, null, null, null))
+          : O(s)
+            ? (s = t.__k[o] = R(A, { children: s }, null, null, null))
+            : s.constructor === void 0 && s.__b > 0
+              ? (s = t.__k[o] = R(s.type, s.props, s.key, s.ref ? s.ref : null, s.__v))
+              : (t.__k[o] = s),
+        (u = o + r),
+        (s.__ = t),
+        (s.__b = t.__b + 1),
+        (l = null),
+        (a = s.__i = Ve(s, n, u, d)) != -1 && (d--, (l = n[a]) && (l.__u |= 2)),
+        l == null || l.__v == null
+          ? (a == -1 && (_ > p ? r-- : _ < p && r++), typeof s.type != 'function' && (s.__u |= 4))
+          : a != u && (a == u - 1 ? r-- : a == u + 1 ? r++ : (a > u ? r-- : r++, (s.__u |= 4))))
+      : (t.__k[o] = null);
+  if (d)
+    for (o = 0; o < p; o++) (l = n[o]) != null && (2 & l.__u) == 0 && (l.__e == i && (i = P(l)), ke(l, l));
+  return i;
+}
+function ve(t, e, n) {
+  var i, _;
+  if (typeof t.type == 'function') {
+    for (i = t.__k, _ = 0; i && _ < i.length; _++) i[_] && ((i[_].__ = t), (e = ve(i[_], e, n)));
+    return e;
+  }
+  t.__e != e && (e && t.type && !e.parentNode && (e = P(t)), (e = n.insertBefore(t.__e, e || null)));
+  do e = e && e.nextSibling;
+  while (e != null && e.nodeType == 8);
+  return e;
+}
+function Ve(t, e, n, i) {
+  var _,
+    o,
+    s,
+    l = t.key,
+    u = t.type,
+    a = e[n],
+    p = a != null && (2 & a.__u) == 0;
+  if ((a === null && l == null) || (p && l == a.key && u == a.type)) return n;
+  if (i > (p ? 1 : 0)) {
+    for (_ = n - 1, o = n + 1; _ >= 0 || o < e.length;)
+      if ((a = e[(s = _ >= 0 ? _-- : o++)]) != null && (2 & a.__u) == 0 && l == a.key && u == a.type)
+        return s;
+  }
+  return -1;
+}
+function ce(t, e, n) {
+  e[0] == '-'
+    ? t.setProperty(e, n ?? '')
+    : (t[e] = n == null ? '' : typeof n != 'number' || We.test(e) ? n : n + 'px');
+}
+function j(t, e, n, i, _) {
+  var o, s;
+  e: if (e == 'style')
+    if (typeof n == 'string') t.style.cssText = n;
+    else {
+      if ((typeof i == 'string' && (t.style.cssText = i = ''), i))
+        for (e in i) (n && e in n) || ce(t.style, e, '');
+      if (n) for (e in n) (i && n[e] == i[e]) || ce(t.style, e, n[e]);
+    }
+  else if (e[0] == 'o' && e[1] == 'n')
+    ((o = e != (e = e.replace(de, '$1'))),
+      (s = e.toLowerCase()),
+      (e = s in t || e == 'onFocusOut' || e == 'onFocusIn' ? s.slice(2) : e.slice(2)),
+      t.l || (t.l = {}),
+      (t.l[e + o] = n),
+      n
+        ? i
+          ? (n[D] = i[D])
+          : ((n[D] = G), t.addEventListener(e, o ? Y : K, o))
+        : t.removeEventListener(e, o ? Y : K, o));
+  else {
+    if (_ == 'http://www.w3.org/2000/svg') e = e.replace(/xlink(H|:h)/, 'h').replace(/sName$/, 's');
+    else if (
+      e != 'width' &&
+      e != 'height' &&
+      e != 'href' &&
+      e != 'list' &&
+      e != 'form' &&
+      e != 'tabIndex' &&
+      e != 'download' &&
+      e != 'rowSpan' &&
+      e != 'colSpan' &&
+      e != 'role' &&
+      e != 'popover' &&
+      e in t
+    )
+      try {
+        t[e] = n ?? '';
+        break e;
+      } catch {}
+    typeof n == 'function' ||
+      (n == null || (n === !1 && e[4] != '-')
+        ? t.removeAttribute(e)
+        : t.setAttribute(e, e == 'popover' && n == 1 ? '' : n));
+  }
+}
+function ue(t) {
+  return function (e) {
+    if (this.l) {
+      var n = this.l[e.type + t];
+      if (e[F] == null) e[F] = G++;
+      else if (e[F] < n[D]) return;
+      return n(f.event ? f.event(e) : e);
+    }
+  };
+}
+function X(t, e, n, i, _, o, s, l, u, a) {
+  var p,
+    d,
+    r,
+    c,
+    m,
+    k,
+    x,
+    y,
+    h,
+    w,
+    M,
+    H,
+    U,
+    ae,
+    N,
+    q,
+    S = e.type;
+  if (e.constructor !== void 0) return null;
+  (128 & n.__u && ((u = !!(32 & n.__u)), (o = [(l = e.__e = n.__e)])), (p = f.__b) && p(e));
+  e: if (typeof S == 'function') {
+    d = s.length;
+    try {
+      if (
+        ((h = e.props),
+        (w = S.prototype && S.prototype.render),
+        (M = (p = S.contextType) && i[p.__c]),
+        (H = p ? (M ? M.props.value : p.__) : i),
+        n.__c
+          ? (y = (r = e.__c = n.__c).__ = r.__E)
+          : (w
+              ? (e.__c = r = new S(h, H))
+              : ((e.__c = r = new z(h, H)), (r.constructor = S), (r.render = Je)),
+            M && M.sub(r),
+            r.state || (r.state = {}),
+            (r.__n = i),
+            (c = r.__d = !0),
+            (r.__h = []),
+            (r._sb = [])),
+        w && r.__s == null && (r.__s = r.state),
+        w &&
+          S.getDerivedStateFromProps != null &&
+          (r.__s == r.state && (r.__s = C({}, r.__s)), C(r.__s, S.getDerivedStateFromProps(h, r.__s))),
+        (m = r.props),
+        (k = r.state),
+        (r.__v = e),
+        c)
+      )
+        (w && S.getDerivedStateFromProps == null && r.componentWillMount != null && r.componentWillMount(),
+          w && r.componentDidMount != null && r.__h.push(r.componentDidMount));
+      else {
+        if (
+          (w &&
+            S.getDerivedStateFromProps == null &&
+            h !== m &&
+            r.componentWillReceiveProps != null &&
+            r.componentWillReceiveProps(h, H),
+          e.__v == n.__v ||
+            (!r.__e && r.shouldComponentUpdate != null && r.shouldComponentUpdate(h, r.__s, H) === !1))
+        ) {
+          (e.__v != n.__v && ((r.props = h), (r.state = r.__s), (r.__d = !1)),
+            (e.__e = n.__e),
+            (e.__k = n.__k),
+            e.__k.some(function (T) {
+              T && (T.__ = e);
+            }),
+            W.push.apply(r.__h, r._sb),
+            (r._sb = []),
+            r.__h.length && s.push(r),
+            (l = P(n)));
+          break e;
+        }
+        (r.componentWillUpdate != null && r.componentWillUpdate(h, r.__s, H),
+          w &&
+            r.componentDidUpdate != null &&
+            r.__h.push(function () {
+              r.componentDidUpdate(m, k, x);
+            }));
+      }
+      if (((r.context = H), (r.props = h), (r.__P = t), (r.__e = !1), (U = f.__r), (ae = 0), w))
+        ((r.state = r.__s),
+          (r.__d = !1),
+          U && U(e),
+          (p = r.render(r.props, r.state, r.context)),
+          W.push.apply(r.__h, r._sb),
+          (r._sb = []));
+      else
+        do ((r.__d = !1), U && U(e), (p = r.render(r.props, r.state, r.context)), (r.state = r.__s));
+        while (r.__d && ++ae < 25);
+      ((r.state = r.__s),
+        r.getChildContext != null && (i = C(C({}, i), r.getChildContext())),
+        w && !c && r.getSnapshotBeforeUpdate != null && (x = r.getSnapshotBeforeUpdate(m, k)),
+        (N = p != null && p.type === A && p.key == null ? xe(p.props.children) : p),
+        (l = be(t, O(N) ? N : [N], e, n, i, _, o, s, l, u, a)),
+        (r.base = e.__e),
+        (e.__u &= -161),
+        r.__h.length && s.push(r),
+        y && (r.__E = r.__ = null));
+    } catch (T) {
+      if (((s.length = d), (e.__v = null), u || o != null)) {
+        if (T.then) {
+          for (e.__u |= u ? 160 : 128; l && l.nodeType == 8 && l.nextSibling;) l = l.nextSibling;
+          (o != null && (o[o.indexOf(l)] = null), (e.__e = l));
+        } else if (o != null) for (q = o.length; q--;) Q(o[q]);
+      } else e.__e = n.__e;
+      (e.__k == null && (e.__k = n.__k || []), T.then || ge(e), f.__e(T, e, n));
+    }
+  } else
+    o == null && e.__v == n.__v
+      ? ((e.__k = n.__k), (e.__e = n.__e))
+      : (l = e.__e = qe(n.__e, e, n, i, _, o, s, u, a));
+  return ((p = f.diffed) && p(e), 128 & e.__u ? void 0 : l);
+}
+function ge(t) {
+  t && (t.__c && (t.__c.__e = !0), t.__k && t.__k.some(ge));
+}
+function ye(t, e, n) {
+  for (var i = 0; i < n.length; i++) Z(n[i], n[++i], n[++i]);
+  (f.__c && f.__c(e, t),
+    t.some(function (_) {
+      try {
+        ((t = _.__h),
+          (_.__h = []),
+          t.some(function (o) {
+            o.call(_);
+          }));
+      } catch (o) {
+        f.__e(o, _.__v);
+      }
+    }));
+}
+function xe(t) {
+  return typeof t != 'object' || t == null || t.__b > 0
+    ? t
+    : O(t)
+      ? t.map(xe)
+      : t.constructor !== void 0
+        ? null
+        : C({}, t);
+}
+function qe(t, e, n, i, _, o, s, l, u) {
+  var a,
+    p,
+    d,
+    r,
+    c,
+    m,
+    k,
+    x = n.props || $,
+    y = e.props,
+    h = e.type;
+  if (
+    (h == 'svg'
+      ? (_ = 'http://www.w3.org/2000/svg')
+      : h == 'math'
+        ? (_ = 'http://www.w3.org/1998/Math/MathML')
+        : _ || (_ = 'http://www.w3.org/1999/xhtml'),
+    o != null)
+  ) {
+    for (a = 0; a < o.length; a++)
+      if ((c = o[a]) && 'setAttribute' in c == !!h && (h ? c.localName == h : c.nodeType == 3)) {
+        ((t = c), (o[a] = null));
+        break;
+      }
+  }
+  if (t == null) {
+    if (h == null) return document.createTextNode(y);
+    ((t = document.createElementNS(_, h, y.is && y)), l && (f.__m && f.__m(e, o), (l = !1)), (o = null));
+  }
+  if (h == null) x === y || (l && t.data == y) || (t.data = y);
+  else {
+    if (((o = h == 'textarea' && y.defaultValue != null ? null : o && B.call(t.childNodes)), !l && o != null))
+      for (x = {}, a = 0; a < t.attributes.length; a++) x[(c = t.attributes[a]).name] = c.value;
+    for (a in x)
+      ((c = x[a]),
+        a == 'dangerouslySetInnerHTML'
+          ? (d = c)
+          : a == 'children' ||
+            a in y ||
+            (a == 'value' && 'defaultValue' in y) ||
+            (a == 'checked' && 'defaultChecked' in y) ||
+            j(t, a, null, c, _));
+    for (a in y)
+      ((c = y[a]),
+        a == 'children'
+          ? (r = c)
+          : a == 'dangerouslySetInnerHTML'
+            ? (p = c)
+            : a == 'value'
+              ? (m = c)
+              : a == 'checked'
+                ? (k = c)
+                : (l && typeof c != 'function') || x[a] === c || j(t, a, c, x[a], _));
+    if (p)
+      (l || (d && (p.__html == d.__html || p.__html == t.innerHTML)) || (t.innerHTML = p.__html),
+        (e.__k = []));
+    else if (
+      (d && (t.innerHTML = ''),
+      be(
+        e.type == 'template' ? t.content : t,
+        O(r) ? r : [r],
+        e,
+        n,
+        i,
+        h == 'foreignObject' ? 'http://www.w3.org/1999/xhtml' : _,
+        o,
+        s,
+        o ? o[0] : n.__k && P(n, 0),
+        l,
+        u
+      ),
+      o != null)
+    )
+      for (a = o.length; a--;) Q(o[a]);
+    (l && h != 'textarea') ||
+      ((a = 'value'),
+      h == 'progress' && m == null
+        ? t.removeAttribute('value')
+        : m != null &&
+          (m !== t[a] || (h == 'progress' && !m) || (h == 'option' && m != x[a])) &&
+          j(t, a, m, x[a], _),
+      (a = 'checked'),
+      k != null && k != t[a] && j(t, a, k, x[a], _));
+  }
+  return t;
+}
+function Z(t, e, n) {
+  try {
+    if (typeof t == 'function') {
+      var i = typeof t.__u == 'function';
+      (i && t.__u(), (i && e == null) || (t.__u = t(e)));
+    } else t.current = e;
+  } catch (_) {
+    f.__e(_, n);
+  }
+}
+function ke(t, e, n) {
+  var i, _;
+  if (
+    (f.unmount && f.unmount(t),
+    (i = t.ref) && ((i.current && i.current != t.__e) || Z(i, null, e)),
+    (i = t.__c) != null)
+  ) {
+    if (i.componentWillUnmount)
+      try {
+        i.componentWillUnmount();
+      } catch (o) {
+        f.__e(o, e);
+      }
+    i.base = i.__P = i.__n = null;
+  }
+  if ((i = t.__k)) for (_ = 0; _ < i.length; _++) i[_] && ke(i[_], e, n || typeof t.type != 'function');
+  (n || Q(t.__e), (t.__c = t.__ = t.__e = void 0));
+}
+function Je(t, e, n) {
+  return this.constructor(t, n);
+}
+function we(t, e, n) {
+  var i, _, o, s;
+  (e == document && (e = document.documentElement),
+    f.__ && f.__(t, e),
+    (_ = (i = typeof n == 'function') ? null : (n && n.__k) || e.__k),
+    (o = []),
+    (s = []),
+    X(
+      e,
+      (t = ((!i && n) || e).__k = Le(A, null, [t])),
+      _ || $,
+      $,
+      e.namespaceURI,
+      !i && n ? [n] : _ ? null : e.firstChild ? B.call(e.childNodes) : null,
+      o,
+      !i && n ? n : _ ? _.__e : e.firstChild,
+      i,
+      s
+    ),
+    ye(o, t, s),
+    (t.props.children = null));
+}
+((B = W.slice),
+  (f = {
+    __e: function (t, e, n, i) {
+      for (var _, o, s; (e = e.__);)
+        if ((_ = e.__c) && !_.__)
+          try {
+            if (
+              ((o = _.constructor) &&
+                o.getDerivedStateFromError != null &&
+                (_.setState(o.getDerivedStateFromError(t)), (s = _.__d)),
+              _.componentDidCatch != null && (_.componentDidCatch(t, i || {}), (s = _.__d)),
+              s)
+            )
+              return (_.__E = _);
+          } catch (l) {
+            t = l;
+          }
+      throw t;
+    },
+  }),
+  (pe = 0),
+  (ze = function (t) {
+    return t != null && t.constructor === void 0;
+  }),
+  (z.prototype.setState = function (t, e) {
+    var n;
+    ((n = this.__s != null && this.__s != this.state ? this.__s : (this.__s = C({}, this.state))),
+      typeof t == 'function' && (t = t(C({}, n), this.props)),
+      t && C(n, t),
+      t != null && this.__v && (e && this._sb.push(e), le(this)));
+  }),
+  (z.prototype.forceUpdate = function (t) {
+    this.__v && ((this.__e = !0), t && this.__h.push(t), le(this));
+  }),
+  (z.prototype.render = A),
+  (E = []),
+  (fe = typeof Promise == 'function' ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout),
+  (he = function (t, e) {
+    return t.__v.__b - e.__v.__b;
+  }),
+  (L.__r = 0),
+  (J = Math.random().toString(8)),
+  (F = '__d' + J),
+  (D = '__a' + J),
+  (de = /(PointerCapture)$|Capture$/i),
+  (G = 0),
+  (K = ue(!1)),
+  (Y = ue(!0)),
+  ($e = 0));
+var te,
+  v,
+  ee,
+  Se,
+  ne = 0,
+  Ue = [],
+  g = f,
+  Ce = g.__b,
+  Ee = g.__r,
+  Ae = g.diffed,
+  He = g.__c,
+  Pe = g.unmount,
+  Te = g.__;
+function Ke(t, e) {
+  (g.__h && g.__h(v, t, ne || e), (ne = 0));
+  var n = v.__H || (v.__H = { __: [], __h: [] });
+  return (t >= n.__.length && n.__.push({}), n.__[t]);
+}
+function I(t) {
+  return ((ne = 1), Ye(De, t));
+}
+function Ye(t, e, n) {
+  var i = Ke(te++, 2);
+  if (
+    ((i.t = t),
+    !i.__c &&
+      ((i.__ = [
+        n ? n(e) : De(void 0, e),
+        function (l) {
+          var u = i.__N ? i.__N[0] : i.__[0],
+            a = i.t(u, l);
+          u !== a && ((i.__N = [a, i.__[1]]), i.__c.setState({}));
+        },
+      ]),
+      (i.__c = v),
+      !v.__f))
+  ) {
+    var _ = function (l, u, a) {
+      if (!i.__c.__H) return !0;
+      var p = !1,
+        d = i.__c.props !== l;
+      if (
+        (i.__c.__H.__.some(function (c) {
+          if (c.__N) {
+            p = !0;
+            var m = c.__[0];
+            ((c.__ = c.__N), (c.__N = void 0), m !== c.__[0] && (d = !0));
+          }
+        }),
+        o)
+      ) {
+        var r = o.call(this, l, u, a);
+        return p ? r || d : r;
+      }
+      return !p || d;
+    };
+    v.__f = !0;
+    var o = v.shouldComponentUpdate,
+      s = v.componentWillUpdate;
+    ((v.componentWillUpdate = function (l, u, a) {
+      if (this.__e) {
+        var p = o;
+        ((o = void 0), _(l, u, a), (o = p));
+      }
+      s && s.call(this, l, u, a);
+    }),
+      (v.shouldComponentUpdate = _));
+  }
+  return i.__N || i.__;
+}
+function Ge() {
+  for (var t; (t = Ue.shift());) {
+    var e = t.__H;
+    if (t.__P && e)
+      try {
+        (e.__h.some(V), e.__h.some(re), (e.__h = []));
+      } catch (n) {
+        ((e.__h = []), g.__e(n, t.__v));
+      }
+  }
+}
+((g.__b = function (t) {
+  ((v = null), Ce && Ce(t));
+}),
+  (g.__ = function (t, e) {
+    (t && e.__k && e.__k.__m && (t.__m = e.__k.__m), Te && Te(t, e));
+  }),
+  (g.__r = function (t) {
+    (Ee && Ee(t), (te = 0));
+    var e = (v = t.__c).__H;
+    (e &&
+      (ee === v
+        ? ((e.__h = []),
+          (v.__h = []),
+          e.__.some(function (n) {
+            (n.__N && (n.__ = n.__N), (n.u = n.__N = void 0));
+          }))
+        : (e.__h.some(V), e.__h.some(re), (e.__h = []), (te = 0))),
+      (ee = v));
+  }),
+  (g.diffed = function (t) {
+    Ae && Ae(t);
+    var e = t.__c;
+    (e &&
+      e.__H &&
+      (e.__H.__h.length &&
+        ((Ue.push(e) !== 1 && Se === g.requestAnimationFrame) || ((Se = g.requestAnimationFrame) || Qe)(Ge)),
+      e.__H.__.some(function (n) {
+        n.u && ((n.__H = n.u), (n.u = void 0));
+      })),
+      (ee = v = null));
+  }),
+  (g.__c = function (t, e) {
+    (e.some(function (n) {
+      try {
+        (n.__h.some(V),
+          (n.__h = n.__h.filter(function (i) {
+            return !i.__ || re(i);
+          })));
+      } catch (i) {
+        (e.some(function (_) {
+          _.__h && (_.__h = []);
+        }),
+          (e = []),
+          g.__e(i, n.__v));
+      }
+    }),
+      He && He(t, e));
+  }),
+  (g.unmount = function (t) {
+    Pe && Pe(t);
+    var e,
+      n = t.__c;
+    n &&
+      n.__H &&
+      (n.__H.__.some(function (i) {
+        try {
+          V(i);
+        } catch (_) {
+          e = _;
+        }
+      }),
+      (n.__H = void 0),
+      e && g.__e(e, n.__v));
+  }));
+var Me = typeof requestAnimationFrame == 'function';
+function Qe(t) {
+  var e,
+    n = function () {
+      (clearTimeout(i), Me && cancelAnimationFrame(e), setTimeout(t));
+    },
+    i = setTimeout(n, 35);
+  Me && (e = requestAnimationFrame(n));
+}
+function V(t) {
+  var e = v,
+    n = t.__c;
+  (typeof n == 'function' && ((t.__c = void 0), n()), (v = e));
+}
+function re(t) {
+  var e = v;
+  ((t.__c = t.__()), (v = e));
+}
+function De(t, e) {
+  return typeof e == 'function' ? e(t) : e;
+}
+var Ie = (t, ...e) => String.raw({ raw: t }, ...e);
+var Ne = Ie`
     html,
     body {
       margin: 0;
@@ -216,4 +962,177 @@ var B,f,pe,ze,E,se,fe,he,J,F,D,de,G,K,Y,$e,$={},W=[],We=/acit|ex(?:s|g|n|p|$)|rp
         color: #0d1b3d;
       }
     }
-  `;var Xe=0;function b(t,e,n,i,_,o){e||(e={});var s,l,u=e;if("ref"in u)for(l in u={},e)l=="ref"?s=e[l]:u[l]=e[l];var a={type:t,props:u,key:n,ref:s,__k:null,__:null,__b:0,__e:null,__c:null,constructor:void 0,__v:--Xe,__i:-1,__u:0,__source:_,__self:o};if(typeof t=="function"&&(s=t.defaultProps))for(l in s)u[l]===void 0&&(u[l]=s[l]);return f.vnode&&f.vnode(a),a}var je="isa-my-server",Ze=5e3,Fe=()=>location.pathname.split("/share/")[1]?.split(/[/?#]/)[0]??"",et=()=>location.assign(`${location.pathname}?native=1`),oe=t=>!(location.protocol==="https:"&&t==="http"),ie=async(t,e)=>{try{let n=await fetch(`${t}://${e}/immich-shared-albums/health`,{signal:AbortSignal.timeout(Ze)});return n.ok&&(await n.json()).ok===!0}catch{return!1}},Re=()=>{let[t,e]=I(localStorage.getItem(je)??""),[n,i]=I(!1),[_,o]=I(""),[s,l]=I(!1),u=async p=>{p.preventDefault();let d=t.trim();if(!d)return;let r=/^https:\/\//i.test(d)?"https":/^http:\/\//i.test(d)?"http":null,c=d.replace(/^https?:\/\//i,"").replace(/\/.*$/,"");o(""),i(!0);let m=!1;if(r?m=oe(r)?await ie(r,c):!0:await ie("https",c)?(r="https",m=!0):oe("http")&&await ie("http",c)?(r="http",m=!0):(r="https",m=!oe("http")&&location.protocol!=="https:"),i(!1),!m){o(`Couldn't find the shared-albums addon at ${c} \u2014 use the address your Immich is served on (with the sidecar routes). Direct setups without a reverse proxy need the sidecar port, not the Immich one.`);return}localStorage.setItem(je,d);let k=encodeURIComponent(JSON.stringify({v:1,host:location.host,scheme:location.protocol.replace(":",""),key:Fe()}));location.href=`${r}://${c}/immich-shared-albums/accept#${k}`},a=Fe();return b(A,{children:[b("style",{children:Ne}),b("iframe",{class:"native-album",src:`/share/${a}?native=1`,title:"Shared album"}),!s&&b("div",{class:"card",role:"dialog","aria-label":"Join this album with your own Immich server",children:[b("button",{class:"dismiss","aria-label":"Continue to the album",onClick:()=>{l(!0),et()},children:"\xD7"}),b("div",{class:"row",children:[b("div",{class:"logo","aria-hidden":"true",children:b("svg",{viewBox:"0 0 24 24",fill:"none",stroke:"#fff","stroke-width":"2","stroke-linecap":"round","stroke-linejoin":"round",children:[b("path",{d:"M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"}),b("path",{d:"M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"})]})}),b("div",{children:[b("h2",{children:"Join shared album with your server?"}),b("p",{class:"sub",children:["Have an Immich server of your own with the shared-albums addon?",b("br",{}),"If so pop your server address down below to begin sharing photos across servers!"]})]})]}),b("form",{onSubmit:u,children:[b("input",{type:"text",inputMode:"url",autocomplete:"off",autocapitalize:"none",spellcheck:!1,placeholder:"your-server.example.com","aria-label":"Your server address",value:t,onInput:p=>e(p.target.value)}),b("button",{class:"join",type:"submit",disabled:n,children:n?"Checking\u2026":"Join"})]}),_&&b("p",{class:"err",children:_}),b("p",{class:"hint",children:["Type your server address once \u2014 it's remembered for next time. Nothing to install for viewing.",b("br",{}),"Want this for your own server?"," ",b("a",{href:"https://github.com/lukeet332/immich-shared-albums",target:"_blank",rel:"noopener",children:"github.com/lukeet332/immich-shared-albums"})]})]})]})};var _e=document.getElementById("share-app");_e&&(_e.id="immich-shared-albums-banner",we(b(Re,{}),_e));
+  `;
+var Xe = 0;
+function b(t, e, n, i, _, o) {
+  e || (e = {});
+  var s,
+    l,
+    u = e;
+  if ('ref' in u) for (l in ((u = {}), e)) l == 'ref' ? (s = e[l]) : (u[l] = e[l]);
+  var a = {
+    type: t,
+    props: u,
+    key: n,
+    ref: s,
+    __k: null,
+    __: null,
+    __b: 0,
+    __e: null,
+    __c: null,
+    constructor: void 0,
+    __v: --Xe,
+    __i: -1,
+    __u: 0,
+    __source: _,
+    __self: o,
+  };
+  if (typeof t == 'function' && (s = t.defaultProps)) for (l in s) u[l] === void 0 && (u[l] = s[l]);
+  return (f.vnode && f.vnode(a), a);
+}
+var je = 'isa-my-server',
+  Ze = 5e3,
+  Fe = () => location.pathname.split('/share/')[1]?.split(/[/?#]/)[0] ?? '',
+  et = () => location.assign(`${location.pathname}?native=1`),
+  oe = t => !(location.protocol === 'https:' && t === 'http'),
+  ie = async (t, e) => {
+    try {
+      let n = await fetch(`${t}://${e}/immich-shared-albums/health`, { signal: AbortSignal.timeout(Ze) });
+      return n.ok && (await n.json()).ok === !0;
+    } catch {
+      return !1;
+    }
+  },
+  Re = () => {
+    let [t, e] = I(localStorage.getItem(je) ?? ''),
+      [n, i] = I(!1),
+      [_, o] = I(''),
+      [s, l] = I(!1),
+      u = async p => {
+        p.preventDefault();
+        let d = t.trim();
+        if (!d) return;
+        let r = /^https:\/\//i.test(d) ? 'https' : /^http:\/\//i.test(d) ? 'http' : null,
+          c = d.replace(/^https?:\/\//i, '').replace(/\/.*$/, '');
+        (o(''), i(!0));
+        let m = !1;
+        if (
+          (r
+            ? (m = oe(r) ? await ie(r, c) : !0)
+            : (await ie('https', c))
+              ? ((r = 'https'), (m = !0))
+              : oe('http') && (await ie('http', c))
+                ? ((r = 'http'), (m = !0))
+                : ((r = 'https'), (m = !oe('http') && location.protocol !== 'https:')),
+          i(!1),
+          !m)
+        ) {
+          o(
+            `Couldn't find the shared-albums addon at ${c} \u2014 use the address your Immich is served on (with the sidecar routes). Direct setups without a reverse proxy need the sidecar port, not the Immich one.`
+          );
+          return;
+        }
+        localStorage.setItem(je, d);
+        let k = encodeURIComponent(
+          JSON.stringify({ v: 1, host: location.host, scheme: location.protocol.replace(':', ''), key: Fe() })
+        );
+        location.href = `${r}://${c}/immich-shared-albums/accept#${k}`;
+      },
+      a = Fe();
+    return b(A, {
+      children: [
+        b('style', { children: Ne }),
+        b('iframe', { class: 'native-album', src: `/share/${a}?native=1`, title: 'Shared album' }),
+        !s &&
+          b('div', {
+            class: 'card',
+            role: 'dialog',
+            'aria-label': 'Join this album with your own Immich server',
+            children: [
+              b('button', {
+                class: 'dismiss',
+                'aria-label': 'Continue to the album',
+                onClick: () => {
+                  (l(!0), et());
+                },
+                children: '\xD7',
+              }),
+              b('div', {
+                class: 'row',
+                children: [
+                  b('div', {
+                    class: 'logo',
+                    'aria-hidden': 'true',
+                    children: b('svg', {
+                      viewBox: '0 0 24 24',
+                      fill: 'none',
+                      stroke: '#fff',
+                      'stroke-width': '2',
+                      'stroke-linecap': 'round',
+                      'stroke-linejoin': 'round',
+                      children: [
+                        b('path', { d: 'M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7' }),
+                        b('path', { d: 'M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7' }),
+                      ],
+                    }),
+                  }),
+                  b('div', {
+                    children: [
+                      b('h2', { children: 'Join shared album with your server?' }),
+                      b('p', {
+                        class: 'sub',
+                        children: [
+                          'Have an Immich server of your own with the shared-albums addon?',
+                          b('br', {}),
+                          'If so pop your server address down below to begin sharing photos across servers!',
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+              b('form', {
+                onSubmit: u,
+                children: [
+                  b('input', {
+                    type: 'text',
+                    inputMode: 'url',
+                    autocomplete: 'off',
+                    autocapitalize: 'none',
+                    spellcheck: !1,
+                    placeholder: 'your-server.example.com',
+                    'aria-label': 'Your server address',
+                    value: t,
+                    onInput: p => e(p.target.value),
+                  }),
+                  b('button', {
+                    class: 'join',
+                    type: 'submit',
+                    disabled: n,
+                    children: n ? 'Checking\u2026' : 'Join',
+                  }),
+                ],
+              }),
+              _ && b('p', { class: 'err', children: _ }),
+              b('p', {
+                class: 'hint',
+                children: [
+                  "Type your server address once \u2014 it's remembered for next time. Nothing to install for viewing.",
+                  b('br', {}),
+                  'Want this for your own server?',
+                  ' ',
+                  b('a', {
+                    href: 'https://github.com/lukeet332/immich-shared-albums',
+                    target: '_blank',
+                    rel: 'noopener',
+                    children: 'github.com/lukeet332/immich-shared-albums',
+                  }),
+                ],
+              }),
+            ],
+          }),
+      ],
+    });
+  };
+var _e = document.getElementById('share-app');
+_e && ((_e.id = 'immich-shared-albums-banner'), we(b(Re, {}), _e));

--- a/src/web/ui/pages/share/share.css
+++ b/src/web/ui/pages/share/share.css
@@ -18,12 +18,21 @@ iframe.native-album {
   width: 400px;
   max-width: calc(100vw - 32px);
   box-sizing: border-box;
-  font-family: 'Overpass', 'Inter', Roboto, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    'Overpass',
+    'Inter',
+    Roboto,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
   background: #ffffff;
   color: #202124;
   border: 1px solid rgba(0, 0, 0, 0.06);
   border-radius: 28px;
-  box-shadow: 0 1px 3px rgba(60, 64, 67, 0.15), 0 8px 28px rgba(60, 64, 67, 0.22);
+  box-shadow:
+    0 1px 3px rgba(60, 64, 67, 0.15),
+    0 8px 28px rgba(60, 64, 67, 0.22);
   padding: 22px 22px 18px;
   animation: isa-in 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) both;
 }
@@ -111,7 +120,10 @@ iframe.native-album {
   background: #f1f3f4;
   color: inherit;
   outline: none;
-  transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 #immich-shared-albums-banner input:focus {
   background: #fff;
@@ -129,7 +141,10 @@ iframe.native-album {
   cursor: pointer;
   background: #4250af;
   color: #fff;
-  transition: filter 0.15s, box-shadow 0.15s, transform 0.05s;
+  transition:
+    filter 0.15s,
+    box-shadow 0.15s,
+    transform 0.05s;
 }
 #immich-shared-albums-banner button.join:hover {
   filter: brightness(1.08);
@@ -183,7 +198,9 @@ iframe.native-album {
     background: #1b1f26;
     color: #e8eaed;
     border-color: rgba(255, 255, 255, 0.08);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 10px 32px rgba(0, 0, 0, 0.5);
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.4),
+      0 10px 32px rgba(0, 0, 0, 0.5);
   }
   #immich-shared-albums-banner .sub {
     color: #9aa0a6;
@@ -215,4 +232,3 @@ iframe.native-album {
     color: #0d1b3d;
   }
 }
-  

--- a/src/web/ui/pages/sign-in/sign-in.css
+++ b/src/web/ui/pages/sign-in/sign-in.css
@@ -1,6 +1,9 @@
 body {
   margin: 0;
-  font-family: Inter, -apple-system, sans-serif;
+  font-family:
+    Inter,
+    -apple-system,
+    sans-serif;
   background: #101216;
   color: #e5e7eb;
   display: grid;


### PR DESCRIPTION
PR 2 of 3 from the v1 freeze audit — the env & deployment contract. Stacked on #36 (merged).

## One namespace
Every setting is now `ISA_`-prefixed. The old names collided with the stack around them: `IMMICH_URL` meant two different things inside one generated compose file (the addon's upstream vs immich-public-proxy's), Immich itself owns `IMMICH_*`, and `PORT`/`DATA_DIR` are claimed by half the container ecosystem. The `.env` secret finally has **one name end-to-end** (`ISA_IMMICH_API_KEY`) — the installer wrote `SIDECAR_API_KEY`, the docs said `IMMICH_API_KEY`, and the demo stacked a third alias on top.

Semantic renames where the audit showed the name lied: `REQUIRE_SHARE_PASSWORD` → `ISA_LINK_JOIN_REQUIRES_PASSWORD` (it gates *joining*, never viewing), `SHARE_USER_DIRECTORY` → `ISA_PUBLISH_USER_DIRECTORY` (outbound only), `UTILITY_QUOTA_MB` → `ISA_BOT_QUOTA_MB`, `ALBUM_TEMPLATE` → `ISA_MIRROR_ALBUM_TEMPLATE` (now `replaceAll`, with the token vocabulary — `{name}`, `{peer}` — declared so adding one later can't change an existing template's meaning). `COMMENT_POLL_MS`, `RELAY`, `RECONCILE_DEBUG` move into `CFG` — there are no inline `process.env` reads left.

## Strict parsing, loud failures
Booleans accept true/false/1/0/yes/no/on/off and **refuse to boot** on anything else. Previously `RELAY=false` silently *enabled* the relay (only the literal `off` worked) and `REQUIRE_SHARE_PASSWORD=1` silently failed open — both on security-relevant settings. Numbers reject garbage instead of handing `setInterval` a NaN.

## Deployment contract
- Dockerfile: `USER node` (breaking for `/data` ownership if added later), `HEALTHCHECK` honouring `ISA_PORT`, `/data` pre-owned by node.
- Installs move to a **named volume** (the identity key lives there; `down -v` is now the documented way to lose it, not an accident). The rig pins `user: "0:0"` because the suite reads `state.db` from the host.
- Boot warns when the data dir is not a mounted volume.
- The route-prefix runtime rewrite machinery is deleted — the prefix could never work per-install (a member's share page probes the *origin's* prefix), so it is frozen and served verbatim.

Installer smoke-tested end-to-end with the new names; unit 9/9; docs (configuration.md rewritten, README, api-key, exposure, INSTALL-AI, SETUP, examples) all renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)