### PR TITLE
feat(naming): don't stack 'server' when a household is already named one

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -153,7 +153,11 @@ export const BOT_PREFIX = {
 export const personName = (name?: string) => (name || '').replace(/\s*\(via .*\)\s*$/, '').trim();
 
 export const markerName = {
-  person: (personName: string, peerName: string) => `${personName} (via ${peerName} server)`,
+  // Don't stack "server" when the household is already named one ("Bob's server" becomes
+  // "(via Bob's server)", not "(via Bob's server server)"). personName strips any trailing
+  // "(via …)" regardless, so this is purely cosmetic and safe.
+  person: (personName: string, peerName: string) =>
+    `${personName} (via ${peerName}${/servers?\s*$/i.test(peerName) ? '' : ' server'})`,
 };
 
 /** Is this one of our bot users? The single source of truth — never inline the check. */

--- a/src/invariants.test.ts
+++ b/src/invariants.test.ts
@@ -34,6 +34,15 @@ test('a marker name never collides with an attribution contributor name', () => 
   assert.ok(!marker.includes(UTILITY_SUFFIX), 'markers must not wear the contributor suffix');
 });
 
+test('marker name does not stack "server" when the household already ends in one', () => {
+  assert.equal(markerName.person('Nan', 'The Smiths'), 'Nan (via The Smiths server)');
+  assert.equal(markerName.person('Nan', "Bob's server"), "Nan (via Bob's server)");
+  assert.equal(markerName.person('Nan', 'My Server'), 'Nan (via My Server)'); // case-insensitive
+  // and personName still recovers the human whichever form was used
+  assert.equal(personName(markerName.person('Nan', "Bob's server")), 'Nan');
+  assert.equal(personName(markerName.person('Nan', 'The Smiths')), 'Nan');
+});
+
 test('isUtilityEmail accepts only the project domain', () => {
   assert.ok(isUtilityEmail(`person-x@${UTILITY_EMAIL_DOMAIN}`));
   assert.ok(!isUtilityEmail('someone@sidecar.local'), 'v1 dropped the legacy domain');


### PR DESCRIPTION
Final v1 polish. A household literally named "Bob's server" produced invite markers reading **"Nan (via Bob's server server)"**. De-dupe a trailing `server`/`servers` (case-insensitive) so it reads "Nan (via Bob's server)".

Purely cosmetic and safe:
- `personName` still strips any trailing `(via …)` regardless of form, so the wire name recovery is unaffected.
- Marker accounts self-heal to the new display name on the next directory poll (they're keyed by id, not name).
- Rig household names don't end in "server", so the e2e marker assertion is unchanged.

Found during the production two-server real-world test. Unit-tested (11/11), including that `personName` round-trips both forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)