### PR TITLE
fix: bot accounts use .internal email domain (was .invalid)

### DIFF
--- a/demo/e2e/e2e-test.mjs
+++ b/demo/e2e/e2e-test.mjs
@@ -16,7 +16,9 @@ const api = async (base, key, path, init = {}) => {
 const j = (o) => ({ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(o) });
 // Bot users live on the project's own email domain — the one check that separates our bots from
 // real people, so it must match src/config.ts isUtilityEmail exactly.
-const isBot = (e) => !!e && e.endsWith('@immich-shared-albums.invalid');
+// Mirror the runtime's isUtilityEmail: current domain plus the legacy ones it still recognises.
+const BOT_DOMAINS = ['immich-shared-albums.internal', 'immich-shared-albums.invalid', 'immich-shared-albums.local', 'sidecar.local'];
+const isBot = (e) => !!e && BOT_DOMAINS.some(d => e.endsWith('@' + d));
 // /immich-shared-albums/join authenticates the caller against that household's own Immich, so the
 // suite has to present a real credential exactly like a signed-in browser would.
 const jAuth = (o, key) => ({ method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': key }, body: JSON.stringify(o) });
@@ -171,7 +173,7 @@ const originOwner = await api(A, AKEY, '/users/me');
 const originOwnerName = originOwner.name;
 // One account per remote person is both the mirror owner and the picker entry, so its display
 // name changes when the directory sync lands. Asserting a name here raced; assert the id keying.
-const originOwnerEmail = `person-${originOwner.id}@immich-shared-albums.invalid`;
+const originOwnerEmail = `person-${originOwner.id}@immich-shared-albums.internal`;
 const ownerUtility = bBotUsers.find(u => u.email === originOwnerEmail);
 check('an account exists for the origin album owner, keyed by their id on their own server',
       !!ownerUtility, bBotUsers.map(u => u.email).join(', '));
@@ -1025,8 +1027,8 @@ console.log('— stage: bot naming uses the project domain');
 {
   const bots = (await api(B, BKEY, '/admin/users')).filter(u => isBot(u.email));
   check('bot users exist', bots.length > 0, `${bots.length} found`);
-  check('every bot uses the project email domain (.invalid, RFC 2606)',
-        bots.every(u => u.email.endsWith('@immich-shared-albums.invalid')),
+  check('every bot uses the project email domain (.internal, ICANN private-use)',
+        bots.every(u => u.email.endsWith('@immich-shared-albums.internal')),
         bots.map(u => u.email.split('@')[1]).filter((v, i, a) => a.indexOf(v) === i).join(', '));
 }
 

--- a/demo/run-mock-e2e.sh
+++ b/demo/run-mock-e2e.sh
@@ -30,7 +30,7 @@ purge() { # base key statedir : delete all albums, sidecar users, non-admin asse
   for AL in $(curl -s $BASE/api/albums -H "x-api-key: $KEY" | python3 -c "import json,sys;[print(a['id']) for a in json.load(sys.stdin)]" 2>/dev/null); do
     curl -s -X DELETE $BASE/api/albums/$AL -H "x-api-key: $KEY" -o /dev/null; done
   # both domains: the product made a clean break at v1, but a dev rig may still hold pre-v1 bots
-  for U in $(curl -s $BASE/api/admin/users -H "x-api-key: $KEY" | python3 -c "import json,sys;[print(u['id']) for u in json.load(sys.stdin) if u['email'].endswith('@immich-shared-albums.invalid') or u['email'].endswith('@immich-shared-albums.local') or u['email'].endswith('@sidecar.local')]" 2>/dev/null); do
+  for U in $(curl -s $BASE/api/admin/users -H "x-api-key: $KEY" | python3 -c "import json,sys;[print(u['id']) for u in json.load(sys.stdin) if u['email'].endswith('@immich-shared-albums.internal') or u['email'].endswith('@immich-shared-albums.invalid') or u['email'].endswith('@immich-shared-albums.local') or u['email'].endswith('@sidecar.local')]" 2>/dev/null); do
     curl -s -X DELETE $BASE/api/admin/users/$U -H "x-api-key: $KEY" -H 'Content-Type: application/json' -d '{"force":true}' -o /dev/null; done
   local IDS=$(curl -s -X POST $BASE/api/search/metadata -H "x-api-key: $KEY" -H 'Content-Type: application/json' -d '{"size":500}' | python3 -c "import json,sys;print(json.dumps([i['id'] for i in json.load(sys.stdin)['assets']['items']]))" 2>/dev/null)
   [ "${IDS:-[]}" != "[]" ] && curl -s -X DELETE $BASE/api/assets -H "x-api-key: $KEY" -H 'Content-Type: application/json' -d "{\"ids\":$IDS,\"force\":true}" -o /dev/null

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,20 +87,35 @@ export const log = (...a) => console.log(new Date().toISOString(), ...a);
 export const UTILITY_SUFFIX = ' (via shared albums)';
 
 /**
- * Email domain for the bot users this addon creates. Named after the project for the same
- * reason ROUTE_PREFIX is: "sidecar" is a generic term another Immich addon could reasonably
- * claim, and these addresses are how we tell our own bots apart from real people.
+ * Email domain for the bot users this addon creates. Named after the project (like ROUTE_PREFIX)
+ * so our own bots are distinguishable from real people.
  *
- * `.invalid` because that TLD exists for exactly this (RFC 2606): deliberately unresolvable,
- * never a real mailbox. `.local` — the previous choice — is mDNS-reserved (RFC 6762) and can
- * trip resolvers and email validators. This rename, like `@sidecar.local` before it, is a
- * ONE-TIME v1.0.0 allowance taken while the install base is ~zero. It is NOT the policy going
- * forward — post-v1, changes to this domain need a migration path.
+ * `.internal` is ICANN-reserved (2024) for private-use networks: guaranteed never delegated in the
+ * public DNS, so — like the `.invalid` it replaces — these addresses never resolve and can never
+ * receive mail. Unlike `.invalid`, it does not read as "broken" to a human who sees a bot in
+ * Immich's People list / album picker: an "internal" account is self-explanatory, an "invalid" one
+ * looks like an error. That end-user legibility is the whole reason for the change.
  *
- * Getting this check wrong is not cosmetic (a bot misread as a human gets added to mirrors and
- * its stubs counted as someone's photos), so the test stays obviously correct by inspection.
+ * History: `sidecar.local` (v0) -> `immich-shared-albums.invalid` (v1) -> `.internal` (this). The v1
+ * rename was a clean break, allowed while the install base was ~zero. This one is NOT — there are
+ * live installs — so it ships WITH a migration. Two parts make it safe:
+ *  - isUtilityEmail recognises LEGACY_UTILITY_DOMAINS too, so existing bots are still classified as
+ *    bots the moment this version boots — never misread as humans.
+ *  - migrateUtilityDomain (immich/migrate-domain.ts) renames existing bot accounts to `.internal` at
+ *    startup, so users stop seeing the old address. Accounts are keyed in state by person id, not
+ *    email, so the rename creates no duplicates.
+ *
+ * Getting isUtilityEmail wrong is not cosmetic (a bot misread as a human gets added to mirrors and
+ * its stubs counted as someone's photos), so the check stays obvious by inspection and legacy-aware.
  */
-export const UTILITY_EMAIL_DOMAIN = 'immich-shared-albums.invalid';
+export const UTILITY_EMAIL_DOMAIN = 'immich-shared-albums.internal';
+
+/**
+ * Domains earlier versions used for bot accounts. Still recognised by isUtilityEmail so a bot made
+ * by an older version stays classified as a bot until migrateUtilityDomain renames it. Never used
+ * for NEW bots. Order is irrelevant — membership is all that matters.
+ */
+export const LEGACY_UTILITY_DOMAINS = ['immich-shared-albums.invalid', 'sidecar.local'] as const;
 
 /**
  * ONE local account per remote person, doing both jobs: it owns their mirrored photos, and it is
@@ -160,8 +175,12 @@ export const markerName = {
     `${personName} (via ${peerName}${/servers?\s*$/i.test(peerName) ? '' : ' server'})`,
 };
 
-/** Is this one of our bot users? The single source of truth — never inline the check. */
-export const isUtilityEmail = (email?: string) => !!email && email.endsWith(`@${UTILITY_EMAIL_DOMAIN}`);
+/** Is this one of our bot users? The single source of truth — never inline the check. Recognises
+ *  the current domain AND every LEGACY_UTILITY_DOMAINS entry, so a bot created by an older version
+ *  is still a bot here (see UTILITY_EMAIL_DOMAIN for why that matters). The leading `@` is required,
+ *  so a subdomain lookalike ("x@evil.immich-shared-albums.internal") is not a match. */
+export const isUtilityEmail = (email?: string) =>
+  !!email && [UTILITY_EMAIL_DOMAIN, ...LEGACY_UTILITY_DOMAINS].some(d => email.endsWith(`@${d}`));
 
 /**
  * The URL prefix this addon owns on the Immich origin.

--- a/src/immich/migrate-domain.ts
+++ b/src/immich/migrate-domain.ts
@@ -1,0 +1,44 @@
+/**
+ * immich/migrate-domain.ts — one-time, idempotent rename of bot accounts onto the current
+ * UTILITY_EMAIL_DOMAIN.
+ *
+ * When the bot email domain changes (see config.ts UTILITY_EMAIL_DOMAIN), existing accounts keep
+ * their old address — they are resolved by state key (person id), not email, so nothing breaks and
+ * no duplicate is created. But the old address is what a human sees in Immich's People list / album
+ * picker, and reading "@…invalid" there is exactly what we're fixing. So on boot we rename any bot
+ * account still on a legacy domain to the same local-part on the current domain.
+ *
+ * Safe by construction: only accounts whose email is a LEGACY_UTILITY_DOMAINS match are touched,
+ * only the domain half changes, and re-running finds none (idempotent). Best-effort — a failure on
+ * one account is logged and skipped, never fatal to boot.
+ */
+import { log, UTILITY_EMAIL_DOMAIN, LEGACY_UTILITY_DOMAINS } from '../config.ts';
+import { immichJson, jsonBody } from './client.ts';
+
+const onLegacyDomain = (email?: string) =>
+  !!email && LEGACY_UTILITY_DOMAINS.some(d => email.endsWith(`@${d}`));
+
+export async function migrateUtilityDomain(): Promise<void> {
+  let users;
+  try {
+    // Active accounts only: soft-deleted bots are already hidden from pickers and purge on their
+    // own, so renaming them buys nothing and can error on an account that is going away.
+    users = await immichJson('/admin/users');
+  } catch (e) {
+    log(`utility-domain migration skipped (cannot list users): ${e.message}`);
+    return;
+  }
+  const stale = (users as { id: string; email: string }[]).filter(u => onLegacyDomain(u.email));
+  if (!stale.length) return;
+  let renamed = 0;
+  for (const u of stale) {
+    const email = `${u.email.split('@')[0]}@${UTILITY_EMAIL_DOMAIN}`;
+    try {
+      await immichJson(`/admin/users/${u.id}`, { ...jsonBody({ email }), method: 'PUT' });
+      renamed++;
+    } catch (e) {
+      log(`utility-domain migration: could not rename ${u.email}: ${e.message}`);
+    }
+  }
+  if (renamed) log(`utility-domain migration: renamed ${renamed} bot account(s) to @${UTILITY_EMAIL_DOMAIN}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { CFG, log } from './config.ts';
 import { server } from './web/server.ts';
 import { proxyUpgrade } from './web/upgrade.ts';
 import { verifyAdminKeyAtBoot } from './immich/admin-key.ts';
+import { migrateUtilityDomain } from './immich/migrate-domain.ts';
 import { startTransport } from './p2p/transport.ts';
 import { helloPeers } from './peers.ts';
 import { peerRoutes } from './p2p/routes.ts';
@@ -25,6 +26,8 @@ process.on('uncaughtException', err => {
 server.on('upgrade', proxyUpgrade);
 // The transport binds first: the share page mints endpoint tokens from it on every request.
 void verifyAdminKeyAtBoot();
+// One-time rename of any bot account still on a legacy email domain — cosmetic, unawaited.
+void migrateUtilityDomain();
 await startTransport(peerRoutes);
 void helloPeers(); // refresh what each linked peer can do — deliberately unawaited
 server.listen(CFG.port, () => log(`sidecar "${CFG.name}" listening :${CFG.port} — immich: ${CFG.immichUrl}`));

--- a/src/invariants.test.ts
+++ b/src/invariants.test.ts
@@ -9,7 +9,14 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { BOT_PREFIX, markerName, isUtilityEmail, UTILITY_EMAIL_DOMAIN, UTILITY_SUFFIX } from './config.ts';
+import {
+  BOT_PREFIX,
+  markerName,
+  isUtilityEmail,
+  UTILITY_EMAIL_DOMAIN,
+  LEGACY_UTILITY_DOMAINS,
+  UTILITY_SUFFIX,
+} from './config.ts';
 import { personName } from './config.ts';
 import { permissionFor } from './sync/invites.ts';
 import { diffInvitees } from './sync/invitees.ts';
@@ -43,14 +50,26 @@ test('marker name does not stack "server" when the household already ends in one
   assert.equal(personName(markerName.person('Nan', 'The Smiths')), 'Nan');
 });
 
-test('isUtilityEmail accepts only the project domain', () => {
+test('isUtilityEmail accepts the current domain and every legacy domain', () => {
+  // Post-v1 the domain moved (.invalid -> .internal) WITH a migration, not as a clean break — so,
+  // unlike v1, isUtilityEmail must still recognise legacy bots. Otherwise an existing bot is misread
+  // as a human and gets added to mirrors / counted as real photos until migrate-domain renames it.
+  assert.equal(
+    UTILITY_EMAIL_DOMAIN,
+    'immich-shared-albums.internal',
+    'current domain reads as "internal", not "invalid"'
+  );
   assert.ok(isUtilityEmail(`person-x@${UTILITY_EMAIL_DOMAIN}`));
-  assert.ok(!isUtilityEmail('someone@sidecar.local'), 'v1 dropped the legacy domain');
-  assert.ok(!isUtilityEmail('person-x@immich-shared-albums.local'), 'v1 also left .local (mDNS-reserved)');
+  for (const d of LEGACY_UTILITY_DOMAINS)
+    assert.ok(isUtilityEmail(`person-x@${d}`), `legacy ${d} is still a bot`);
+  assert.ok(isUtilityEmail('shared-admin@sidecar.local'), 'v0 bots still recognised');
+  assert.ok(isUtilityEmail('person-x@immich-shared-albums.invalid'), 'v1 bots still recognised');
   assert.ok(!isUtilityEmail('real.person@example.com'));
   assert.ok(!isUtilityEmail(undefined));
-  // a lookalike domain must not pass
+  // a lookalike domain must not pass — the leading "@" is required, so neither a suffix hack nor a
+  // subdomain of our domain is a match.
   assert.ok(!isUtilityEmail(`x@evil-${UTILITY_EMAIL_DOMAIN}.example.com`));
+  assert.ok(!isUtilityEmail(`x@evil.${UTILITY_EMAIL_DOMAIN}`));
 });
 
 test('album roles map to share permissions', () => {


### PR DESCRIPTION
## What
Bot placeholder accounts move from `@immich-shared-albums.invalid` to `@immich-shared-albums.internal`.

## Why
On-device testing of the paired servers surfaced that `.invalid` reads as an error/broken to end users wherever Immich shows the address (album People list, invite picker) — e.g. `Admin (via Mum and Dad server) <person-…@immich-shared-albums.invalid>`. `.internal` is ICANN-reserved (2024) for private use: still never resolves publicly or receives mail, but reads as an "internal account" instead of "invalid".

## How
- `UTILITY_EMAIL_DOMAIN` → `immich-shared-albums.internal`.
- `isUtilityEmail` now recognises the current domain **and** `LEGACY_UTILITY_DOMAINS` (`.invalid`, `sidecar.local`), so existing bots stay classified as bots the moment this version boots — otherwise one would be misread as a human (added to mirrors, its stubs counted as real photos). This deliberately reverses the v1 clean break.
- One-time, idempotent startup pass (`immich/migrate-domain.ts`) renames existing bot accounts onto the new domain so users stop seeing the old one. Accounts are keyed in state by person id (not email), so the rename creates **no duplicates**.

## Testing
- `npm test` — `isUtilityEmail` asserts current + both legacy domains, keeps lookalike/real-email rejection.
- `npm run typecheck` clean; pre-commit `verify:fast` (bundles/format/lint/types/cycles) green.
- Non-breaking: these emails never travel on the wire; a mixed-version mesh is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)