### PR TITLE
fix: mirror stubs carry the origin aspect ratio (was 1x1)

### DIFF
--- a/demo/e2e/e2e-test.mjs
+++ b/demo/e2e/e2e-test.mjs
@@ -198,6 +198,24 @@ if (mirrorAssets) {
   const stubSizes = mirrorAssets.map(a => (a.exifInfo || {}).fileSizeInByte || 0);
   check('mirrors are kilobyte stubs — hotlink model stores no pixels', stubSizes.every(n => n > 0 && n < 20000),
         stubSizes.join(','));
+  // Regression: a mirror stub must carry the origin's ASPECT RATIO, not a fixed 1x1 (which made
+  // Immich lay every mirrored photo out square in the grid and letterboxed in the viewer). Compare
+  // DISPLAY aspect (orientation applied); mirror dims are capped so allow a small rounding tolerance.
+  const dispAspect = a => {
+    let w = a.exifInfo?.exifImageWidth ?? 0, h = a.exifInfo?.exifImageHeight ?? 0;
+    const o = Number(a.exifInfo?.orientation);
+    if (o >= 5 && o <= 8) [w, h] = [h, w];
+    return w > 0 && h > 0 ? w / h : 0;
+  };
+  check('mirror stubs carry real dimensions, not 1x1',
+        mirrorAssets.every(a => (a.exifInfo?.exifImageWidth ?? 0) > 1 && (a.exifInfo?.exifImageHeight ?? 0) > 1),
+        mirrorAssets.map(a => `${a.exifInfo?.exifImageWidth}x${a.exifInfo?.exifImageHeight}`).join(','));
+  const originAspects = (await albumAssets(A, AKEY, ALBUM_ID)).map(dispAspect).sort((x, y) => x - y);
+  const mirrorAspects = mirrorAssets.map(dispAspect).sort((x, y) => x - y);
+  check('mirror aspect ratios match the origin photos',
+        originAspects.length === mirrorAspects.length &&
+          originAspects.every((v, i) => Math.abs(v - mirrorAspects[i]) < 0.03),
+        `origin=[${originAspects.map(n => n.toFixed(2))}] mirror=[${mirrorAspects.map(n => n.toFixed(2))}]`);
   const gpsProxy = withGps || mirrorAssets[0];
   const viaProxy = await fetchBytes(`${BS}/api/assets/${gpsProxy.id}/original`, BKEY);
   const originOrig = await fetchBytes(`${A}/api/assets/${aIds[0]}/original`, AKEY);

--- a/src/immich/materialise.ts
+++ b/src/immich/materialise.ts
@@ -9,6 +9,7 @@ import { state, seenHas, seenAdd } from '../state.ts';
 import { peerByteRequest, recvIterable } from '../p2p/transport.ts';
 import { STUB_JPEG, immichJson, jsonBody, uploadAsset, addToAlbum, applyRefMetadata } from './client.ts';
 import { ensureContributor } from './contributors.ts';
+import { jpegOfSize } from '../media/jpeg.ts';
 
 // Fetch a ref's preview from the peer and create the local proxy copy. Returns
 // false (without marking seen) on failure so reconciliation can retry later.
@@ -61,7 +62,13 @@ async function materialiseRefLocked(mapping, peer, ref) {
     }
     bytes = Buffer.concat([...prefix, crypto.randomBytes(8)]);
   } else {
-    bytes = Buffer.concat([STUB_JPEG, crypto.randomBytes(8)]);
+    // Size the stub to the origin's aspect ratio so Immich lays the mirror out correctly (grid tile
+    // shape + viewer box); real pixels still stream via the interceptor. A ref from an older peer
+    // carries no dimensions -> fall back to the legacy 1×1 stub. The random tail keeps each stub a
+    // distinct asset (Immich dedupes identical bytes per user).
+    const { width, height } = ref.exif ?? {};
+    const base = width && height ? jpegOfSize(width, height) : STUB_JPEG;
+    bytes = Buffer.concat([base, crypto.randomBytes(8)]);
   }
   const hostKey = mapping.hostSlug ? state.contributors[mapping.hostSlug]?.apiKey : undefined;
   // On an INVITATION album a human already added the people they chose — their membership IS the

--- a/src/immich/refs.ts
+++ b/src/immich/refs.ts
@@ -8,6 +8,18 @@ import { CFG, personName } from '../config.ts';
 import { usersById } from './client.ts';
 import { wireChecksum, ledgerByAsset, seenHas } from '../state.ts';
 
+// Immich stores raw sensor dimensions plus an EXIF orientation; the DISPLAYED photo (and the
+// oriented thumbnail the interceptor serves) has width/height swapped for the quarter-turn
+// orientations (5–8). Send the DISPLAY dimensions so the mirror stub's aspect matches what Immich
+// actually renders. Absent/unreadable exif -> no dimensions -> receiver keeps the legacy 1×1 stub.
+function displayDims(exif): { width?: number; height?: number } {
+  const w = Number(exif?.exifImageWidth);
+  const h = Number(exif?.exifImageHeight);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return {};
+  const o = Number(exif?.orientation);
+  return o >= 5 && o <= 8 ? { width: h, height: w } : { width: w, height: h };
+}
+
 // A shared photo, described for a peer. For utility-owned proxies (relayed photos)
 // the true contributor is recovered from the utility user's name; the credit line we
 // append locally is stripped so downstream hops don't stack "Shared by" twice.
@@ -26,6 +38,7 @@ export async function assetToRef(a): Promise<AssetRef> {
           longitude: a.exifInfo.longitude,
           description,
           rating: a.exifInfo.rating,
+          ...displayDims(a.exifInfo),
         }
       : undefined,
     contributor: { displayName, originUserId: a.ownerId },

--- a/src/invariants.test.ts
+++ b/src/invariants.test.ts
@@ -13,6 +13,7 @@ import { BOT_PREFIX, markerName, isUtilityEmail, UTILITY_EMAIL_DOMAIN, UTILITY_S
 import { personName } from './config.ts';
 import { permissionFor } from './sync/invites.ts';
 import { diffInvitees } from './sync/invitees.ts';
+import { jpegOfSize, boundedStubDims } from './media/jpeg.ts';
 
 test('bot accounts are keyed by id, never by display name', () => {
   // Two remote people who share a display name must never collapse into one local account
@@ -104,4 +105,45 @@ test('personName recovers the human, however the account was decorated', () => {
   // the compounded form seen in run27, which is what this exists to prevent
   assert.equal(personName('Nan (via Demo household (B) server) (via shared albums)'), 'Nan');
   assert.equal(personName(undefined), '');
+});
+
+test('mirror stub JPEG declares the origin aspect ratio, not 1x1', () => {
+  // A fixed 1x1 stub made Immich lay every mirrored photo out square (grid) / letterboxed (viewer).
+  // jpegOfSize must emit a valid baseline JPEG whose SOF0 carries the origin's aspect. Parse the
+  // SOF0 marker directly — no JPEG decoder dependency.
+  const sofDims = (buf: Buffer) => {
+    for (let i = 2; i < buf.length - 9;) {
+      if (buf[i] !== 0xff) {
+        i++;
+        continue;
+      }
+      const marker = buf[i + 1];
+      if (marker === 0xc0) return { w: buf.readUInt16BE(i + 7), h: buf.readUInt16BE(i + 5) };
+      if (marker === 0xd8 || marker === 0xd9) {
+        i += 2;
+        continue;
+      }
+      i += 2 + buf.readUInt16BE(i + 2);
+    }
+    return null;
+  };
+  for (const [w, h] of [
+    [4000, 3000],
+    [3000, 4000],
+    [1000, 1000],
+    [4032, 3024],
+    [100, 50],
+    [7, 13],
+  ]) {
+    const buf = jpegOfSize(w, h);
+    assert.equal(buf[0], 0xff);
+    assert.equal(buf[1], 0xd8, 'starts with SOI');
+    assert.equal(buf[buf.length - 2], 0xff);
+    assert.equal(buf[buf.length - 1], 0xd9, 'ends with EOI');
+    const [bw, bh] = boundedStubDims(w, h);
+    assert.deepEqual(sofDims(buf), { w: bw, h: bh }, `SOF matches bounded dims for ${w}x${h}`);
+    assert.ok(bw <= 256 && bh <= 256, 'capped to <=256 on the long edge');
+    assert.ok(Math.abs(bw / bh / (w / h) - 1) < 0.02, `aspect preserved for ${w}x${h}`);
+    assert.ok(buf.length < 4096, `stub stays tiny (${buf.length}B for ${w}x${h})`);
+  }
 });

--- a/src/media/jpeg.ts
+++ b/src/media/jpeg.ts
@@ -1,0 +1,122 @@
+/**
+ * media/jpeg.ts — a tiny, dependency-free baseline-JPEG generator for mirror stubs.
+ *
+ * A mirrored photo is represented locally by a placeholder asset; the real pixels stream from the
+ * owner via the byte interceptor. Immich reads the placeholder's pixel dimensions and lays the photo
+ * out from them — the grid tile's shape and the viewer's aspect box. A fixed 1×1 stub therefore
+ * makes every mirror square in the grid and letterboxed in the viewer. `jpegOfSize` instead emits a
+ * solid mid-grey JPEG whose SOF header declares the photo's real ASPECT RATIO, so Immich lays it out
+ * correctly. (The interceptor still serves the true full-resolution bytes on view.)
+ *
+ * Deliberately minimal: mid-grey is sample 128, which level-shifts to 0, so every 8×8 block is
+ * all-zero coefficients and encodes as the SAME six bits — DC category 0 (`00`) then AC end-of-block
+ * (`1010`) using the standard Annex-K luminance Huffman tables. No DCT, no quantiser maths. The
+ * requested dimensions are capped to a small box (long edge ≤ MAX_EDGE) preserving aspect, so a stub
+ * stays ~1KB regardless of the original's size: the point is the ratio, not the resolution.
+ */
+
+// Long-edge cap for the stub. Small enough to stay ~1KB; the true resolution is never stored here.
+const MAX_EDGE = 256;
+
+// Standard Annex-K luminance Huffman tables (BITS = code counts by length 1..16; VALS = symbols).
+// The DC code for symbol 0 is "00" (2 bits) and the AC code for symbol 0 (EOB) is "1010" (4 bits);
+// both follow from these tables, so they must be emitted verbatim.
+const DC_BITS = [0, 1, 5, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0];
+const DC_VALS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+const AC_BITS = [0, 2, 1, 3, 3, 2, 4, 3, 5, 5, 4, 4, 0, 0, 1, 0x7d];
+// prettier-ignore
+const AC_VALS = [
+  0x01, 0x02, 0x03, 0x00, 0x04, 0x11, 0x05, 0x12, 0x21, 0x31, 0x41, 0x06, 0x13, 0x51, 0x61, 0x07,
+  0x22, 0x71, 0x14, 0x32, 0x81, 0x91, 0xa1, 0x08, 0x23, 0x42, 0xb1, 0xc1, 0x15, 0x52, 0xd1, 0xf0,
+  0x24, 0x33, 0x62, 0x72, 0x82, 0x09, 0x0a, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x25, 0x26, 0x27, 0x28,
+  0x29, 0x2a, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,
+  0x4a, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
+  0x6a, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89,
+  0x8a, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+  0xa8, 0xa9, 0xaa, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xc2, 0xc3, 0xc4, 0xc5,
+  0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xe1, 0xe2,
+  0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8,
+  0xf9, 0xfa,
+];
+
+/**
+ * Cap dimensions to a small box, preserving aspect ratio. Never upscales. Rounding can shift the
+ * ratio by a fraction of a pixel — imperceptible in layout.
+ */
+export function boundedStubDims(width: number, height: number): [number, number] {
+  const w = Math.max(1, Math.round(width));
+  const h = Math.max(1, Math.round(height));
+  if (w <= MAX_EDGE && h <= MAX_EDGE) return [w, h];
+  return w >= h
+    ? [MAX_EDGE, Math.max(1, Math.round((h * MAX_EDGE) / w))]
+    : [Math.max(1, Math.round((w * MAX_EDGE) / h)), MAX_EDGE];
+}
+
+/** A solid mid-grey baseline JPEG at the given aspect (dimensions capped, see boundedStubDims). */
+export function jpegOfSize(width: number, height: number): Buffer {
+  const [w, h] = boundedStubDims(width, height);
+  const u16 = (n: number) => [(n >> 8) & 0xff, n & 0xff];
+  const out: number[] = [];
+
+  out.push(0xff, 0xd8); // SOI
+  // APP0 / JFIF
+  out.push(
+    0xff,
+    0xe0,
+    0x00,
+    0x10,
+    0x4a,
+    0x46,
+    0x49,
+    0x46,
+    0x00,
+    0x01,
+    0x01,
+    0x00,
+    0x00,
+    0x01,
+    0x00,
+    0x01,
+    0x00,
+    0x00
+  );
+  // DQT: a flat table (every coefficient is zero, so the values are irrelevant; flat = order-agnostic)
+  out.push(0xff, 0xdb, 0x00, 0x43, 0x00, ...new Array(64).fill(16));
+  // SOF0: 8-bit, one component, no subsampling
+  out.push(0xff, 0xc0, 0x00, 0x0b, 0x08, ...u16(h), ...u16(w), 0x01, 0x01, 0x11, 0x00);
+  // DHT: DC table 0 + AC table 0
+  const dc = [0x00, ...DC_BITS, ...DC_VALS];
+  const ac = [0x10, ...AC_BITS, ...AC_VALS];
+  out.push(0xff, 0xc4, ...u16(2 + dc.length + ac.length), ...dc, ...ac);
+  // SOS: one component, DC/AC table 0
+  out.push(0xff, 0xda, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3f, 0x00);
+
+  // Entropy-coded scan: one all-zero block per 8×8 MCU. MSB-first, with 0xFF byte-stuffing.
+  let acc = 0;
+  let nbits = 0;
+  const putBits = (value: number, len: number) => {
+    for (let i = len - 1; i >= 0; i--) {
+      acc = (acc << 1) | ((value >> i) & 1);
+      if (++nbits === 8) {
+        out.push(acc & 0xff);
+        if ((acc & 0xff) === 0xff) out.push(0x00);
+        acc = 0;
+        nbits = 0;
+      }
+    }
+  };
+  const blocks = Math.ceil(w / 8) * Math.ceil(h / 8);
+  for (let i = 0; i < blocks; i++) {
+    putBits(0b00, 2); // DC category 0 (diff 0)
+    putBits(0b1010, 4); // AC end-of-block
+  }
+  if (nbits > 0) {
+    // pad the final partial byte with 1-bits, per the JPEG convention
+    const b = ((acc << (8 - nbits)) | ((1 << (8 - nbits)) - 1)) & 0xff;
+    out.push(b);
+    if (b === 0xff) out.push(0x00);
+  }
+
+  out.push(0xff, 0xd9); // EOI
+  return Buffer.from(out);
+}

--- a/src/p2p/wire-protocol.md
+++ b/src/p2p/wire-protocol.md
@@ -119,7 +119,10 @@ a hung peer costs one timeout, never a wedged loop.
 The rules that make additive change legal, written down so nobody has to re-derive them:
 
 1. **Unknown JSON fields MUST be ignored**, in request bodies, response bodies, and the frame
-   headers. Adding an optional field is never a breaking change.
+   headers. Adding an optional field is never a breaking change. (Example: an `AssetRef`'s optional
+   `exif.width`/`exif.height` — the origin photo's display dimensions, used to size the mirror stub
+   to the right aspect ratio — were added this way; a peer that omits them makes the receiver fall
+   back to a 1×1 stub, exactly the prior behaviour.)
 2. **Unknown routes answer 404**, and callers treat a 404 from a route added after protocol 2
    as "peer too old", never as an error. Adding a route is never a breaking change.
 3. **The ALPN carries the protocol MAJOR** (`isa/2`). A future major keeps serving the previous

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,12 @@ export type AssetRef = {
     longitude?: number;
     description?: string;
     rating?: number;
+    /** DISPLAY dimensions of the origin photo (orientation already applied). Used only to size the
+     *  mirror stub so Immich lays the photo out at the right aspect ratio. Optional per
+     *  wire-protocol.md evolution rule 1 — a peer that omits them makes the receiver fall back to the
+     *  legacy 1×1 stub, exactly today's behaviour. */
+    width?: number;
+    height?: number;
   };
 };
 


### PR DESCRIPTION
## What
Cross-server **mirrored** photos now render at their true aspect ratio in Immich (grid + viewer), instead of appearing square/letterboxed.

## Why
The image stub was a fixed **1×1** JPEG, so Immich recorded every mirror as 1×1 and sized the grid tile / viewer box from that. The real pixels stream fine via the byte interceptor — only the layout *metadata* was wrong. Confirmed on-device: a mirrored asset had `exifImageWidth/Height = 1×1`.

## How
- `AssetRef.exif` gains optional `width`/`height` — the origin's **display** dimensions (orientation applied in `refs.ts`). Optional per wire-protocol evolution rule 1.
- New dependency-free `src/media/jpeg.ts` (`jpegOfSize`): emits a tiny solid-grey baseline JPEG whose SOF declares that aspect, capped to a 256 px long edge so a stub stays **~1 KB**.
- `materialise.ts` sizes the image stub with `jpegOfSize`, falling back to the legacy 1×1 stub for refs from peers too old to send dimensions.

## Trade-off (deliberate)
Only the ⓘ info-panel *resolution* reads small (~256×192) for mirrors — the same panel that already shows the ~2 KB stub file-size. Grid/viewer layout, full-quality viewing, and downloads all use the real bytes from the owner. Exact resolution comes with the future store-locally feature.

## Testing
- `npm test` — new unit test parses the generated SOF and asserts correct bounded dims + aspect across shapes (portrait/landscape/square/odd).
- Encoder validated against a real decoder (macOS ImageIO/`sips`) — correct dims, no errors, ~900 B for a 4000×3000.
- **Full mock e2e green (155 checks)**, incl. a new regression asserting a mirror's stored dimensions match the origin's aspect (not 1×1).
- Non-breaking: mixed-version mesh falls back to the 1×1 stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)